### PR TITLE
ci: Add linters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.tox
+.mypy_cache
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.tox]
+envlist = ["lint"]
+
+[tool.tox.env.lint]
+description = "Run linters"
+deps = ["mypy", "ruff"]
+commands = [
+  ["ruff", "format", "decent_bench"],
+  ["mypy", "decent_bench", "--strict"],
+  ["ruff", "check", "decent_bench"]
+]
+
+[tool.ruff]
+lint.select = ["ALL"]
+lint.ignore = [
+  "CPY001", # Missing copyright notice at top of file
+  "D100",   # Missing docstring in public module
+  "D104",   # Missing docstring in public package
+  "D107",   # Missing docstring in __init__
+  "D203",   # incorrect-blank-line-before-class (D203) and no-blank-line-before-class (D211) are incompatible
+  "D212"    # multi-line-summary-first-line (D212) and multi-line-summary-second-line (D213) are incompatible
+]
+fix = true
+preview = true
+line-length = 120


### PR DESCRIPTION
Add  mypy (type checker) and ruff (format and style checker) to pyproject.toml. Run both using `tox`.