### PR TITLE
ci: Add p313 env to tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
+[project]
+name = "decent-bench"
+version = "0.0.0"
+dependencies = []
+
 [tool.tox]
-envlist = ["mypy", "pytest", "ruff"]
+envlist = ["py313", "mypy", "pytest", "ruff"]
 
 [tool.tox.env.mypy]
 description = "Run mypy (static type checker)"


### PR DESCRIPTION
Add python 3.13 tox env which installs all the project's listed dependencies. Useful for development. Activate the venv using 'source .tox/py313/bin/activate'.