### PR TITLE
ci: Update dev env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,18 @@
 [project]
 name = "decent-bench"
 version = "0.0.0"
+requires-python = ">=3.13"
 dependencies = []
 
 [tool.tox]
-envlist = ["py313", "mypy", "pytest", "ruff"]
+envlist = ["dev", "mypy", "pytest", "ruff"]
+
+[tool.tox.env.dev]
+deps = [
+  "mypy",
+  "pytest",
+  "ruff",
+]
 
 [tool.tox.env.mypy]
 description = "Run mypy (static type checker)"
@@ -40,7 +48,8 @@ lint.ignore = [
   "D104",   # Missing docstring in public package
   "D107",   # Missing docstring in __init__
   "D203",   # incorrect-blank-line-before-class (D203) and no-blank-line-before-class (D211) are incompatible
-  "D212"    # multi-line-summary-first-line (D212) and multi-line-summary-second-line (D213) are incompatible
+  "D212",   # multi-line-summary-first-line (D212) and multi-line-summary-second-line (D213) are incompatible
+  "TC002",  # typing-only-third-party-import, reduces rt overhead but slows down development and makes imports messy
 ]
 preview = true
 line-length = 120


### PR DESCRIPTION
Set dev env name to `dev` and add dev dependencies. Running `tox` now creates a venv with both prod dependencies and dev dependencies installed. Activate with `source .tox/dev/bin/activate`.