### PR TITLE
docs: Enable readthedocs to install dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,21 @@ version = "0.0.0"
 requires-python = ">=3.13"
 dependencies = []
 
-[tool.tox]
-envlist = ["dev", "mypy", "pytest", "ruff"]
-
-[tool.tox.env.dev]
-deps = [
+[project.optional-dependencies]
+dev = [
   "mypy",
   "pytest",
   "ruff",
   "sphinx",
-  "sphinx_rtd_theme",
+  "sphinx_rtd_theme"
 ]
+
+[tool.tox]
+envlist = ["dev", "mypy", "pytest", "ruff", "sphinx"]
+
+[tool.tox.env.dev]
+description = "Generate dev venv with all dependencies, active with `source .tox/dev/bin/activate`"
+deps = [".[dev]"]
 
 [tool.tox.env.sphinx]
 description = "Generate rst and html files using sphinx"

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -15,3 +15,9 @@ sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
 
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev


### PR DESCRIPTION
Enable readthedocs to install the required dependencies to build sphinx docs, which is currently failing. This involves putting the dependencies under project.optional-dependencies, making them installable when installing decent-bench.