### PR TITLE
ci: Turn sphinx warnings into errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ commands = [
   ["find", "docs/source", "-name", "*.rst", "!", "-name", "index.rst", "-delete"],
   ["sphinx-apidoc", "-o", "docs/source", "decent_bench", "--no-toc"],
   ["make", "-C", "docs", "clean"],
-  ["make", "-C", "docs", "html"],
+  ["make", "-C", "docs", "html", "SPHINXOPTS=-W"],
 ]
 
 [tool.tox.env.mypy]


### PR DESCRIPTION
Turn sphinx warnings into errors which was missed in #36. The point of #36 was to fail the sphinx ci check when a docstring reference can't be resolved, which requires warnings to be raised as errors.