### PR TITLE
feat: Add datasets

### DIFF
--- a/decent_bench/library/core/benchmark_problem/datasets.py
+++ b/decent_bench/library/core/benchmark_problem/datasets.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from typing import NewType
+
+from numpy import float64
+from numpy.typing import NDArray
+from sklearn import datasets as sk_datasets
+
+A = NewType("A", NDArray[float64])
+"""Feature matrix type."""
+
+b = NewType("b", NDArray[float64])
+"""Target vector type."""
+
+DatasetPartition = NewType("DatasetPartition", tuple[A, b])
+"""Tuple of (A, b) representing one dataset partition."""
+
+
+class Dataset(ABC):
+    """Dataset containing partitions in the form of feature matrix A and target vector b."""
+
+    @property
+    @abstractmethod
+    def training_partitions(self) -> Sequence[DatasetPartition]:
+        """Partitions used for finding the optimal optimization variable x."""
+
+
+class SyntheticClassificationData(Dataset):
+    """Dataset with synthetic classification data."""
+
+    def __init__(
+        self, partitions: int, classes: int, samples_per_partition: int, features: int, seed: int | None = None
+    ):
+        """
+        Dataset with synthetic classification data.
+
+        Args:
+            classes: number of classes, i.e. unique values in the target vector b
+            partitions: number of training partitions to generate, i.e. the length of the sequence returned by
+                :attr:`training_partitions`
+            samples_per_partition: number of rows in A and b per partition
+            features: columns in A
+            seed: used for random generation, set to a specific value for reproducible results
+
+        """
+        self.partitions = partitions
+        self.classes = classes
+        self.samples_per_partition = samples_per_partition
+        self.features = features
+        self.seed = seed
+
+    @property
+    def training_partitions(self) -> Sequence[DatasetPartition]:  # noqa: D102
+        res = []
+        for i in range(self.partitions):
+            seed = self.seed + i if self.seed is not None else None
+            partition = sk_datasets.make_classification(
+                n_samples=self.samples_per_partition,
+                n_features=self.features,
+                n_redundant=0,
+                n_classes=self.classes,
+                random_state=seed,
+            )
+            res.append(DatasetPartition((A(partition[0]), b(partition[1]))))
+        return res

--- a/decent_bench/library/core/benchmark_problem/schemes/compression_schemes.py
+++ b/decent_bench/library/core/benchmark_problem/schemes/compression_schemes.py
@@ -6,7 +6,7 @@ from numpy.typing import NDArray
 
 
 class CompressionScheme(ABC):
-    """Schema defining how messages are compressed when sent over the network."""
+    """Scheme defining how messages are compressed when sent over the network."""
 
     @abstractmethod
     def compress(self, msg: NDArray[float64]) -> NDArray[float64]:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,6 +30,7 @@ extensions = [
 autodoc_default_options = {"special-members": "__add__, __iter__"}
 
 autodoc_member_order = "bysource"
+autoclass_content = "init"
 
 nitpicky = True
 nitpick_ignore = [("py:class", "numpy.float64")]

--- a/docs/source/decent_bench.library.core.benchmark_problem.rst
+++ b/docs/source/decent_bench.library.core.benchmark_problem.rst
@@ -9,6 +9,17 @@ Subpackages
 
    decent_bench.library.core.benchmark_problem.schemes
 
+Submodules
+----------
+
+decent\_bench.library.core.benchmark\_problem.datasets module
+-------------------------------------------------------------
+
+.. automodule:: decent_bench.library.core.benchmark_problem.datasets
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 Module contents
 ---------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,16 @@ requires-python = ">=3.13"
 dependencies = [
   "numpy",
   "scipy",
-  "scipy-stubs"
+  "scikit-learn",
 ]
 
 [project.optional-dependencies]
 dev = [
+  "microsoft-python-type-stubs @ git+https://github.com/microsoft/python-type-stubs.git",
   "mypy",
   "pytest",
   "ruff",
+  "scipy-stubs",
   "sphinx",
   "sphinx_rtd_theme"
 ]
@@ -37,7 +39,7 @@ commands = [
 
 [tool.tox.env.mypy]
 description = "Run mypy (static type checker)"
-deps = ["mypy"]
+deps = [".[dev]"]
 commands = [["mypy", "decent_bench"]]
 
 [tool.tox.env.pytest]


### PR DESCRIPTION
Add datasets that will be used as input to cost functions. Also change sphinx config to render init docstrings (and let these take precedence over class docstrings to avoid summary duplication). The reasoning is that if we want to document init parameters, we should do this in the init docstring rather than the class docstring so that ruff is able to detect missing/misspelled parameters in the docstring.