### PR TITLE
docs: Put __init__ params doc in class doc

### DIFF
--- a/decent_bench/library/core/benchmark_problem/datasets.py
+++ b/decent_bench/library/core/benchmark_problem/datasets.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import NewType
@@ -28,39 +26,38 @@ class Dataset(ABC):
 
 
 class SyntheticClassificationData(Dataset):
-    """Dataset with synthetic classification data."""
+    """
+    Dataset with synthetic classification data.
+
+    Args:
+        n_partitions: number of training partitions to generate, i.e. the length of the sequence returned by
+            :attr:`training_partitions`
+        n_classes: number of classes, i.e. unique values in target vector b
+        n_samples_per_partition: number of rows in A and b per partition
+        n_features: columns in A
+        seed: used for random generation, set to a specific value for reproducible results
+
+    """
 
     def __init__(
-        self, partitions: int, classes: int, samples_per_partition: int, features: int, seed: int | None = None
+        self, n_partitions: int, n_classes: int, n_samples_per_partition: int, n_features: int, seed: int | None = None
     ):
-        """
-        Dataset with synthetic classification data.
-
-        Args:
-            classes: number of classes, i.e. unique values in the target vector b
-            partitions: number of training partitions to generate, i.e. the length of the sequence returned by
-                :attr:`training_partitions`
-            samples_per_partition: number of rows in A and b per partition
-            features: columns in A
-            seed: used for random generation, set to a specific value for reproducible results
-
-        """
-        self.partitions = partitions
-        self.classes = classes
-        self.samples_per_partition = samples_per_partition
-        self.features = features
+        self.n_partitions = n_partitions
+        self.n_classes = n_classes
+        self.n_samples_per_partition = n_samples_per_partition
+        self.n_features = n_features
         self.seed = seed
 
     @property
     def training_partitions(self) -> Sequence[DatasetPartition]:  # noqa: D102
         res = []
-        for i in range(self.partitions):
+        for i in range(self.n_partitions):
             seed = self.seed + i if self.seed is not None else None
             partition = sk_datasets.make_classification(
-                n_samples=self.samples_per_partition,
-                n_features=self.features,
+                n_samples=self.n_samples_per_partition,
+                n_features=self.n_features,
                 n_redundant=0,
-                n_classes=self.classes,
+                n_classes=self.n_classes,
                 random_state=seed,
             )
             res.append(DatasetPartition((A(partition[0]), b(partition[1]))))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,6 @@ extensions = [
 autodoc_default_options = {"special-members": "__add__, __iter__"}
 
 autodoc_member_order = "bysource"
-autoclass_content = "init"
 
 nitpicky = True
 nitpick_ignore = [("py:class", "numpy.float64")]


### PR DESCRIPTION
Put doc for __init__ params in class docstring instead of in __init__ docstring to keep both summary and param docs in a single place. This is cleaner and only requires updating one docstring instead of two when making a change. It also allows us to partially document params, i.e. skip self-explanatory ones, unlike in __init__ docstrings where it's all or nothing.