### PR TITLE
enh(agent): Change received_messages return type hint

### DIFF
--- a/decent_bench/library/core/agent.py
+++ b/decent_bench/library/core/agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from types import MappingProxyType
 
 from numpy import float64
@@ -50,7 +51,7 @@ class Agent:
         self._historical_x.append(x)
 
     @property
-    def received_messages(self) -> MappingProxyType[Agent, NDArray[float64]]:
+    def received_messages(self) -> Mapping[Agent, NDArray[float64]]:
         """Messages received by neighbors."""
         return MappingProxyType(self._received_messages)
 


### PR DESCRIPTION
Change the type hint of received_messages from MappingProxyType to Mapping to preserve the generics in the html generated by sphinx.