### PR TITLE
enh: Set eq to false in dataclasses

### DIFF
--- a/decent_bench/library/core/agent.py
+++ b/decent_bench/library/core/agent.py
@@ -90,7 +90,7 @@ class Agent:
         return self._id
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class AgentMetricsView:
     """Immutable view of agent that exposes useful properties for calculating metrics."""
 

--- a/decent_bench/library/core/benchmark_problem/benchmark_problems.py
+++ b/decent_bench/library/core/benchmark_problem/benchmark_problems.py
@@ -31,7 +31,7 @@ else:
     AnyGraph = Graph
 
 
-@dataclass
+@dataclass(eq=False)
 class BenchmarkProblem:
     """
     Benchmark problem to run algorithms on, defining settings such as communication constraints and topology.
@@ -88,8 +88,8 @@ class SimpleBenchmarkProblemFactory:
             n_classes=2, n_partitions=n_agents, n_samples_per_partition=10, n_features=3, seed=0
         )
         costs = [cost_function_cls(*p) for p in dataset.training_partitions]
-        cost_sum = reduce(add, costs)
-        optimal_x = ca.accelerated_gradient_descent(cost_sum, x0=None, max_iter=50000, stop_tol=1e-100, max_tol=1e-100)
+        sum_cost = reduce(add, costs)
+        optimal_x = ca.accelerated_gradient_descent(sum_cost, x0=None, max_iter=50000, stop_tol=1e-100, max_tol=1e-100)
         agent_activation_schemes = [UniformActivationRate(0.5) if asynchrony else AlwaysActive()] * n_agents
         compression_scheme = Quantization(n_significant_digits=4) if compressed else NoCompression()
         noise_scheme = GaussianNoise(mean=0, sd=0.001) if noisy else NoNoise()

--- a/decent_bench/library/core/dst_algorithms.py
+++ b/decent_bench/library/core/dst_algorithms.py
@@ -28,7 +28,7 @@ class DstAlgorithm(ABC):
         """
 
 
-@dataclass
+@dataclass(eq=False)
 class DGD(DstAlgorithm):
     r"""
     Distributed gradient descent characterized by the update step below.
@@ -72,7 +72,7 @@ class DGD(DstAlgorithm):
                 network.receive_all(i)
 
 
-@dataclass
+@dataclass(eq=False)
 class GT1(DstAlgorithm):
     r"""
     Gradient tracking algorithm characterized by the update step below.
@@ -122,7 +122,7 @@ class GT1(DstAlgorithm):
                 network.receive_all(i)
 
 
-@dataclass
+@dataclass(eq=False)
 class GT2(DstAlgorithm):
     r"""
     Gradient tracking algorithm characterized by the update step below.
@@ -179,7 +179,7 @@ class GT2(DstAlgorithm):
                 network.receive_all(i)
 
 
-@dataclass
+@dataclass(eq=False)
 class ADMM(DstAlgorithm):
     r"""
     Distributed Alternating Direction Method of Multipliers characterized by the update step below.


### PR DESCRIPTION
Set the eq parameter in the dataclass decorator to false to not autogenerate the equality method. By avoiding this, objects remain hashable, and performance is improved when comparing two objects since only their ids are used instead of all their fields.