### PR TITLE
enh: Remove unused __future__.annotations imports

### DIFF
--- a/decent_bench/library/core/dst_algorithms.py
+++ b/decent_bench/library/core/dst_algorithms.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 

--- a/decent_bench/library/core/metrics/metric_utils.py
+++ b/decent_bench/library/core/metrics/metric_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 from functools import lru_cache
 

--- a/decent_bench/library/utils/logger.py
+++ b/decent_bench/library/utils/logger.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from logging import LogRecord
 from logging.handlers import QueueHandler, QueueListener


### PR DESCRIPTION
Remove __future__.annotations imports from files without forward references. This reduces unnecessary code, and some things don't support __future__.annotations.