### PR TITLE
enh: Improve naming

### DIFF
--- a/decent_bench/library/core/metrics/plot_metrics/plot.py
+++ b/decent_bench/library/core/metrics/plot_metrics/plot.py
@@ -25,7 +25,7 @@ def plot(
     metrics: list[PlotMetric],
 ) -> None:
     """
-    Plot the results with one subplot per metric.
+    Plot the execution results with one subplot per metric.
 
     Each algorithm's curve is its mean across the trials.
 

--- a/decent_bench/library/core/metrics/table_metrics/tabulate.py
+++ b/decent_bench/library/core/metrics/table_metrics/tabulate.py
@@ -2,7 +2,7 @@ import warnings
 from typing import Literal
 
 import numpy as np
-import tabulate
+import tabulate as tb
 from scipy import stats
 
 from decent_bench.library.core.agent import AgentMetricsView
@@ -12,7 +12,7 @@ from decent_bench.library.core.metrics.table_metrics.table_metrics_constructs im
 from decent_bench.library.core.network import Network
 
 
-def generate_table(
+def tabulate(
     resulting_nw_states_per_alg: dict[DstAlgorithm, list[Network]],
     problem: BenchmarkProblem,
     metrics: list[TableMetric],
@@ -20,10 +20,10 @@ def generate_table(
     table_fmt: Literal["grid", "latex"],
 ) -> str:
     """
-    Generate table with confidence intervals, one row per metric and statistic, and one column per algorithm.
+    Print table with confidence intervals, one row per metric and statistic, and one column per algorithm.
 
     Args:
-        resulting_nw_states_per_alg: resulting network states from the trial executions, ordered by algorithm
+        resulting_nw_states_per_alg: resulting network states from the trial executions, grouped by algorithm
         problem: benchmark problem whose properties, e.g.
             :attr:`~decent_bench.library.core.benchmark_problem.benchmark_problems.BenchmarkProblem.optimal_x`,
             are used for metric calculations
@@ -52,7 +52,7 @@ def generate_table(
                     formatted_confidence_interval = _format_confidence_interval(mean, margin_of_error)
                     row.append(formatted_confidence_interval)
                 rows.append(row)
-        return tabulate.tabulate(rows, headers, tablefmt=table_fmt)
+        return tb.tabulate(rows, headers, tablefmt=table_fmt)
 
 
 def _get_mean_and_margin_of_error(data: list[float], confidence_level: float) -> tuple[float, float]:

--- a/decent_bench/library/core/network.py
+++ b/decent_bench/library/core/network.py
@@ -139,9 +139,9 @@ class Network:
             self.receive(receiver, neighbor)
 
 
-def generate_distributed_network(problem: BenchmarkProblem) -> Network:
+def create_distributed_network(problem: BenchmarkProblem) -> Network:
     """
-    Generate a distributed network - a network with peer-to-peer communication only, no coordinator.
+    Create a distributed network - a network with peer-to-peer communication only, no coordinator.
 
     Raises:
         ValueError: if there are less agent activation schemes or cost functions than agents

--- a/docs/source/decent_bench.library.core.metrics.table_metrics.rst
+++ b/docs/source/decent_bench.library.core.metrics.table_metrics.rst
@@ -12,14 +12,6 @@ decent\_bench.library.core.metrics.table\_metrics.default\_table\_metrics module
    :show-inheritance:
    :undoc-members:
 
-decent\_bench.library.core.metrics.table\_metrics.table\_generator module
--------------------------------------------------------------------------
-
-.. automodule:: decent_bench.library.core.metrics.table_metrics.table_generator
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
 decent\_bench.library.core.metrics.table\_metrics.table\_metrics\_constructs module
 -----------------------------------------------------------------------------------
 
@@ -32,6 +24,14 @@ decent\_bench.library.core.metrics.table\_metrics.table\_metrics\_data\_extracto
 -----------------------------------------------------------------------------------------
 
 .. automodule:: decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+decent\_bench.library.core.metrics.table\_metrics.tabulate module
+-----------------------------------------------------------------
+
+.. automodule:: decent_bench.library.core.metrics.table_metrics.tabulate
    :members:
    :show-inheritance:
    :undoc-members:


### PR DESCRIPTION
Improve naming and reduce boilerplate. There is no need for benchmark problem creation to be in a class, and the word 'generate' should be avoided (except in factories etc.) for clarity.