### PR TITLE
docs(metrics): Add reusable definitions

### DIFF
--- a/decent_bench/library/core/metrics/plot_metrics/default_plot_metrics.py
+++ b/decent_bench/library/core/metrics/plot_metrics/default_plot_metrics.py
@@ -18,12 +18,10 @@ DEFAULT_PLOT_METRICS = [
     ),
 ]
 """
-- Global cost error (y-axis) per iteration (x-axis). Semi-log plot.
-  Details: :func:`~decent_bench.library.core.metrics.plot_metrics.plot_metrics_data_extractors.\
-global_cost_error_per_iteration`.
-- Global gradient optimality (y-axis) per iteration (x-axis). Semi-log plot.
-  Details: :func:`~decent_bench.library.core.metrics.plot_metrics.plot_metrics_data_extractors.\
-global_gradient_optimality_per_iteration`.
+- :func:`~decent_bench.library.core.metrics.plot_metrics.plot_metrics_data_extractors.global_cost_error_per_iteration` \
+(semi-log)
+- :func:`~decent_bench.library.core.metrics.plot_metrics.plot_metrics_data_extractors.\
+global_gradient_optimality_per_iteration` (semi-log)
 
 :meta hide-value:
 """

--- a/decent_bench/library/core/metrics/plot_metrics/plot_metrics_data_extractors.py
+++ b/decent_bench/library/core/metrics/plot_metrics/plot_metrics_data_extractors.py
@@ -6,9 +6,11 @@ from decent_bench.library.core.metrics.plot_metrics.plot_metrics_constructs impo
 
 def global_cost_error_per_iteration(agents: list[AgentMetricsView], problem: BenchmarkProblem) -> list[tuple[X, Y]]:
     r"""
-    Calculate the global cost error (y-axis) for each iteration (x-axis).
+    Calculate the global cost error (y-axis) per iteration (x-axis).
 
-    Global cost error is defined at :func:`~decent_bench.library.core.metrics.metric_utils.global_cost_error_at_iter`.
+    Global cost error is defined as:
+
+    .. include:: snippets/global_cost_error.rst
 
     All iterations up to and including the last one reached by all *agents* are taken into account, subsequent
     iterations are disregarded. This is done to not miscalculate the global cost error which relies on all agents for
@@ -20,10 +22,11 @@ def global_cost_error_per_iteration(agents: list[AgentMetricsView], problem: Ben
 
 def global_gradient_optimality_per_iteration(agents: list[AgentMetricsView], _: BenchmarkProblem) -> list[tuple[X, Y]]:
     r"""
-    Calculate the global gradient optimality (y-axis) for each iteration (x-axis).
+    Calculate the global gradient optimality (y-axis) per iteration (x-axis).
 
-    Global gradient optimality is defined at
-    :func:`~decent_bench.library.core.metrics.metric_utils.global_gradient_optimality_at_iter`.
+    Global gradient optimality is defined as:
+
+    .. include:: snippets/global_gradient_optimality.rst
 
     All iterations up to and including the last one reached by all *agents* are taken into account, subsequent
     iterations are disregarded. This avoids the curve volatility that occurs when fewer and fewer agents are included in

--- a/decent_bench/library/core/metrics/table_metrics/default_table_metrics.py
+++ b/decent_bench/library/core/metrics/table_metrics/default_table_metrics.py
@@ -26,36 +26,28 @@ DEFAULT_TABLE_METRICS = [
     TableMetric("nr sent messages dropped", [Avg, Sum], data_extractors.n_sent_messages_dropped),
 ]
 """
-- Global cost error (single) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.global_cost_error`.
-- Global gradient optimality (single) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.global_gradient_optimality`.
-- x error (min, avg, max) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.x_error`.
-- Asymptotic convergence order (avg) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.asymptotic_convergence_order`.
-- Asymptotic convergence rate (avg) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.asymptotic_convergence_rate`.
-- Iterative convergence order (avg) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.iterative_convergence_order`.
-- Iterative convergence rate (avg) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.iterative_convergence_rate`.
-- Nr of x updates (avg, sum) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.n_x_updates`.
-- Nr of evaluate calls (avg, sum) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.n_evaluate_calls`.
-- Nr of gradient calls (avg, sum) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.n_gradient_calls`.
-- Nr of hessian calls (avg, sum) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.n_hessian_calls`.
-- Nr of proximal calls (avg, sum) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.n_proximal_calls`.
-- Nr of sent messages (avg, sum) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.n_sent_messages`.
-- Nr of received messages (avg, sum) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.n_received_messages`.
-- Nr of sent messages dropped (avg, sum) defined at :func:`~decent_bench.library.core.metrics.table_metrics.\
-table_metrics_data_extractors.n_sent_messages_dropped`.
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.global_cost_error` (single)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.global_gradient_optimality` \
+(single)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.x_error` (min, avg, max)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.asymptotic_convergence_order` \
+(avg)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.asymptotic_convergence_rate` \
+(avg)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.iterative_convergence_order` \
+(avg)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.iterative_convergence_rate` \
+(avg)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.n_x_updates` (avg, sum)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.n_evaluate_calls` (avg, sum)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.n_gradient_calls` (avg, sum)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.n_hessian_calls` (avg, sum)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.n_proximal_calls` (avg, sum)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.n_sent_messages` (avg, sum)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.n_received_messages` (avg, sum)
+- :func:`~decent_bench.library.core.metrics.table_metrics.table_metrics_data_extractors.n_sent_messages_dropped` \
+(avg, sum)
+
 
 :meta hide-value:
 """

--- a/decent_bench/library/core/metrics/table_metrics/table_metrics_data_extractors.py
+++ b/decent_bench/library/core/metrics/table_metrics/table_metrics_data_extractors.py
@@ -9,7 +9,9 @@ def global_cost_error(agents: list[AgentMetricsView], problem: BenchmarkProblem)
     """
     Calculate the global cost error using the agents' final x.
 
-    For details, see :func:`~decent_bench.library.core.metrics.metric_utils.global_cost_error_at_iter`.
+    Global cost error is defined as:
+
+    .. include:: snippets/global_cost_error.rst
     """
     return (utils.global_cost_error_at_iter(agents, problem, iteration=-1),)
 
@@ -18,7 +20,9 @@ def global_gradient_optimality(agents: list[AgentMetricsView], _: BenchmarkProbl
     """
     Calculate the global gradient optimality using the agents' final x.
 
-    For details, see :func:`~decent_bench.library.core.metrics.metric_utils.global_gradient_optimality_at_iter`.
+    Global gradient optimality is defined as:
+
+    .. include:: snippets/global_gradient_optimality.rst
     """
     return (utils.global_gradient_optimality_at_iter(agents, iteration=-1),)
 
@@ -40,36 +44,36 @@ def x_error(agents: list[AgentMetricsView], problem: BenchmarkProblem) -> list[f
 
 def asymptotic_convergence_rate(agents: list[AgentMetricsView], problem: BenchmarkProblem) -> list[float]:
     """
-    Calculate the asymptotic convergence rate per agent.
+    Estimate the asymptotic convergence rate per agent as defined below.
 
-    For details, see :func:`~decent_bench.library.core.metrics.metric_utils.asymptotic_convergence_rate_and_order`.
+    .. include:: snippets/asymptotic_convergence_rate_and_order.rst
     """
     return [utils.asymptotic_convergence_rate_and_order(a, problem)[0] for a in agents]
 
 
 def asymptotic_convergence_order(agents: list[AgentMetricsView], problem: BenchmarkProblem) -> list[float]:
     """
-    Calculate the asymptotic convergence order per agent.
+    Estimate the asymptotic convergence order per agent as defined below.
 
-    For details, see :func:`~decent_bench.library.core.metrics.metric_utils.asymptotic_convergence_rate_and_order`.
+    .. include:: snippets/asymptotic_convergence_rate_and_order.rst
     """
     return [utils.asymptotic_convergence_rate_and_order(a, problem)[1] for a in agents]
 
 
 def iterative_convergence_rate(agents: list[AgentMetricsView], problem: BenchmarkProblem) -> list[float]:
     """
-    Calculate the iterative convergence rate per agent.
+    Estimate the iterative convergence rate per agent as defined below.
 
-    For details, see :func:`~decent_bench.library.core.metrics.metric_utils.iterative_convergence_rate_and_order`.
+    .. include:: snippets/iterative_convergence_rate_and_order.rst
     """
     return [utils.iterative_convergence_rate_and_order(a, problem)[0] for a in agents]
 
 
 def iterative_convergence_order(agents: list[AgentMetricsView], problem: BenchmarkProblem) -> list[float]:
     """
-    Calculate the iterative convergence order per agent.
+    Estimate the iterative convergence order per agent as defined below.
 
-    For details, see :func:`~decent_bench.library.core.metrics.metric_utils.iterative_convergence_rate_and_order`.
+    .. include:: snippets/iterative_convergence_rate_and_order.rst
     """
     return [utils.iterative_convergence_rate_and_order(a, problem)[1] for a in agents]
 

--- a/docs/source/snippets/asymptotic_convergence_rate_and_order.rst
+++ b/docs/source/snippets/asymptotic_convergence_rate_and_order.rst
@@ -1,0 +1,8 @@
+.. math::
+    \lim_{k \to \infty}
+    \frac{\| \mathbf{x}_{k+1} - \mathbf{x}^\star \|}{\| \mathbf{x}_{k} - \mathbf{x}^\star\|^q} = \mu
+
+where :math:`\mathbf{x}_k` is the agent's local x at iteration k,
+:math:`\mathbf{x}^\star` is the optimal x defined in the *problem*,
+:math:`q` is the asymptotic convergence order,
+and :math:`\mu` is the asymptotic convergence rate.

--- a/docs/source/snippets/global_cost_error.rst
+++ b/docs/source/snippets/global_cost_error.rst
@@ -1,0 +1,6 @@
+.. math::
+    | \sum_i (f_i(\mathbf{\bar{x}}) - f_i(\mathbf{x}^\star)) |
+
+where :math:`f_i` is agent i's local cost function,
+:math:`\mathbf{\bar{x}}` is the mean x across all *agents*,
+and :math:`\mathbf{x}^\star` is the optimal x defined in the *problem*.

--- a/docs/source/snippets/global_gradient_optimality.rst
+++ b/docs/source/snippets/global_gradient_optimality.rst
@@ -1,0 +1,6 @@
+.. math::
+    \| \frac{1}{N} \sum_i \nabla f_i(\mathbf{\bar{x}}) \|^2
+
+where N is the number of *agents*,
+:math:`f_i` is agent i's local cost function,
+and :math:`\mathbf{\bar{x}}` is the mean x across all *agents*.

--- a/docs/source/snippets/iterative_convergence_rate_and_order.rst
+++ b/docs/source/snippets/iterative_convergence_rate_and_order.rst
@@ -1,0 +1,8 @@
+.. math::
+    k = \frac{\mu}{\|\mathbf{x}_k - \mathbf{x}^\star\|^q}
+
+where k is the iteration,
+:math:`\mu` is the iterative convergence rate,
+:math:`\mathbf{x}_k` is the agent's local x at iteration k,
+:math:`\mathbf{x}^\star` is the optimal x defined in the *problem*,
+and :math:`q` is the iterative convergence order.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ description = "Clean up and regenerate rst and html files using sphinx"
 deps = ["sphinx", "sphinx_rtd_theme"]
 allowlist_externals = ["find", "make"]
 commands = [
-  ["find", "docs/source", "-name", "*.rst", "!", "-name", "index.rst", "-delete"],
+  ["find", "docs/source", "-name", "*.rst", "!", "-name", "index.rst", "!", "-path", "*/snippets/*", "-delete"],
   ["sphinx-apidoc", "-o", "docs/source", "decent_bench", "--no-toc"],
   ["make", "-C", "docs", "clean"],
   ["make", "-C", "docs", "html", "SPHINXOPTS=-W"],


### PR DESCRIPTION
Add definitions used in multiple docstrings to snippet files which can be loaded in docstrings using the include-directive. Using this pattern, docstrings don't have to redefine defintions, and future changes can be done in a single place. As part of this, metric definitions have been moved closer to the default metrics: before, you had to go down 2 levels - first to data extractors and then to metric utils - to see the definition of certain metrics, now the definitions are shown directly in data extractors.