### PR TITLE
enh(metrics): Default to semi-log

### DIFF
--- a/decent_bench/library/core/metrics/plot_metrics/plot_metrics_constructs.py
+++ b/decent_bench/library/core/metrics/plot_metrics/plot_metrics_constructs.py
@@ -21,11 +21,11 @@ class PlotMetric:
 
     """
 
+    get_data_from_trial: Callable[[list[AgentMetricsView], BenchmarkProblem], Sequence[tuple[X, Y]]]
     x_label: str
     y_label: str
-    x_log: bool
-    y_log: bool
-    get_data_from_trial: Callable[[list[AgentMetricsView], BenchmarkProblem], Sequence[tuple[X, Y]]]
+    x_log: bool = False
+    y_log: bool = True
 
 
 X = float


### PR DESCRIPTION
Use semi-log as the default for plot metrics to steer users in the direction of producing meaningful plots.