### PR TITLE
enh(metrics): Use markevery in plots

### DIFF
--- a/decent_bench/library/core/metrics/plot_metrics/plot.py
+++ b/decent_bench/library/core/metrics/plot_metrics/plot.py
@@ -55,7 +55,7 @@ def plot(
                 continue
             mean_curve: Sequence[tuple[X, Y]] = _calculate_mean_curve(data_per_trial)
             x, y_mean = zip(*mean_curve, strict=True)
-            subplot.plot(x, y_mean, label=alg.name, color=color, marker=marker, linewidth=3)
+            subplot.plot(x, y_mean, label=alg.name, color=color, marker=marker, linewidth=3, markevery=100)
             y_min, y_max = _calculate_envelope(data_per_trial)
             subplot.fill_between(x, y_min, y_max, color=color, alpha=0.3)
     manager = plt.get_current_fig_manager()


### PR DESCRIPTION
To not overcrowd plots with thousands and thousands of datapoints, use markevery to only plot every 100 datapoint.