### PR TITLE
fix(costs): Add tolerance to QuadraticCost.m_cvx

### DIFF
--- a/decent_bench/library/core/cost_functions.py
+++ b/decent_bench/library/core/cost_functions.py
@@ -154,9 +154,10 @@ class QuadraticCost(CostFunction):
         """
         eigs = np.linalg.eigvalsh(self.A_sym)
         l_min = float(np.min(eigs))
-        if l_min > 0:
+        tol = 1e-12
+        if l_min > tol:
             return l_min
-        if l_min == 0:
+        if abs(l_min) <= tol:
             return 0
         return np.nan
 


### PR DESCRIPTION
Add tolerance of 1e-12 to QuadraticCost.m_cvx when determining if it is convex (not strong). The determining conditition is that the smallest eigenvalue is precisely 0. However, due to numerical noise, tolerance is needed.