### PR TITLE
enh(metrics): Output link to metric definitions

### DIFF
--- a/decent_bench/library/core/metrics/plot_metrics/plot.py
+++ b/decent_bench/library/core/metrics/plot_metrics/plot.py
@@ -15,6 +15,7 @@ from decent_bench.library.core.metrics.plot_metrics.plot_metrics_constructs impo
 from decent_bench.library.core.network import Network
 from decent_bench.library.utils.logger import LOGGER
 
+DOC_LINK = "https://decent-bench.readthedocs.io/en/latest/decent_bench.library.core.metrics.plot_metrics.html"
 COLORS = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf"]
 MARKERS = ["o", "s", "v", "^", "*", "D", "H", "<", ">", "p"]
 
@@ -63,6 +64,7 @@ def plot(
         raise RuntimeError("Something went wrong, did not receive a FigureManager...")
     manager.full_screen_toggle()
     plt.tight_layout()
+    LOGGER.info(f"Metric definitions can be found here: {DOC_LINK}")
     plt.show()
 
 

--- a/decent_bench/library/core/metrics/table_metrics/tabulate.py
+++ b/decent_bench/library/core/metrics/table_metrics/tabulate.py
@@ -12,6 +12,8 @@ from decent_bench.library.core.metrics.table_metrics.table_metrics_constructs im
 from decent_bench.library.core.network import Network
 from decent_bench.library.utils.logger import LOGGER
 
+DOC_LINK = "https://decent-bench.readthedocs.io/en/latest/decent_bench.library.core.metrics.table_metrics.html"
+
 
 def tabulate(
     resulting_nw_states_per_alg: dict[DstAlgorithm, list[Network]],
@@ -46,6 +48,7 @@ def tabulate(
             rows.append(row)
     formatted_table = tb.tabulate(rows, headers, tablefmt=table_fmt)
     LOGGER.info("\n" + formatted_table)
+    LOGGER.info(f"Metric definitions can be found here: {DOC_LINK}")
 
 
 def _get_aggregated_data_per_trial(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
   "matplotlib",
   "networkx",
   "numpy",
+  "requests",
   "rich",
   "scipy",
   "scikit-learn",

--- a/test/test_links.py
+++ b/test/test_links.py
@@ -1,0 +1,12 @@
+import requests
+
+from decent_bench.library.core.metrics.table_metrics.tabulate import DOC_LINK as TABLE_METRICS_DOC_LINK
+from decent_bench.library.core.metrics.plot_metrics.plot import DOC_LINK as PLOT_METRICS_DOC_LINK
+
+
+def test_table_metrics_doc_link_works():
+    assert requests.head(TABLE_METRICS_DOC_LINK, allow_redirects=True, timeout=10).status_code == 200
+
+
+def test_plot_metrics_doc_link_works():
+    assert requests.head(PLOT_METRICS_DOC_LINK, allow_redirects=True, timeout=10).status_code == 200


### PR DESCRIPTION
Output link to definitions of default table metrics and default plot metrics in conjunction with tabulating and plotting. This makes it easier for users to understand the metrics, several of which are not obvious.