### PR TITLE
test: Use urllib instead of requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ dependencies = [
   "matplotlib",
   "networkx",
   "numpy",
-  "requests",
   "rich",
   "scipy",
   "scikit-learn",

--- a/test/test_links.py
+++ b/test/test_links.py
@@ -1,12 +1,16 @@
-import requests
-
+from urllib.request import Request, urlopen
 from decent_bench.library.core.metrics.table_metrics.tabulate import DOC_LINK as TABLE_METRICS_DOC_LINK
 from decent_bench.library.core.metrics.plot_metrics.plot import DOC_LINK as PLOT_METRICS_DOC_LINK
 
 
+def open_url(url: str):
+    req = Request(url, method="HEAD", headers={"User-Agent": "Mozilla/5.0", "Accept": "*/*"})
+    assert urlopen(url=req, timeout=10).status == 200
+
+
 def test_table_metrics_doc_link_works():
-    assert requests.head(TABLE_METRICS_DOC_LINK, allow_redirects=True, timeout=10).status_code == 200
+    open_url(TABLE_METRICS_DOC_LINK)
 
 
 def test_plot_metrics_doc_link_works():
-    assert requests.head(PLOT_METRICS_DOC_LINK, allow_redirects=True, timeout=10).status_code == 200
+    open_url(PLOT_METRICS_DOC_LINK)


### PR DESCRIPTION
Use the already built-in urllib instead of requests when testing that links work.