### PR TITLE
docs: Make docs more simplistic

### DIFF
--- a/decent_bench/utils/logger.py
+++ b/decent_bench/utils/logger.py
@@ -10,6 +10,11 @@ from typing import Protocol
 from rich.logging import RichHandler
 
 LOGGER = logging.getLogger()
+"""
+Logger to be used across the codebase.
+
+:meta hide-value:
+"""
 
 
 class LogQueue(Protocol):

--- a/docs/source/_templates/module.rst.jinja
+++ b/docs/source/_templates/module.rst.jinja
@@ -1,0 +1,8 @@
+{%- if show_headings %}
+{{- [basename] | join(' ') | e | heading }}
+
+{% endif -%}
+.. automodule:: {{ qualname }}
+{%- for option in automodule_options %}
+   :{{ option }}:
+{%- endfor %}

--- a/docs/source/_templates/package.rst.jinja
+++ b/docs/source/_templates/package.rst.jinja
@@ -1,0 +1,49 @@
+{%- macro automodule(modname, options) -%}
+.. automodule:: {{ modname }}
+{%- for option in options %}
+   :{{ option }}:
+{%- endfor %}
+{%- endmacro %}
+
+{%- macro toctree(docnames) -%}
+.. toctree::
+   :maxdepth: 2
+{% for docname in docnames %}
+   {{ docname }}
+{%- endfor %}
+{%- endmacro %}
+
+{%- if is_namespace %}
+{{- [pkgname, "namespace"] | join(" ") | e | heading }}
+{% else %}
+{{- [pkgname] | join(" ") | e | heading }}
+{% endif %}
+
+{%- if is_namespace %}
+.. py:module:: {{ pkgname }}
+{% endif %}
+
+{%- if modulefirst and not is_namespace %}
+{{ automodule(pkgname, automodule_options) }}
+{% endif %}
+
+{%- if subpackages %}
+{{ toctree(subpackages) }}
+{% endif %}
+
+{%- if submodules %}
+{% if separatemodules %}
+{{ toctree(submodules) }}
+{% else %}
+{%- for submodule in submodules %}
+{% if show_headings %}
+{{- [submodule] | join(" ") | e | heading(2) }}
+{% endif %}
+{{ automodule(submodule, automodule_options) }}
+{% endfor %}
+{%- endif %}
+{%- endif %}
+
+{%- if not modulefirst and not is_namespace %}
+{{ automodule(pkgname, automodule_options) }}
+{% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,6 @@ intersphinx_mapping = {
 }
 
 
-templates_path = ["_templates"]
 exclude_patterns = []
 
 

--- a/docs/source/decent_bench.agent.rst
+++ b/docs/source/decent_bench.agent.rst
@@ -1,0 +1,7 @@
+decent\_bench.agent
+===================
+
+.. automodule:: decent_bench.agent
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.benchmark.rst
+++ b/docs/source/decent_bench.benchmark.rst
@@ -1,0 +1,7 @@
+decent\_bench.benchmark
+=======================
+
+.. automodule:: decent_bench.benchmark
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.benchmark_problem.rst
+++ b/docs/source/decent_bench.benchmark_problem.rst
@@ -1,0 +1,7 @@
+decent\_bench.benchmark\_problem
+================================
+
+.. automodule:: decent_bench.benchmark_problem
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.centralized_algorithms.rst
+++ b/docs/source/decent_bench.centralized_algorithms.rst
@@ -1,0 +1,7 @@
+decent\_bench.centralized\_algorithms
+=====================================
+
+.. automodule:: decent_bench.centralized_algorithms
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.cost_functions.rst
+++ b/docs/source/decent_bench.cost_functions.rst
@@ -1,0 +1,7 @@
+decent\_bench.cost\_functions
+=============================
+
+.. automodule:: decent_bench.cost_functions
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.datasets.rst
+++ b/docs/source/decent_bench.datasets.rst
@@ -1,0 +1,7 @@
+decent\_bench.datasets
+======================
+
+.. automodule:: decent_bench.datasets
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.distributed_algorithms.rst
+++ b/docs/source/decent_bench.distributed_algorithms.rst
@@ -1,0 +1,7 @@
+decent\_bench.distributed\_algorithms
+=====================================
+
+.. automodule:: decent_bench.distributed_algorithms
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.metrics.metric_utils.rst
+++ b/docs/source/decent_bench.metrics.metric_utils.rst
@@ -1,0 +1,7 @@
+decent\_bench.metrics.metric\_utils
+===================================
+
+.. automodule:: decent_bench.metrics.metric_utils
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.metrics.plot_metrics.rst
+++ b/docs/source/decent_bench.metrics.plot_metrics.rst
@@ -1,0 +1,7 @@
+decent\_bench.metrics.plot\_metrics
+===================================
+
+.. automodule:: decent_bench.metrics.plot_metrics
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.metrics.rst
+++ b/docs/source/decent_bench.metrics.rst
@@ -1,35 +1,13 @@
-decent\_bench.metrics package
-=============================
+decent\_bench.metrics
+=====================
 
-Submodules
-----------
 
-decent\_bench.metrics.metric\_utils module
-------------------------------------------
+.. toctree::
+   :maxdepth: 2
 
-.. automodule:: decent_bench.metrics.metric_utils
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.metrics.plot\_metrics module
-------------------------------------------
-
-.. automodule:: decent_bench.metrics.plot_metrics
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.metrics.table\_metrics module
--------------------------------------------
-
-.. automodule:: decent_bench.metrics.table_metrics
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-Module contents
----------------
+   decent_bench.metrics.metric_utils
+   decent_bench.metrics.plot_metrics
+   decent_bench.metrics.table_metrics
 
 .. automodule:: decent_bench.metrics
    :members:

--- a/docs/source/decent_bench.metrics.table_metrics.rst
+++ b/docs/source/decent_bench.metrics.table_metrics.rst
@@ -1,0 +1,7 @@
+decent\_bench.metrics.table\_metrics
+====================================
+
+.. automodule:: decent_bench.metrics.table_metrics
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.network.rst
+++ b/docs/source/decent_bench.network.rst
@@ -1,0 +1,7 @@
+decent\_bench.network
+=====================
+
+.. automodule:: decent_bench.network
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.rst
+++ b/docs/source/decent_bench.rst
@@ -1,92 +1,25 @@
-decent\_bench package
-=====================
-
-Subpackages
------------
+decent\_bench
+=============
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 2
 
    decent_bench.metrics
    decent_bench.utils
 
-Submodules
-----------
 
-decent\_bench.agent module
---------------------------
+.. toctree::
+   :maxdepth: 2
 
-.. automodule:: decent_bench.agent
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.benchmark module
-------------------------------
-
-.. automodule:: decent_bench.benchmark
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.benchmark\_problem module
----------------------------------------
-
-.. automodule:: decent_bench.benchmark_problem
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.centralized\_algorithms module
---------------------------------------------
-
-.. automodule:: decent_bench.centralized_algorithms
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.cost\_functions module
-------------------------------------
-
-.. automodule:: decent_bench.cost_functions
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.datasets module
------------------------------
-
-.. automodule:: decent_bench.datasets
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.distributed\_algorithms module
---------------------------------------------
-
-.. automodule:: decent_bench.distributed_algorithms
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.network module
-----------------------------
-
-.. automodule:: decent_bench.network
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.schemes module
-----------------------------
-
-.. automodule:: decent_bench.schemes
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-Module contents
----------------
+   decent_bench.agent
+   decent_bench.benchmark
+   decent_bench.benchmark_problem
+   decent_bench.centralized_algorithms
+   decent_bench.cost_functions
+   decent_bench.datasets
+   decent_bench.distributed_algorithms
+   decent_bench.network
+   decent_bench.schemes
 
 .. automodule:: decent_bench
    :members:

--- a/docs/source/decent_bench.schemes.rst
+++ b/docs/source/decent_bench.schemes.rst
@@ -1,0 +1,7 @@
+decent\_bench.schemes
+=====================
+
+.. automodule:: decent_bench.schemes
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.utils.logger.rst
+++ b/docs/source/decent_bench.utils.logger.rst
@@ -1,0 +1,7 @@
+decent\_bench.utils.logger
+==========================
+
+.. automodule:: decent_bench.utils.logger
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.utils.progress_bar.rst
+++ b/docs/source/decent_bench.utils.progress_bar.rst
@@ -1,0 +1,7 @@
+decent\_bench.utils.progress\_bar
+=================================
+
+.. automodule:: decent_bench.utils.progress_bar
+   :members:
+   :show-inheritance:
+   :undoc-members:

--- a/docs/source/decent_bench.utils.rst
+++ b/docs/source/decent_bench.utils.rst
@@ -1,27 +1,12 @@
-decent\_bench.utils package
-===========================
+decent\_bench.utils
+===================
 
-Submodules
-----------
 
-decent\_bench.utils.logger module
----------------------------------
+.. toctree::
+   :maxdepth: 2
 
-.. automodule:: decent_bench.utils.logger
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-decent\_bench.utils.progress\_bar module
-----------------------------------------
-
-.. automodule:: decent_bench.utils.progress_bar
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-Module contents
----------------
+   decent_bench.utils.logger
+   decent_bench.utils.progress_bar
 
 .. automodule:: decent_bench.utils
    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ Welcome to decent-bench's documentation!
 
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 2
    :caption: Contents:
 
    decent_bench

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ deps = ["sphinx", "pydata-sphinx-theme @ git+https://github.com/pydata/pydata-sp
 allowlist_externals = ["find", "make"]
 commands = [
   ["find", "docs/source", "-name", "*.rst", "!", "-name", "index.rst", "!", "-path", "*/snippets/*", "-delete"],
-  ["sphinx-apidoc", "-o", "docs/source", "decent_bench", "--no-toc"],
+  ["sphinx-apidoc", "-o", "docs/source", "decent_bench", "--separate", "--no-toc", "--templatedir=docs/source/_templates"],
   ["make", "-C", "docs", "clean"],
   ["make", "-C", "docs", "html", "SPHINXOPTS=-W"],
 ]


### PR DESCRIPTION
Remove unnecessary headers, make toctree less deep, and don't show submodule contents at package lvl. This makes it easier to get a clear overview.