### PR TITLE
fix(costs): Preserve QuadraticCost type in __add__

### DIFF
--- a/decent_bench/centralized_algorithms.py
+++ b/decent_bench/centralized_algorithms.py
@@ -135,5 +135,5 @@ def proximal_solver(cost_function: "CostFunction", y: NDArray[float64], rho: flo
         raise ValueError("Penalty term `rho` must be greater than 0")
     from decent_bench.cost_functions import QuadraticCost  # noqa: PLC0415
 
-    proximal_cost = cost_function + QuadraticCost(A=np.eye(len(y)) / rho, b=-y / rho, c=y.dot(y) / (2 * rho))
+    proximal_cost = QuadraticCost(A=np.eye(len(y)) / rho, b=-y / rho, c=y.dot(y) / (2 * rho)) + cost_function
     return accelerated_gradient_descent(proximal_cost, y, max_iter=100, stop_tol=1e-10, max_tol=None)

--- a/decent_bench/cost_functions.py
+++ b/decent_bench/cost_functions.py
@@ -215,6 +215,8 @@ class QuadraticCost(CostFunction):
             raise ValueError(f"Mismatching domain shapes: {self.domain_shape} vs {other.domain_shape}")
         if isinstance(other, QuadraticCost):
             return QuadraticCost(self.A + other.A, self.b + other.b, self.c + other.c)
+        if isinstance(other, LinearRegressionCost):
+            return self + other.inner
         return SumCost([self, other])
 
 


### PR DESCRIPTION
Preserve the QuadraticCostType when adding with LinearRegressionCost. This was accidently removed earlier when ProximalCost was removed.