### PR TITLE
ref(metrics): Make each metric a class

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,9 @@ extensions = [
     "sphinx.ext.viewcode",  # View source code
 ]
 
-autodoc_default_options = {"special-members": "__add__, __iter__"}
+autodoc_default_options = {
+    "special-members": "__add__",
+}
 autodoc_member_order = "bysource"
 autodoc_preserve_defaults = True
 


### PR DESCRIPTION
Make each metric its own class instead of instances of TableMetric or PlotMetric. To overall goal was to have metrics defined outside of the DEFAULT_METRICS so that users can easily pick which metrics to include. The motivation behind this is that some users might only want a subset of the metrics defined, for example to exclude metrics that are too computationally heavy when dealing with neural networks. We should also have a pattern for defining ready-to-use metrics which are not part of the defaults. Now, instead of defining global variables for metrics, the approach of creating classes was chosen because it reduces runtime overhead during imports and is sphinx friendly (sphinx documentation involving globals is quite annoying to maintain, and causes reference issues when making modules private as we plan to do). Lastly, Statistic was removed to reduce boilerplate.