### PR TITLE
fix(logger): Stop logger daemon

### DIFF
--- a/decent_bench/benchmark.py
+++ b/decent_bench/benchmark.py
@@ -66,6 +66,7 @@ def benchmark(
         tm.tabulate(resulting_nw_states, benchmark_problem, table_metrics, confidence_level, table_fmt)
     with Status("Creating plot"):
         plot(resulting_nw_states, benchmark_problem, plot_metrics)
+    log_listener.stop()
 
 
 def _run_trials(  # noqa: PLR0917

--- a/decent_bench/utils/logger.py
+++ b/decent_bench/utils/logger.py
@@ -51,4 +51,6 @@ def start_log_listener(manager: SyncManager, log_level: int) -> QueueListener:
 
 def start_queue_logger(queue: LogQueue) -> None:
     """Configure the default logger for the current process to put log messages in the *queue*."""
-    logging.basicConfig(level=logging.NOTSET, format="%(message)s", handlers=[QueueHandler(queue)])
+    LOGGER.handlers.clear()
+    LOGGER.addHandler(QueueHandler(queue))
+    LOGGER.setLevel(logging.NOTSET)


### PR DESCRIPTION
Stop logger daemon thread after benchmark execution, which is currently being shutdown forcefully at program exit, often leading to "Exception in thread Thread-1 (_monitor)". To be able to restart the logger, i.e. when running benchmark multiple times in the same execution, setup_queue_logger is modified to not rely on logger.basicConfig. Without this change, no logs show up in subsequent executions.