### PR TITLE
fix(problem): Set realistic max tol for opt x

### DIFF
--- a/decent_bench/benchmark_problem.py
+++ b/decent_bench/benchmark_problem.py
@@ -87,7 +87,7 @@ def create_regression_problem(
     )
     costs = [cost_function_cls(*p) for p in dataset.training_partitions]
     sum_cost = reduce(add, costs)
-    optimal_x = ca.accelerated_gradient_descent(sum_cost, x0=None, max_iter=50000, stop_tol=1e-100, max_tol=1e-100)
+    optimal_x = ca.accelerated_gradient_descent(sum_cost, x0=None, max_iter=50000, stop_tol=1e-100, max_tol=1e-16)
     agent_activation_schemes = [UniformActivationRate(0.5) if asynchrony else AlwaysActive()] * n_agents
     compression_scheme = Quantization(n_significant_digits=4) if compressed else NoCompression()
     noise_scheme = GaussianNoise(mean=0, sd=0.001) if noisy else NoNoise()


### PR DESCRIPTION
Set max tol to 1e-16 when using accelerated gradient descent to calculate the optimal x in ``create_regression_problem``. It was not able to reach the previous max tol with linear regression as cost function.