### PR TITLE
enh(metrics): Handle np.nan in stats.t interval

### DIFF
--- a/decent_bench/metrics/table_metrics.py
+++ b/decent_bench/metrics/table_metrics.py
@@ -313,10 +313,9 @@ def _calculate_mean_and_margin_of_error(data: list[float], confidence_level: flo
     raw_interval = (
         stats.t.interval(confidence=confidence_level, df=len(data) - 1, loc=mean, scale=sem) if sem else (mean, mean)
     )
-    res = (float(mean), float(mean - raw_interval[0]))
-    if any(np.isinf(res)):
-        return np.nan, np.nan
-    return res
+    if np.isfinite(mean) and np.isfinite(raw_interval).all():
+        return (float(mean), float(mean - raw_interval[0]))
+    return np.nan, np.nan
 
 
 def _format_confidence_interval(mean: float, margin_of_error: float) -> str:


### PR DESCRIPTION
Return (np.nan, np.nan) if any element in the confidence interval is np.nan. Currently, only np.inf is handled like this. Also, check for isfinite before doing subtraction to avoid warnings (in case we stop silencing these).