### PR TITLE
docs(conf): Remove version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,6 @@
 project = "decent-bench"
 copyright = "2025, Team Decent"
 author = "team-decent"
-release = "0.0.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
Remove the version field from conf.py which is currently not displayed in the docs anyways. The planned release workflow #145 will use a better way of versioning docs -  it will allow us to display "dev" or "pre-release" instead of the latest released version, e.g. 0.2.1, when looking at the [latest docs](https://decent-bench.readthedocs.io/en/latest/), i.e. the docs reflecting the latest github commit.