### PR TITLE
fix(metrics): Don't auto-fullscreen plot metrics

### DIFF
--- a/decent_bench/metrics/plot_metrics.py
+++ b/decent_bench/metrics/plot_metrics.py
@@ -149,7 +149,6 @@ def plot(
     manager = plt.get_current_fig_manager()
     if not manager:
         raise RuntimeError("Something went wrong, did not receive a FigureManager...")
-    manager.full_screen_toggle()
     plt.tight_layout()
     plt.show()
 


### PR DESCRIPTION
Do not automatically turn on full screen for plot metrics since it can be hard to close the window due to matplotlib limitations.