### PR TITLE
fix(interoperability): stabilize tf pow precision

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,10 +30,7 @@ extensions = [
 autodoc_default_options = {}
 autodoc_member_order = "bysource"
 autodoc_preserve_defaults = True
-autodoc_type_aliases = {
-    "SupportedArrayTypes": "decent_bench.utils.types.SupportedArrayTypes",
-    "ArrayKey": "decent_bench.utils.types.ArrayKey",
-}
+autodoc_type_aliases = {}
 
 nitpicky = True
 nitpick_ignore = [
@@ -41,15 +38,10 @@ nitpick_ignore = [
     ("py:class", "float64"),
     ("py:class", "numpy._typing._array_like._SupportsArray"),
     ("py:class", "numpy._typing._nested_sequence._NestedSequence"),
-    ("py:class", "TypeAliasForwardRef"),
     ("py:class", "T"),
     ("py:class", "TorchTensor"),
     ("py:class", "TensorFlowTensor"),
     ("py:class", "JaxArray"),
-    ("py:class", "SupportedArrayTypes"),
-    ("py:class", "decent_bench.utils.types.SupportedArrayTypes"),
-    ("py:class", "ArrayKey"),
-    ("py:class", "decent_bench.utils.types.ArrayKey"),
 ]
 
 intersphinx_mapping = {


### PR DESCRIPTION
- Cast TF float tensors to float64 for pow/ipow then back to avoid float32 ULP drift on TF 2.20/Py3.13.

- Add autodoc type aliases and ignore TypeAliasForwardRef to keep Sphinx nitpicky builds passing.

- closes #225