### PR TITLE
feat(costs): Add dunder methods to costs

### DIFF
--- a/decent_bench/costs/_base/_cost.py
+++ b/decent_bench/costs/_base/_cost.py
@@ -171,8 +171,14 @@ class Cost(ABC):  # noqa: PLR0904
         return self.__mul__(1.0 / float(other))
 
     def __rtruediv__(self, other: float) -> Cost:
-        """Right-side scalar division, equivalent to dividing this cost by the scalar."""
-        return self.__truediv__(other)
+        """
+        Right-side scalar division is not supported.
+
+        Raises:
+            TypeError: Always, since scalar / cost is not supported.
+
+        """
+        raise TypeError("Right-side division is not supported for Cost objects.")
 
     def __neg__(self) -> Cost:
         """Negate this cost function."""

--- a/decent_bench/costs/_base/_scaled_cost.py
+++ b/decent_bench/costs/_base/_scaled_cost.py
@@ -60,6 +60,10 @@ class ScaledCost(Cost):
         return self.cost.hessian(x, *args, **kwargs) * self.scalar
 
     def proximal(self, x: Array, rho: float, *args: Any, **kwargs: Any) -> Array:  # noqa: ANN401
+        if rho <= 0:
+            raise ValueError("The penalty parameter rho must be positive.")
+        if self.scalar < 0:
+            raise ValueError("The proximal operator is not defined for negative scaling.")
         if self.scalar == 0:
             return x
         return self.cost.proximal(x, rho * self.scalar, *args, **kwargs)

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -448,6 +448,15 @@ Create new cost functions by subclassing :class:`~decent_bench.costs.Cost` and u
 your implementation framework-agnostic. The decorators automatically wrap inputs/outputs as `Array` and ensure
 compatibility with the selected framework and device of your custom cost.
 
+Supported operations for cost objects:
+
+- Addition: ``cost_a + cost_b``
+- Subtraction: ``cost_a - cost_b``
+- Negation: ``-cost``
+- Scalar multiplication: ``scalar * cost`` or ``cost * scalar``
+- Scalar division: ``cost / scalar``
+- Summation: ``sum(costs)`` (uses ``__radd__``)
+
 .. code-block:: python
 
     from numpy import float64

--- a/test/test_cost_operators.py
+++ b/test/test_cost_operators.py
@@ -28,10 +28,8 @@ def test_cost_scalar_division() -> None:
     cost = _simple_quadratic(A_scale=4.0, b_scale=2.0, c=1.0)
     x = np.array([0.5, -0.25])
     divided = cost / 2.0
-    divided_reverse = 2.0 / cost
 
     assert divided.function(x) == pytest.approx(0.5 * cost.function(x))
-    assert divided_reverse.function(x) == pytest.approx(0.5 * cost.function(x))
     np.testing.assert_allclose(iop.to_numpy(divided.gradient(x)), 0.5 * iop.to_numpy(cost.gradient(x)))
     np.testing.assert_allclose(iop.to_numpy(divided.hessian(x)), 0.5 * iop.to_numpy(cost.hessian(x)))
 
@@ -82,5 +80,5 @@ def test_cost_scalar_ops_reject_invalid_inputs() -> None:
         _ = 1.0 + cost  # type: ignore[operator]
     with pytest.raises(ZeroDivisionError):
         _ = cost / 0.0
-    with pytest.raises(ZeroDivisionError):
+    with pytest.raises(TypeError):
         _ = 0.0 / cost


### PR DESCRIPTION
## Summary
- Add scalar multiplication, division, negation, subtraction, and reverse add for Cost
- Introduce ScaledCost to represent weighted objectives
- Add operator tests for the new behaviours



Closes #178