### PR TITLE
enh(algs): Add hyperparameter validation and default values

### DIFF
--- a/decent_bench/distributed_algorithms.py
+++ b/decent_bench/distributed_algorithms.py
@@ -21,6 +21,7 @@ class Algorithm[NetworkT: Network](ABC):
 
     def __post_init__(self) -> None:
         """Optional hook to be called by dataclasses after __init__."""  # noqa: D401
+        return
 
     def __init_subclass__(cls, **kwargs: dict[str, Any]) -> None:
         """Validate `iterations` for all subclasses."""


### PR DESCRIPTION
This PR adds hyperparameter validation (through `__post_init__`) to all implemented algorithms (with the superclass taking care of validating `iterations`). Default (representative) values are also added to all algorithms

Had to also give a default to `iterations` because apparently `field()` didn't satisfy the abstract class checks

closes #252 