### PR TITLE
feat(schemes): add new activation, compression, drops schemes and tests

### DIFF
--- a/decent_bench/schemes.py
+++ b/decent_bench/schemes.py
@@ -71,7 +71,7 @@ class MarkovChainActivation(AgentActivationScheme):
             [1 - inactive_to_active, inactive_to_active],
             [active_to_inactive, 1 - active_to_inactive],
         ])  # transition matrix
-        self._current_state = rng.choice(self._states, p=[1 - inactive_to_active, 1 - active_to_inactive])
+        self._current_state = rng.choice(self._states, p=[0, 1])
 
     def is_active(self, iteration: int) -> bool:  # noqa: D102, ARG002
         self._current_state = rng.choice(self._states, p=self._P[self._current_state])  # evolve the Markov chain
@@ -184,23 +184,42 @@ class Quantization(CompressionScheme):
 
 
 class TopK(CompressionScheme):
-    """Top-k compression which transmits only the k elements with largest magnitude."""
+    """
+    Top-k compression which transmits only the k elements with largest magnitude.
+
+    Raises:
+        ValueError: if ``k <= 0``
+
+    Note:
+        If the message has fewer than ``k`` elements, no compression is applied.
+
+    """
 
     def __init__(self, k: int):
         if k <= 0:
-            raise ValueError("`k` must be a positive integer")
+            raise ValueError(f"`k` must be a positive integer, got {k}")
         self.k = k
 
     def compress(self, msg: Array) -> Array:  # noqa: D102
-        msg_np = iop.to_numpy(msg).ravel()
-        idx = np.argpartition(np.abs(msg_np), -self.k, axis=None)[-self.k :]
-        mask = np.isin(np.arange(msg_np.size), idx)
+        msg_np = np.copy(iop.to_numpy(msg))
+        k = min(self.k, msg_np.size)
+        idx = np.argpartition(np.abs(msg_np), -k, axis=None)[-k:]
+        mask = np.isin(np.arange(msg_np.size), idx).reshape(msg_np.shape)
         msg_np[~mask] = 0
         return iop.to_array_like(msg_np, msg)
 
 
 class RandK(CompressionScheme):
-    """Rand-k compression which transmits only k randomly selected elements."""
+    """
+    Rand-k compression which transmits only k randomly selected elements.
+
+    Raises:
+        ValueError: if ``k <= 0``
+
+    Note:
+        If the message has fewer than ``k`` elements, no compression is applied.
+
+    """
 
     def __init__(self, k: int):
         if k <= 0:
@@ -208,9 +227,10 @@ class RandK(CompressionScheme):
         self.k = k
 
     def compress(self, msg: Array) -> Array:  # noqa: D102
-        msg_np = iop.to_numpy(msg).ravel()
-        idx = rng.choice(msg_np.size, size=self.k, replace=False)
-        mask = np.isin(np.arange(msg_np.size), idx)
+        msg_np = np.copy(iop.to_numpy(msg))
+        k = min(self.k, msg_np.size)
+        idx = rng.choice(msg_np.size, size=k, replace=False)
+        mask = np.isin(np.arange(msg_np.size), idx).reshape(msg_np.shape)
         msg_np[~mask] = 0
         return iop.to_array_like(msg_np, msg)
 

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -271,7 +271,7 @@ Create a custom benchmark problem using existing resources.
         x_optimal=x_optimal,
         agent_activations=[UniformActivationRate(0.5)] * n_agents,
         message_compression=Quantization(n_significant_digits=4),
-        message_noise=GaussianNoise(mean=0, sd=0.001),
+        message_noise=GaussianNoise(mean=0, std=0.001),
         message_drop=UniformDropRate(drop_rate=0.5),
     )
 

--- a/test/test_schemes.py
+++ b/test/test_schemes.py
@@ -180,9 +180,57 @@ def test_randk_compression() -> None:
 def test_k_compression(scheme: CompressionScheme) -> None:
     for k in range(1, 15+1):
         s = scheme(k=k)
-        compressed_msg = s.compress(Array(np.ones(k)))
+        compressed_msg = s.compress(Array(np.ones(k+5)))
 
         assert np.count_nonzero(compressed_msg) == k
+
+
+# test RandK and TopK with mismatched k and message size
+@pytest.mark.parametrize(
+    "scheme",
+    [
+        TopK,
+        RandK
+    ],
+)
+def test_k_compression_mismatched(scheme: CompressionScheme) -> None:
+    for k in range(5, 15+1):
+        s = scheme(k=k)
+        compressed_msg = s.compress(Array(np.ones(k-2)))
+
+        assert np.count_nonzero(compressed_msg) == k-2
+
+
+# test RandK and TopK with mismatched k and message size
+@pytest.mark.parametrize(
+    "scheme",
+    [
+        TopK,
+        RandK
+    ],
+)
+def test_k_compression_mismatched_k_msg_size(scheme: CompressionScheme) -> None:
+    for k in range(5, 15+1):
+        s = scheme(k=k)
+        compressed_msg = s.compress(Array(np.ones(k-2)))
+
+        assert np.count_nonzero(compressed_msg) == k-2
+
+
+# test RandK and TopK to check message shape is preserved
+@pytest.mark.parametrize(
+    "scheme",
+    [
+        TopK,
+        RandK
+    ],
+)
+def test_k_compression_preserved_shape(scheme: CompressionScheme) -> None:
+    message = Array(np.ones((10, 15)))
+    s = scheme(k=5)
+    compressed_msg = s.compress(message)
+
+    assert iop.to_numpy(message).shape == iop.to_numpy(compressed_msg).shape
 
 
 ## DropScheme
@@ -248,7 +296,7 @@ def test_no_noise(
         GaussianNoise(mean=0.5, std=0.5)
     ],
 )
-def test_no_noise(
+def test_noise(
     scheme: NoiseScheme,
 ) -> None:
     message = Array(np.ones(5))


### PR DESCRIPTION
The PR introduces new activation, compression, and drop schemes and adds tests for all schemes. The main changes are the addition of Markov chain and Poisson-based agent activation schemes, new compression algorithms (TopK and RandK), a Gilbert-Elliott drop model, improvements to the Gaussian noise scheme, and a new test suite covering all schemes.

**New schemes and models:**

* Added `MarkovChainActivation` and `PoissonActivation` classes for agent activation, enabling more realistic modeling of agent participation using Markov chains and Poisson processes.
* Introduced `TopK` and `RandK` compression schemes that transmit only the largest or randomly selected elements, respectively, improving flexibility for message compression.
* Added the `GilbertElliott` drop scheme, which models message drops using a two-state Markov chain, allowing for bursty loss patterns.

**Improvements and fixes:**

* Updated `GaussianNoise` to use the standard deviation parameter `std` (instead of `sd`) for consistency, and improved error handling.

**Testing:**

* Added a comprehensive test suite in `test/test_schemes.py` to verify the behavior of all activation, client selection, compression, drop, and noise schemes, ensuring correctness and robustness.