### PR TITLE
Fix FedNetwork custom server availability

### DIFF
--- a/decent_bench/networks.py
+++ b/decent_bench/networks.py
@@ -445,7 +445,7 @@ class FedNetwork(Network):
     Args:
         clients: list of client agents in the network.
         server: server agent in the network. If ``None``, a default server with zero cost and always active scheme will
-            be created.
+            be created. Custom servers must use :class:`~decent_bench.schemes.AlwaysActive`.
         buffer_messages: whether to keep stored messages at the end of each iteration. If ``True``, messages
             persist on the receiver until they are overwritten by a newer message from the same sender to the same
             receiver. If ``False``, messages delivered to a receiver during iteration *k* are dropped when
@@ -460,6 +460,10 @@ class FedNetwork(Network):
         message_drop: drop scheme(s) to apply to messages sent by agents in the network. Can be a single
             :class:`~decent_bench.schemes.DropScheme` instance to apply the same scheme to all agents, a dictionary
             mapping each agent to its scheme, or ``None`` to apply no message drop to any agent.
+
+    Raises:
+        ValueError: if ``clients`` is empty or if a custom ``server`` does not use
+            :class:`~decent_bench.schemes.AlwaysActive`.
 
     """
 
@@ -484,6 +488,8 @@ class FedNetwork(Network):
                 AlwaysActive(),
                 min(c.state_snapshot_period for c in clients),
             )
+        elif not isinstance(server._activation, AlwaysActive):  # noqa: SLF001
+            raise ValueError("FedNetwork server must use AlwaysActive activation")
         graph = nx.star_graph([server, *list(clients)])  # create AgentGraph
 
         # specify the server's message schemes if not provided

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -668,6 +668,7 @@ Similarly, in order for the benchmark problem's communication schemes to be appl
 Be sure to use :meth:`~decent_bench.networks.Network.active_agents` during algorithm runtime so that asynchrony is properly handled.
 You can also inspect :attr:`~decent_bench.networks.Network.graph` to use NetworkX utilities (e.g., plotting or listing edges); mutating this graph changes the network topology.
 In :class:`~decent_bench.networks.FedNetwork`, :meth:`~decent_bench.networks.Network.agents` and :meth:`~decent_bench.networks.Network.active_agents` refer to clients (the server is available via :attr:`~decent_bench.networks.FedNetwork.server`/ :attr:`~decent_bench.networks.FedNetwork.coordinator`).
+Federated networks enforce an always-available server: a custom server passed to :class:`~decent_bench.networks.FedNetwork` must use :class:`~decent_bench.schemes.AlwaysActive`, otherwise network construction raises ``ValueError``.
 The agents/clients lists are cached for efficiency, so the network graph should be treated as immutable after construction.
 Client weights (``client_weights``) are used only during aggregation and do not change the objective being optimized.
 If you want to optimize a weighted objective :math:`\min \sum_i w_i f_i(x)`, scale each local cost by ``w_i`` when

--- a/test/test_networks.py
+++ b/test/test_networks.py
@@ -5,7 +5,7 @@ from decent_bench.agents import Agent
 from decent_bench.networks import P2PNetwork, FedNetwork
 from decent_bench.costs import L2RegularizerCost
 from decent_bench.utils import interoperability as iop
-from decent_bench.schemes import NoiseScheme, NoNoise, CompressionScheme, NoDrops
+from decent_bench.schemes import AlwaysActive, CompressionScheme, NoiseScheme, NoDrops, NoNoise, UniformActivationRate
 from unittest.mock import MagicMock
 
 
@@ -56,6 +56,31 @@ def test_fed_network(n_agents: int = 10) -> None:
         net.send(i, msg=x)
         tot_msg += 1
     assert tot_msg == n_agents
+
+
+def test_fed_network_accepts_custom_always_active_server() -> None:
+    clients = [Agent(i, L2RegularizerCost((10,))) for i in range(3)]
+    server = Agent(99, L2RegularizerCost((10,)), activation=AlwaysActive())
+
+    net = FedNetwork(clients=clients, server=server)
+
+    assert net.server() is server
+
+
+def test_fed_network_rejects_custom_non_always_active_server() -> None:
+    clients = [Agent(i, L2RegularizerCost((10,))) for i in range(3)]
+    server = Agent(99, L2RegularizerCost((10,)), activation=UniformActivationRate(0.5))
+
+    with pytest.raises(ValueError, match="FedNetwork server must use AlwaysActive activation"):
+        FedNetwork(clients=clients, server=server)
+
+
+def test_fed_network_default_server_is_always_active() -> None:
+    clients = [Agent(i, L2RegularizerCost((10,))) for i in range(3)]
+
+    net = FedNetwork(clients=clients)
+
+    assert isinstance(net.server()._activation, AlwaysActive)  # noqa: SLF001
 
 
 def test_initialize_message_schemes_with_dict_all_agents() -> None:


### PR DESCRIPTION
## Summary

Fix `FedNetwork` so custom servers must use an `AlwaysActive`
activation scheme.

This matches the current federated algorithm design, where the server
is assumed to be available every round. Before this change, a custom
server with a non-`AlwaysActive` activation scheme could be passed to
`FedNetwork`, which created an inconsistent configuration.

Closes #270

## Changes

- Raise a `ValueError` during `FedNetwork` creation when a custom server
  does not use `AlwaysActive`
- Keep support for passing a custom server, but enforce the current
  availability invariant instead of allowing unsupported behavior
- Update the `FedNetwork` docstring to document the constraint
- Update the user guide to state that federated networks enforce an
  always-available server
- Add regression tests covering:
  - accepting a custom `AlwaysActive` server
  - rejecting a custom non-`AlwaysActive` server
  - preserving the default server behavior
