### PR TITLE
feat(distributed_algorithms): Add FedProx algorithm

### DIFF
--- a/decent_bench/distributed_algorithms.py
+++ b/decent_bench/distributed_algorithms.py
@@ -451,7 +451,7 @@ class FedProx(FedAlgorithm):
         Costs that preserve the empirical-risk abstraction default ``gradient`` to ``indices="batch"``, so FedProx
         performs mini-batch local updates automatically. Generic costs keep their usual full-gradient behavior.
         """
-        reference_x = iop.copy(client.messages[server]) if server in client.messages else iop.copy(client.x)
+        reference_x = client.messages[server] if server in client.messages else client.x
         local_x = iop.copy(reference_x)
         for _ in range(self.num_local_epochs):
             grad = client.cost.gradient(local_x) + self.mu * (local_x - reference_x)

--- a/decent_bench/distributed_algorithms.py
+++ b/decent_bench/distributed_algorithms.py
@@ -370,16 +370,16 @@ class FedProx(FedAlgorithm):
     r"""
     Federated Proximal (FedProx) with local SGD epochs.
 
-    FedProx follows the same communication and aggregation pattern as
-    :class:`FedAvg <decent_bench.distributed_algorithms.FedAvg>`, but each client solves a proximalized local
-    subproblem around the round's server model:
+    Each client solves a proximalized local subproblem around the round's server model:
 
     .. math::
         h_k(\mathbf{w}; \mathbf{w}^t) = F_k(\mathbf{w}) + \frac{\mu}{2} \|\mathbf{w} - \mathbf{w}^t\|^2
 
     .. math::
-        \mathbf{x}_{i, k}^{(t+1)} = \mathbf{x}_{i, k}^{(t)} - \eta \left(
-        \nabla f_i(\mathbf{x}_{i, k}^{(t)}) + \mu (\mathbf{x}_{i, k}^{(t)} - \mathbf{w}^t) \right)
+        \mathbf{x}_{i, k}^{(t+1)} = \mathbf{x}_{i, k}^{(t)} - \eta
+        \nabla h_k(\mathbf{x}_{i, k}^{(t)}; \mathbf{w}^t)
+
+    where :math:`\nabla h_k(\mathbf{w}; \mathbf{w}^t) = \nabla F_k(\mathbf{w}) + \mu (\mathbf{w} - \mathbf{w}^t)`.
 
     .. math::
         \mathbf{x}_{k+1} = \frac{1}{|S_k|} \sum_{i \in S_k} \mathbf{x}_{i, k}^{(E)}
@@ -387,10 +387,9 @@ class FedProx(FedAlgorithm):
     where :math:`\mathbf{w}^t` is the server model broadcast at the start of round :math:`k`, held fixed
     throughout each selected client's local epochs, :math:`\mu \geq 0` is the proximal coefficient,
     :math:`\eta` is the step size, and :math:`S_k` is the set of participating clients. Setting ``mu=0.0``
-    recovers FedAvg exactly. The default ``mu=0.01`` is a sensible benchmark starting point, but users are
-    strongly encouraged to tune ``mu`` for each problem; a practical grid is ``[0.001, 0.01, 0.1, 0.5, 1.0]``.
-    As in FedAvg, aggregation uses client weights, defaulting to data-size weights when ``client_weights`` is not
-    provided, and client selection defaults to uniform sampling with fraction 1.0. For
+    recovers :class:`FedAvg <decent_bench.distributed_algorithms.FedAvg>` exactly. Aggregation uses client weights,
+    defaulting to data-size weights when ``client_weights`` is not provided, and client selection defaults to uniform
+    sampling with fraction 1.0. For
     :class:`~decent_bench.costs.EmpiricalRiskCost`, local updates use mini-batches of size
     :attr:`EmpiricalRiskCost.batch_size <decent_bench.costs.EmpiricalRiskCost.batch_size>`; for generic costs,
     local updates use full-batch gradients.
@@ -399,7 +398,7 @@ class FedProx(FedAlgorithm):
     iterations: int = 100
     step_size: float = 0.001
     num_local_epochs: int = 1
-    mu: float = 0.01  # Sensible benchmark default; tune over {0.001, 0.01, 0.1, 0.5, 1} for new settings.
+    mu: float = 0.01
     client_weights: ClientWeights | None = None
     selection_scheme: ClientSelectionScheme | None = field(
         default_factory=lambda: UniformClientSelection(client_fraction=1.0)

--- a/decent_bench/distributed_algorithms.py
+++ b/decent_bench/distributed_algorithms.py
@@ -445,28 +445,16 @@ class FedProx(FedAlgorithm):
             network.send(sender=client, receiver=network.server(), msg=client.x)
 
     def _compute_local_update(self, client: "Agent", server: "Agent") -> "Array":
+        """
+        Run local proximal gradient steps using the batching semantics of ``client.cost.gradient``.
+
+        Costs that preserve the empirical-risk abstraction default ``gradient`` to ``indices="batch"``, so FedProx
+        performs mini-batch local updates automatically. Generic costs keep their usual full-gradient behavior.
+        """
         reference_x = iop.copy(client.messages[server]) if server in client.messages else iop.copy(client.x)
         local_x = iop.copy(reference_x)
-        if isinstance(client.cost, EmpiricalRiskCost):
-            cost = client.cost
-            n_samples = cost.n_samples
-            return self._epoch_minibatch_update(cost, local_x, reference_x, cost.batch_size, n_samples)
-
         for _ in range(self.num_local_epochs):
             grad = client.cost.gradient(local_x) + self.mu * (local_x - reference_x)
-            local_x -= self.step_size * grad
-        return local_x
-
-    def _epoch_minibatch_update(
-        self,
-        cost: EmpiricalRiskCost,
-        local_x: "Array",
-        reference_x: "Array",
-        per_client_batch: int,
-        n_samples: int,
-    ) -> "Array":
-        for _ in range(self.num_local_epochs):
-            grad = cost.gradient(local_x) + self.mu * (local_x - reference_x)
             local_x -= self.step_size * grad
         return local_x
 

--- a/decent_bench/distributed_algorithms.py
+++ b/decent_bench/distributed_algorithms.py
@@ -387,9 +387,11 @@ class FedProx(FedAlgorithm):
     where :math:`\mathbf{w}^t` is the server model broadcast at the start of round :math:`k`, held fixed
     throughout each selected client's local epochs, :math:`\mu \geq 0` is the proximal coefficient,
     :math:`\eta` is the step size, and :math:`S_k` is the set of participating clients. Setting ``mu=0.0``
-    recovers FedAvg. As in FedAvg, aggregation uses client weights, defaulting to data-size weights when
-    ``client_weights`` is not provided, and client selection defaults to uniform sampling with fraction 1.0.
-    For :class:`~decent_bench.costs.EmpiricalRiskCost`, local updates use mini-batches of size
+    recovers FedAvg exactly. The default ``mu=0.01`` is a sensible benchmark starting point, but users are
+    strongly encouraged to tune ``mu`` for each problem; a practical grid is ``[0.001, 0.01, 0.1, 0.5, 1.0]``.
+    As in FedAvg, aggregation uses client weights, defaulting to data-size weights when ``client_weights`` is not
+    provided, and client selection defaults to uniform sampling with fraction 1.0. For
+    :class:`~decent_bench.costs.EmpiricalRiskCost`, local updates use mini-batches of size
     :attr:`EmpiricalRiskCost.batch_size <decent_bench.costs.EmpiricalRiskCost.batch_size>`; for generic costs,
     local updates use full-batch gradients.
     """

--- a/decent_bench/distributed_algorithms.py
+++ b/decent_bench/distributed_algorithms.py
@@ -466,12 +466,8 @@ class FedProx(FedAlgorithm):
         n_samples: int,
     ) -> "Array":
         for _ in range(self.num_local_epochs):
-            indices = list(range(n_samples))
-            random.shuffle(indices)
-            for start in range(0, n_samples, per_client_batch):
-                batch_indices = indices[start : start + per_client_batch]
-                grad = cost.gradient(local_x, indices=batch_indices) + self.mu * (local_x - reference_x)
-                local_x -= self.step_size * grad
+            grad = cost.gradient(local_x) + self.mu * (local_x - reference_x)
+            local_x -= self.step_size * grad
         return local_x
 
 

--- a/decent_bench/distributed_algorithms.py
+++ b/decent_bench/distributed_algorithms.py
@@ -416,12 +416,9 @@ class FedProx(FedAlgorithm):
         if not selected_clients:
             return
 
-        self._sync_server_to_clients(network, selected_clients)
+        self.server_broadcast(network, selected_clients)
         self._run_local_updates(network, selected_clients)
         self.aggregate(network, selected_clients)
-
-    def _sync_server_to_clients(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
-        network.send(sender=network.server(), receiver=selected_clients, msg=network.server().x)
 
     def _run_local_updates(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
         for client in selected_clients:
@@ -435,7 +432,7 @@ class FedProx(FedAlgorithm):
         Costs that preserve the empirical-risk abstraction default ``gradient`` to ``indices="batch"``, so FedProx
         performs mini-batch local updates automatically. Generic costs keep their usual full-gradient behavior.
         """
-        reference_x = client.messages[server] if server in client.messages else client.x
+        reference_x = client.messages.get(server, client.x)
         local_x = iop.copy(reference_x)
         for _ in range(self.num_local_epochs):
             grad = client.cost.gradient(local_x) + self.mu * (local_x - reference_x)

--- a/decent_bench/distributed_algorithms.py
+++ b/decent_bench/distributed_algorithms.py
@@ -364,6 +364,116 @@ class FedAvg(FedAlgorithm):
         return local_x
 
 
+@tags("federated")
+@dataclass(eq=False)
+class FedProx(FedAlgorithm):
+    r"""
+    Federated Proximal (FedProx) with local SGD epochs.
+
+    FedProx follows the same communication and aggregation pattern as
+    :class:`FedAvg <decent_bench.distributed_algorithms.FedAvg>`, but each client solves a proximalized local
+    subproblem around the round's server model:
+
+    .. math::
+        h_k(\mathbf{w}; \mathbf{w}^t) = F_k(\mathbf{w}) + \frac{\mu}{2} \|\mathbf{w} - \mathbf{w}^t\|^2
+
+    .. math::
+        \mathbf{x}_{i, k}^{(t+1)} = \mathbf{x}_{i, k}^{(t)} - \eta \left(
+        \nabla f_i(\mathbf{x}_{i, k}^{(t)}) + \mu (\mathbf{x}_{i, k}^{(t)} - \mathbf{w}^t) \right)
+
+    .. math::
+        \mathbf{x}_{k+1} = \frac{1}{|S_k|} \sum_{i \in S_k} \mathbf{x}_{i, k}^{(E)}
+
+    where :math:`\mathbf{w}^t` is the server model broadcast at the start of round :math:`k`, held fixed
+    throughout each selected client's local epochs, :math:`\mu \geq 0` is the proximal coefficient,
+    :math:`\eta` is the step size, and :math:`S_k` is the set of participating clients. Setting ``mu=0.0``
+    recovers FedAvg. As in FedAvg, aggregation uses client weights, defaulting to data-size weights when
+    ``client_weights`` is not provided, and client selection defaults to uniform sampling with fraction 1.0.
+    For :class:`~decent_bench.costs.EmpiricalRiskCost`, local updates use mini-batches of size
+    :attr:`EmpiricalRiskCost.batch_size <decent_bench.costs.EmpiricalRiskCost.batch_size>`; for generic costs,
+    local updates use full-batch gradients.
+    """
+
+    iterations: int = 100
+    step_size: float = 0.001
+    num_local_epochs: int = 1
+    mu: float = 0.01  # Sensible benchmark default; tune over {0.001, 0.01, 0.1, 0.5, 1} for new settings.
+    client_weights: ClientWeights | None = None
+    selection_scheme: ClientSelectionScheme | None = field(
+        default_factory=lambda: UniformClientSelection(client_fraction=1.0)
+    )
+    x0: InitialStates = None
+    name: str = "FedProx"
+
+    def __post_init__(self) -> None:
+        """
+        Validate hyperparameters.
+
+        Raises:
+            ValueError: if hyperparameters are invalid.
+
+        """
+        if self.step_size <= 0:
+            raise ValueError("`step_size` must be positive")
+        if self.num_local_epochs <= 0:
+            raise ValueError("`num_local_epochs` must be positive")
+        if self.mu < 0:
+            raise ValueError("`mu` must be non-negative")
+
+    def initialize(self, network: FedNetwork) -> None:  # noqa: D102
+        self.x0 = alg_helpers.initial_states(self.x0, network)
+        network.server().initialize(x=self.x0[network.server()])
+        for client in network.clients():
+            client.initialize(x=self.x0[client])
+
+    def step(self, network: FedNetwork, iteration: int) -> None:  # noqa: D102
+        selected_clients = self._selected_clients_for_round(network, iteration)
+        if not selected_clients:
+            return
+
+        self._sync_server_to_clients(network, selected_clients)
+        self._run_local_updates(network, selected_clients)
+        self.aggregate(network, selected_clients)
+
+    def _sync_server_to_clients(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
+        network.send(sender=network.server(), receiver=selected_clients, msg=network.server().x)
+
+    def _run_local_updates(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
+        for client in selected_clients:
+            client.x = self._compute_local_update(client, network.server())
+            network.send(sender=client, receiver=network.server(), msg=client.x)
+
+    def _compute_local_update(self, client: "Agent", server: "Agent") -> "Array":
+        reference_x = iop.copy(client.messages[server]) if server in client.messages else iop.copy(client.x)
+        local_x = iop.copy(reference_x)
+        if isinstance(client.cost, EmpiricalRiskCost):
+            cost = client.cost
+            n_samples = cost.n_samples
+            return self._epoch_minibatch_update(cost, local_x, reference_x, cost.batch_size, n_samples)
+
+        for _ in range(self.num_local_epochs):
+            grad = client.cost.gradient(local_x) + self.mu * (local_x - reference_x)
+            local_x -= self.step_size * grad
+        return local_x
+
+    def _epoch_minibatch_update(
+        self,
+        cost: EmpiricalRiskCost,
+        local_x: "Array",
+        reference_x: "Array",
+        per_client_batch: int,
+        n_samples: int,
+    ) -> "Array":
+        for _ in range(self.num_local_epochs):
+            indices = list(range(n_samples))
+            random.shuffle(indices)
+            for start in range(0, n_samples, per_client_batch):
+                batch_indices = indices[start : start + per_client_batch]
+                grad = cost.gradient(local_x, indices=batch_indices) + self.mu * (local_x - reference_x)
+                local_x -= self.step_size * grad
+        return local_x
+
+
 @tags("peer-to-peer", "gradient-based")
 @dataclass(eq=False)
 class DGD(P2PAlgorithm):

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -108,6 +108,10 @@ Federated
             :tag: federated
             :module: decent_bench.distributed_algorithms
 
+FedProx extends FedAvg with a proximal coefficient ``mu``. Setting ``mu=0`` reduces
+FedProx to FedAvg. In practice, ``mu`` should typically be tuned for each problem;
+``[0.001, 0.01, 0.1, 0.5, 1.0]`` is a reasonable starting grid.
+
 
 Available costs
 ---------------

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -109,8 +109,7 @@ Federated
             :module: decent_bench.distributed_algorithms
 
 FedProx extends FedAvg with a proximal coefficient ``mu``. Setting ``mu=0`` reduces
-FedProx to FedAvg. In practice, ``mu`` should typically be tuned for each problem;
-``[0.001, 0.01, 0.1, 0.5, 1.0]`` is a reasonable starting grid.
+FedProx to FedAvg.
 
 
 Available costs

--- a/test/test_distributed_algorithms.py
+++ b/test/test_distributed_algorithms.py
@@ -10,6 +10,7 @@ from decent_bench.distributed_algorithms import (
     ED,
     EXTRA,
     FedAvg,
+    FedProx,
     NIDS,
     AugDGM,
     SimpleGT,
@@ -21,6 +22,7 @@ from decent_bench.distributed_algorithms import (
     ("algorithm_cls", "kwargs"),
     [
         (FedAvg, {"iterations": 10, "step_size": 0.1}),
+        (FedProx, {"iterations": 10, "step_size": 0.1}),
         (DGD, {"iterations": 10, "step_size": 0.1}),
         (ATC, {"iterations": 10, "step_size": 0.1}),
         (SimpleGT, {"iterations": 10, "step_size": 0.1}),

--- a/test/test_fedprox_cost_routing.py
+++ b/test/test_fedprox_cost_routing.py
@@ -1,0 +1,249 @@
+from typing import Any
+
+import numpy as np
+
+from decent_bench.agents import Agent
+from decent_bench.costs import BaseRegularizerCost, Cost, EmpiricalRiskCost, ZeroCost
+from decent_bench.distributed_algorithms import FedProx
+from decent_bench.utils.types import (
+    Dataset,
+    EmpiricalRiskIndices,
+    EmpiricalRiskReduction,
+    SupportedDevices,
+    SupportedFrameworks,
+)
+
+
+class TrackingCost(Cost):
+    def __init__(self, gradient_value: float = 1.0):
+        self.gradient_kwargs: list[dict[str, Any]] = []
+        self._gradient = np.array([gradient_value], dtype=float)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return (1,)
+
+    @property
+    def framework(self) -> SupportedFrameworks:
+        return SupportedFrameworks.NUMPY
+
+    @property
+    def device(self) -> SupportedDevices:
+        return SupportedDevices.CPU
+
+    @property
+    def m_smooth(self) -> float:
+        return 0.0
+
+    @property
+    def m_cvx(self) -> float:
+        return 0.0
+
+    def function(self, x: np.ndarray, **kwargs: Any) -> float:
+        del x, kwargs
+        return 0.0
+
+    def gradient(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+        del x
+        self.gradient_kwargs.append(dict(kwargs))
+        return self._gradient.copy()
+
+    def hessian(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+        del x, kwargs
+        return np.zeros((1, 1), dtype=float)
+
+    def proximal(self, x: np.ndarray, rho: float, **kwargs: Any) -> np.ndarray:
+        del rho, kwargs
+        return x
+
+
+class TrackingRegularizerCost(BaseRegularizerCost):
+    def __init__(self, gradient_value: float = 0.0):
+        super().__init__(shape=(1,))
+        self.gradient_kwargs: list[dict[str, Any]] = []
+        self._gradient = np.array([gradient_value], dtype=float)
+
+    @property
+    def m_smooth(self) -> float:
+        return 0.0
+
+    @property
+    def m_cvx(self) -> float:
+        return 0.0
+
+    def function(self, x: np.ndarray, **kwargs: Any) -> float:
+        del x, kwargs
+        return 0.0
+
+    def gradient(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+        del x
+        self.gradient_kwargs.append(dict(kwargs))
+        return self._gradient.copy()
+
+    def hessian(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+        del x, kwargs
+        return np.zeros((1, 1), dtype=float)
+
+    def proximal(self, x: np.ndarray, rho: float, **kwargs: Any) -> np.ndarray:
+        del rho, kwargs
+        return x
+
+
+class TrackingEmpiricalCost(EmpiricalRiskCost):
+    def __init__(self, n_samples: int = 5, batch_size: int = 2, gradient_value: float = 1.0):
+        self._dataset: Dataset = [(np.array([float(i)]), np.array([0.0])) for i in range(n_samples)]
+        self._batch_size = batch_size
+        self.gradient_indices: list[list[int]] = []
+        self._gradient = np.array([gradient_value], dtype=float)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return (1,)
+
+    @property
+    def framework(self) -> SupportedFrameworks:
+        return SupportedFrameworks.NUMPY
+
+    @property
+    def device(self) -> SupportedDevices:
+        return SupportedDevices.CPU
+
+    @property
+    def m_smooth(self) -> float:
+        return 0.0
+
+    @property
+    def m_cvx(self) -> float:
+        return 0.0
+
+    @property
+    def n_samples(self) -> int:
+        return len(self._dataset)
+
+    @property
+    def batch_size(self) -> int:
+        return self._batch_size
+
+    @property
+    def dataset(self) -> Dataset:
+        return self._dataset
+
+    def predict(self, x: np.ndarray, data: list[np.ndarray]) -> np.ndarray:
+        del x
+        return np.asarray(data)
+
+    def function(self, x: np.ndarray, indices: EmpiricalRiskIndices = "batch", **kwargs: Any) -> float:
+        del x, kwargs
+        self._sample_batch_indices(indices)
+        return 0.0
+
+    def gradient(
+        self,
+        x: np.ndarray,
+        indices: EmpiricalRiskIndices = "batch",
+        reduction: EmpiricalRiskReduction = "mean",
+        **kwargs: Any,
+    ) -> np.ndarray:
+        del x, kwargs
+        sampled_indices = self._sample_batch_indices(indices)
+        self.gradient_indices.append(list(sampled_indices))
+        if reduction is None:
+            return np.repeat(self._gradient[np.newaxis, :], len(sampled_indices), axis=0)
+        return self._gradient.copy()
+
+    def hessian(self, x: np.ndarray, indices: EmpiricalRiskIndices = "batch", **kwargs: Any) -> np.ndarray:
+        del x, kwargs
+        self._sample_batch_indices(indices)
+        return np.zeros((1, 1), dtype=float)
+
+    def _get_batch_data(self, indices: EmpiricalRiskIndices = "batch") -> list[tuple[np.ndarray, np.ndarray]]:
+        sampled_indices = self._sample_batch_indices(indices)
+        return [self._dataset[i] for i in sampled_indices]
+
+
+def _run_fedprox_local_update(
+    cost: Cost,
+    *,
+    step_size: float = 1.0,
+    num_local_epochs: int = 1,
+    mu: float = 0.5,
+) -> np.ndarray:
+    algorithm = FedProx(iterations=1, step_size=step_size, num_local_epochs=num_local_epochs, mu=mu)
+    client = Agent(0, cost)
+    server = Agent(1, ZeroCost(cost.shape))
+    client.initialize(x=np.zeros(cost.shape, dtype=float))
+    server.initialize(x=np.zeros(cost.shape, dtype=float))
+    return algorithm._compute_local_update(client, server)
+
+
+def test_empirical_costs_use_minibatch_local_updates_in_fedprox() -> None:
+    cost = TrackingEmpiricalCost(n_samples=5, batch_size=2)
+
+    updated = _run_fedprox_local_update(cost, num_local_epochs=3)
+
+    np.testing.assert_allclose(updated, np.array([-1.75]))
+    assert len(cost.gradient_indices) == 3
+    assert all(len(indices) == 2 for indices in cost.gradient_indices)
+    assert set().union(*(set(indices) for indices in cost.gradient_indices)) == set(range(cost.n_samples))
+
+
+def test_empirical_regularized_costs_keep_minibatch_local_updates_in_fedprox() -> None:
+    empirical_cost = TrackingEmpiricalCost(n_samples=5, batch_size=2)
+    regularizer = TrackingRegularizerCost()
+    objective = empirical_cost + regularizer
+
+    updated = _run_fedprox_local_update(objective, num_local_epochs=3)
+
+    np.testing.assert_allclose(updated, np.array([-1.75]))
+    assert len(empirical_cost.gradient_indices) == 3
+    assert all(len(indices) == 2 for indices in empirical_cost.gradient_indices)
+    assert set().union(*(set(indices) for indices in empirical_cost.gradient_indices)) == set(
+        range(empirical_cost.n_samples)
+    )
+    assert len(regularizer.gradient_kwargs) == 3
+    assert all(kwargs == {} for kwargs in regularizer.gradient_kwargs)
+
+
+def test_scaled_empirical_costs_keep_minibatch_local_updates_in_fedprox() -> None:
+    empirical_cost = TrackingEmpiricalCost(n_samples=5, batch_size=2)
+    objective = 2.0 * empirical_cost
+
+    updated = _run_fedprox_local_update(objective, num_local_epochs=3)
+
+    np.testing.assert_allclose(updated, np.array([-3.5]))
+    assert len(empirical_cost.gradient_indices) == 3
+    assert all(len(indices) == 2 for indices in empirical_cost.gradient_indices)
+    assert set().union(*(set(indices) for indices in empirical_cost.gradient_indices)) == set(
+        range(empirical_cost.n_samples)
+    )
+
+
+def test_plain_costs_use_full_gradient_local_updates_in_fedprox() -> None:
+    cost = TrackingCost(gradient_value=1.0)
+
+    updated = _run_fedprox_local_update(cost, num_local_epochs=3)
+
+    np.testing.assert_allclose(updated, np.array([-1.75]))
+    assert len(cost.gradient_kwargs) == 3
+    assert all(kwargs == {} for kwargs in cost.gradient_kwargs)
+
+
+def test_scaled_costs_over_non_empirical_terms_use_full_gradient_local_updates_in_fedprox() -> None:
+    cost = TrackingCost(gradient_value=1.0)
+    objective = 2.0 * cost
+
+    updated = _run_fedprox_local_update(objective, num_local_epochs=3)
+
+    np.testing.assert_allclose(updated, np.array([-3.5]))
+    assert len(cost.gradient_kwargs) == 3
+    assert all(kwargs == {} for kwargs in cost.gradient_kwargs)
+
+
+def test_regularizers_follow_the_non_batched_local_update_path_in_fedprox() -> None:
+    regularizer = TrackingRegularizerCost(gradient_value=1.0)
+
+    updated = _run_fedprox_local_update(regularizer, num_local_epochs=3)
+
+    np.testing.assert_allclose(updated, np.array([-1.75]))
+    assert len(regularizer.gradient_kwargs) == 3
+    assert all(kwargs == {} for kwargs in regularizer.gradient_kwargs)


### PR DESCRIPTION
This PR adds FedProx as a new federated algorithm. 

Implemented as a proper FedAlgorithm subclass that preserves the existing federated round structure used by FedAvg. The only behavioral difference is the local client update: each selected client optimizes the FedProx subproblem with a proximal term anchored at the round’s server model.