### PR TITLE
feat(federated): Add FedPD, FedDyn, and update message buffering

### DIFF
--- a/decent_bench/algorithms/federated/__init__.py
+++ b/decent_bench/algorithms/federated/__init__.py
@@ -2,6 +2,7 @@ from ._fed_adagrad import FedAdagrad
 from ._fed_adam import FedAdam
 from ._fed_algorithm import FedAlgorithm
 from ._fed_avg import FedAvg
+from ._fed_dyn import FedDyn
 from ._fed_lt import FedLT
 from ._fed_nova import FedNova
 from ._fed_opt import FedOpt
@@ -15,6 +16,7 @@ __all__ = [
     "FedAdam",
     "FedAlgorithm",
     "FedAvg",
+    "FedDyn",
     "FedLT",
     "FedNova",
     "FedOpt",

--- a/decent_bench/algorithms/federated/__init__.py
+++ b/decent_bench/algorithms/federated/__init__.py
@@ -4,6 +4,7 @@ from ._fed_algorithm import FedAlgorithm
 from ._fed_avg import FedAvg
 from ._fed_nova import FedNova
 from ._fed_opt import FedOpt
+from ._fed_pd import FedPD
 from ._fed_prox import FedProx
 from ._fed_yogi import FedYogi
 from ._scaffold import Scaffold
@@ -15,6 +16,7 @@ __all__ = [
     "FedAvg",
     "FedNova",
     "FedOpt",
+    "FedPD",
     "FedProx",
     "FedYogi",
     "Scaffold",

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -74,41 +74,12 @@ class FedAlgorithm(Algorithm[FedNetwork]):
         return self.selection_scheme.select(active_clients, iteration)
 
     def server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
-        """Clear stale server broadcasts, then send the current server model to the selected clients."""
-        self._clear_buffered_client_server_messages(network, selected_clients)
+        """Send the current server model to the selected clients."""
         network.send(sender=network.server(), receiver=selected_clients, msg=network.server().x)
 
     def _clients_with_server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> list["Agent"]:
         """Return selected clients that received the current broadcast sent by :meth:`server_broadcast`."""
         return [client for client in selected_clients if network.server() in client.messages]
-
-    def _clear_buffered_client_server_messages(
-        self,
-        network: FedNetwork,
-        selected_clients: Sequence["Agent"],
-    ) -> None:
-        """
-        Remove stale server-to-client messages for the current selected clients.
-
-        This ensures selected clients participate only if they receive the current server broadcast. The clean-up is
-        needed when :class:`~decent_bench.networks.Network` uses ``buffer_messages=True``, since old server broadcasts
-        would otherwise remain stored at clients and could be mistaken for fresh round broadcasts.
-        """
-        for client in selected_clients:
-            client._received_messages.pop(network.server(), None)  # noqa: SLF001
-
-    def _clear_buffered_server_messages(self, network: FedNetwork, participating_clients: Sequence["Agent"]) -> None:
-        """
-        Remove stale client-to-server messages for the current participants.
-
-        This ensures the server aggregates only updates actually received from those clients in the current round.
-        The clean-up is needed when :class:`~decent_bench.networks.Network` uses ``buffer_messages=True``, since old
-        client uploads would otherwise remain stored at the server and could be mistaken for fresh round updates.
-        Call this immediately before the current client upload phase.
-
-        """
-        for client in participating_clients:
-            network.server()._received_messages.pop(client, None)  # noqa: SLF001
 
     @staticmethod
     def _get_server_broadcast(client: "Agent", server: "Agent") -> "Array":
@@ -138,10 +109,6 @@ class FedAlgorithm(Algorithm[FedNetwork]):
         Aggregate client model uploads at the server using uniform averaging.
 
         This default federated aggregation assumes clients upload final local model states.
-
-        When used with :class:`~decent_bench.networks.Network` ``buffer_messages=True``, this method assumes the
-        caller has already removed stale buffered client-to-server messages for the participating clients, so only
-        current-round updates are aggregated.
         """
         received_clients = [client for client in participating_clients if client in network.server().messages]
         if not received_clients:

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -16,7 +16,7 @@ class FedAlgorithm(Algorithm[FedNetwork]):
     """Federated algorithm - clients collaborate via a central server."""
 
     selection_scheme: ClientSelectionScheme | None = None
-    num_local_steps: LocalSteps
+    num_local_steps: LocalSteps = 1
 
     def cleanup_agents(self, network: FedNetwork) -> Iterable["Agent"]:
         return [network.server(), *network.clients()]
@@ -36,6 +36,8 @@ class FedAlgorithm(Algorithm[FedNetwork]):
             return
         if isinstance(self.num_local_steps, dict):
             for step in self.num_local_steps.values():
+                if not isinstance(step, int):
+                    raise TypeError("`num_local_steps` mapping values must be integers")
                 if step <= 0:
                     raise ValueError("`num_local_steps` must have positive values")
             return

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -21,57 +21,6 @@ class FedAlgorithm(Algorithm[FedNetwork]):
     def cleanup_agents(self, network: FedNetwork) -> Iterable["Agent"]:
         return [network.server(), *network.clients()]
 
-    def server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
-        """Send the current server model to the selected clients."""
-        network.send(sender=network.server(), receiver=selected_clients, msg=network.server().x)
-
-    def _clients_with_server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> list["Agent"]:
-        """Return the selected clients that actually received the current server broadcast."""
-        return [client for client in selected_clients if network.server() in client.messages]
-
-    def _clear_buffered_server_messages(self, network: FedNetwork, participating_clients: Sequence["Agent"]) -> None:
-        """
-        Remove stale client-to-server messages for the current participants.
-
-        This ensures the server aggregates only updates actually received from those clients in the current round.
-        The clean-up is needed when :class:`~decent_bench.networks.Network` uses ``buffer_messages=True``, since old
-        client uploads would otherwise remain stored at the server and could be mistaken for fresh round updates.
-        """
-        for client in participating_clients:
-            network.server()._received_messages.pop(client, None)  # noqa: SLF001
-
-    @staticmethod
-    def _get_server_broadcast(client: "Agent", server: "Agent") -> "Array":
-        """
-        Return the current server broadcast received by the client.
-
-        Raises:
-            ValueError: if the client did not receive the current server broadcast.
-
-        """
-        if server not in client.messages:
-            raise ValueError("Client did not receive the current server broadcast")
-        return iop.copy(client.messages[server])
-
-    @staticmethod
-    def _weighted_average(values: Sequence["Array"], weights: Sequence[float], total_weight: float) -> "Array":
-        """Compute a weighted average of same-shaped arrays."""
-        weighted_values = [value * weight for value, weight in zip(values, weights, strict=True)]
-        return iop.sum(iop.stack(weighted_values, dim=0), dim=0) / total_weight
-
-    def _selected_clients_for_round(self, network: FedNetwork, iteration: int) -> list["Agent"]:
-        """
-        Select participating clients for the current round from the currently active clients.
-
-        If ``self.selection_scheme`` is ``None``, all active clients are selected.
-        """
-        active_clients = network.active_clients()
-        if not active_clients:
-            return []
-        if self.selection_scheme is None:
-            return list(active_clients)
-        return self.selection_scheme.select(active_clients, iteration)
-
     def _validate_num_local_steps(self) -> None:
         """
         Validate homogeneous or per-client local step counts.
@@ -110,6 +59,75 @@ class FedAlgorithm(Algorithm[FedNetwork]):
                 f"missing clients: {missing_clients}"
             )
         return {client: self.num_local_steps[client] for client in clients}
+
+    def _selected_clients_for_round(self, network: FedNetwork, iteration: int) -> list["Agent"]:
+        """
+        Select participating clients for the current round from the currently active clients.
+
+        If ``self.selection_scheme`` is ``None``, all active clients are selected.
+        """
+        active_clients = network.active_clients()
+        if not active_clients:
+            return []
+        if self.selection_scheme is None:
+            return list(active_clients)
+        return self.selection_scheme.select(active_clients, iteration)
+
+    def server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
+        """Clear stale server broadcasts, then send the current server model to the selected clients."""
+        self._clear_buffered_client_server_messages(network, selected_clients)
+        network.send(sender=network.server(), receiver=selected_clients, msg=network.server().x)
+
+    def _clients_with_server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> list["Agent"]:
+        """Return selected clients that received the current broadcast sent by :meth:`server_broadcast`."""
+        return [client for client in selected_clients if network.server() in client.messages]
+
+    def _clear_buffered_client_server_messages(
+        self,
+        network: FedNetwork,
+        selected_clients: Sequence["Agent"],
+    ) -> None:
+        """
+        Remove stale server-to-client messages for the current selected clients.
+
+        This ensures selected clients participate only if they receive the current server broadcast. The clean-up is
+        needed when :class:`~decent_bench.networks.Network` uses ``buffer_messages=True``, since old server broadcasts
+        would otherwise remain stored at clients and could be mistaken for fresh round broadcasts.
+        """
+        for client in selected_clients:
+            client._received_messages.pop(network.server(), None)  # noqa: SLF001
+
+    def _clear_buffered_server_messages(self, network: FedNetwork, participating_clients: Sequence["Agent"]) -> None:
+        """
+        Remove stale client-to-server messages for the current participants.
+
+        This ensures the server aggregates only updates actually received from those clients in the current round.
+        The clean-up is needed when :class:`~decent_bench.networks.Network` uses ``buffer_messages=True``, since old
+        client uploads would otherwise remain stored at the server and could be mistaken for fresh round updates.
+        Call this immediately before the current client upload phase.
+
+        """
+        for client in participating_clients:
+            network.server()._received_messages.pop(client, None)  # noqa: SLF001
+
+    @staticmethod
+    def _get_server_broadcast(client: "Agent", server: "Agent") -> "Array":
+        """
+        Return the current server broadcast received by the client.
+
+        Raises:
+            ValueError: if the client did not receive the current server broadcast.
+
+        """
+        if server not in client.messages:
+            raise ValueError("Client did not receive the current server broadcast")
+        return iop.copy(client.messages[server])
+
+    @staticmethod
+    def _weighted_average(values: Sequence["Array"], weights: Sequence[float], total_weight: float) -> "Array":
+        """Compute a weighted average of same-shaped arrays."""
+        weighted_values = [value * weight for value, weight in zip(values, weights, strict=True)]
+        return iop.sum(iop.stack(weighted_values, dim=0), dim=0) / total_weight
 
     def aggregate(
         self,

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -5,6 +5,7 @@ import decent_bench.utils.interoperability as iop
 from decent_bench.algorithms._algorithm import Algorithm
 from decent_bench.networks import FedNetwork
 from decent_bench.schemes import ClientSelectionScheme
+from decent_bench.utils.types import LocalSteps
 
 if TYPE_CHECKING:
     from decent_bench.agents import Agent
@@ -15,6 +16,7 @@ class FedAlgorithm(Algorithm[FedNetwork]):
     """Federated algorithm - clients collaborate via a central server."""
 
     selection_scheme: ClientSelectionScheme | None = None
+    num_local_steps: LocalSteps
 
     def cleanup_agents(self, network: FedNetwork) -> Iterable["Agent"]:
         return [network.server(), *network.clients()]
@@ -69,6 +71,45 @@ class FedAlgorithm(Algorithm[FedNetwork]):
         if self.selection_scheme is None:
             return list(active_clients)
         return self.selection_scheme.select(active_clients, iteration)
+
+    def _validate_num_local_steps(self) -> None:
+        """
+        Validate homogeneous or per-client local step counts.
+
+        Raises:
+            TypeError: if ``num_local_steps`` is not an integer or client mapping.
+            ValueError: if ``num_local_steps`` contains non-positive step counts.
+
+        """
+        if isinstance(self.num_local_steps, int):
+            if self.num_local_steps <= 0:
+                raise ValueError("`num_local_steps` must be positive")
+            return
+        if isinstance(self.num_local_steps, dict):
+            for step in self.num_local_steps.values():
+                if step <= 0:
+                    raise ValueError("`num_local_steps` must have positive values")
+            return
+        raise TypeError("`num_local_steps` must be an int or a mapping from Agent to integer values")
+
+    def _settle_num_local_steps(self, network: FedNetwork) -> dict["Agent", int]:
+        """
+        Resolve homogeneous or per-client local step counts for the network clients.
+
+        Raises:
+            ValueError: if a per-client mapping is missing a network client.
+
+        """
+        clients = network.clients()
+        if isinstance(self.num_local_steps, int):
+            return dict.fromkeys(clients, self.num_local_steps)
+        missing_clients = [client for client in clients if client not in self.num_local_steps]
+        if missing_clients:
+            raise ValueError(
+                "`num_local_steps` mapping must provide a value for every network client; "
+                f"missing clients: {missing_clients}"
+            )
+        return {client: self.num_local_steps[client] for client in clients}
 
     def aggregate(
         self,

--- a/decent_bench/algorithms/federated/_fed_avg.py
+++ b/decent_bench/algorithms/federated/_fed_avg.py
@@ -79,7 +79,6 @@ class FedAvg(FedAlgorithm):
         participating_clients = self._clients_with_server_broadcast(network, selected_clients)
         if not participating_clients:
             return
-        self._clear_buffered_server_messages(network, participating_clients)
         self._run_local_updates(network, participating_clients)
         self.aggregate(network, participating_clients)
 

--- a/decent_bench/algorithms/federated/_fed_dyn.py
+++ b/decent_bench/algorithms/federated/_fed_dyn.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import decent_bench.utils.interoperability as iop
 from decent_bench.algorithms.utils import initial_states
 from decent_bench.networks import FedNetwork
-from decent_bench.schemes import ClientSelectionScheme, UniformClientSelection
+from decent_bench.schemes import ClientSelectionScheme, UniformSelection
 from decent_bench.utils._tags import tags
 from decent_bench.utils.types import InitialStates
 
@@ -60,7 +60,7 @@ class FedDyn(FedAlgorithm):
     alpha: float = 0.01
     num_local_epochs: int = 1
     selection_scheme: ClientSelectionScheme | None = field(
-        default_factory=lambda: UniformClientSelection(client_fraction=1.0)
+        default_factory=lambda: UniformSelection(fraction_selected_clients=1.0)
     )
     x0: InitialStates = None
     name: str = "FedDyn"

--- a/decent_bench/algorithms/federated/_fed_dyn.py
+++ b/decent_bench/algorithms/federated/_fed_dyn.py
@@ -1,0 +1,153 @@
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import decent_bench.utils.interoperability as iop
+from decent_bench.algorithms.utils import initial_states
+from decent_bench.networks import FedNetwork
+from decent_bench.schemes import ClientSelectionScheme, UniformClientSelection
+from decent_bench.utils._tags import tags
+from decent_bench.utils.types import InitialStates
+
+from ._fed_algorithm import FedAlgorithm
+
+if TYPE_CHECKING:
+    from decent_bench.agents import Agent
+    from decent_bench.utils.array import Array
+
+
+@tags("federated")
+@dataclass(eq=False)
+class FedDyn(FedAlgorithm):
+    r"""
+    Federated Dynamic Regularization (FedDyn) with local gradient steps :footcite:p:`Alg_FedDyn`.
+
+    FedDyn keeps one dynamic state :math:`g_i` per client and one server auxiliary vector :math:`h`. In each
+    communication round, selected clients approximately minimize the dynamic-regularized local objective
+
+    .. math::
+        f_i(\theta) - \langle g_i, \theta \rangle
+        + \frac{\alpha}{2}\|\theta - \theta^t\|^2
+
+    by running ``num_local_epochs`` gradient steps from the received server model, with local gradient
+
+    .. math::
+        \nabla f_i(\theta) - g_i + \alpha(\theta - \theta^t).
+
+    After local training, each participating client updates its dynamic state as
+
+    .. math::
+        g_i^+ = g_i - \alpha(\theta_i^+ - \theta^t).
+
+    The server aggregates only the selected client models it actually receives. If :math:`R_t` is the received subset,
+    :math:`m` is the total number of clients, and :math:`\theta^t` is the server model before aggregation, then
+
+    .. math::
+        h^+ = h - \frac{\alpha}{m}\sum_{i \in R_t}(\theta_i^+ - \theta^t),
+        \qquad
+        \theta^+ = \frac{1}{|R_t|}\sum_{i \in R_t}\theta_i^+ - \frac{1}{\alpha}h^+.
+
+    If no selected client model is received, the server model and ``h`` remain unchanged. Unselected clients and
+    selected clients that miss the server broadcast keep their previous local model and dynamic state. Costs that
+    preserve the :class:`~decent_bench.costs.EmpiricalRiskCost` abstraction use mini-batch local updates; generic costs
+    keep their usual full-gradient behavior. Client selection defaults to uniform sampling with fraction 1.0.
+
+    .. footbibliography::
+    """
+
+    iterations: int = 100
+    step_size: float = 0.001
+    alpha: float = 0.01
+    num_local_epochs: int = 1
+    selection_scheme: ClientSelectionScheme | None = field(
+        default_factory=lambda: UniformClientSelection(client_fraction=1.0)
+    )
+    x0: InitialStates = None
+    name: str = "FedDyn"
+
+    def __post_init__(self) -> None:
+        """
+        Validate hyperparameters.
+
+        Raises:
+            ValueError: if hyperparameters are invalid.
+
+        """
+        if self.step_size <= 0:
+            raise ValueError("`step_size` must be positive")
+        if self.alpha <= 0:
+            raise ValueError("`alpha` must be positive")
+        if self.num_local_epochs <= 0:
+            raise ValueError("`num_local_epochs` must be positive")
+
+    def initialize(self, network: FedNetwork) -> None:
+        self.x0 = initial_states(self.x0, network)
+        server = network.server()
+        server_x0 = self.x0[server]
+        server.initialize(x=server_x0, aux_vars={"h": iop.zeros_like(server_x0)})
+        for client in network.clients():
+            client_x0 = self.x0[client]
+            client.initialize(x=client_x0, aux_vars={"g": iop.zeros_like(client_x0)})
+
+    def step(self, network: FedNetwork, iteration: int) -> None:
+        selected_clients = self._selected_clients_for_round(network, iteration)
+        if not selected_clients:
+            return
+
+        self.server_broadcast(network, selected_clients)
+        participating_clients = self._clients_with_server_broadcast(network, selected_clients)
+        if not participating_clients:
+            return
+        self._clear_buffered_server_messages(network, participating_clients)
+        self._run_local_updates(network, participating_clients)
+        self.aggregate(network, participating_clients)
+
+    def _run_local_updates(self, network: FedNetwork, participating_clients: Sequence["Agent"]) -> None:
+        for client in participating_clients:
+            reference_x = self._get_server_broadcast(client, network.server())
+            local_x = self._compute_local_update(client, reference_x)
+            client.x = local_x
+            client.aux_vars["g"] -= self.alpha * (local_x - reference_x)
+            network.send(sender=client, receiver=network.server(), msg=client.x)
+
+    def _compute_local_update(self, client: "Agent", reference_x: "Array") -> "Array":
+        """
+        Run local FedDyn gradient steps using the batching semantics of ``client.cost.gradient``.
+
+        Costs that preserve the empirical-risk abstraction default ``gradient`` to ``indices="batch"``, so FedDyn
+        performs mini-batch local updates automatically. Generic costs keep their usual full-gradient behavior.
+        """
+        local_x = iop.copy(reference_x)
+        dynamic_state = iop.copy(client.aux_vars["g"])
+        for _ in range(self.num_local_epochs):
+            grad = client.cost.gradient(local_x) - dynamic_state + self.alpha * (local_x - reference_x)
+            local_x -= self.step_size * grad
+        return local_x
+
+    def aggregate(
+        self,
+        network: FedNetwork,
+        participating_clients: Sequence["Agent"],
+    ) -> None:
+        """
+        Aggregate received FedDyn client models and apply the server dynamic correction.
+
+        When used with :class:`~decent_bench.networks.Network` ``buffer_messages=True``, this method assumes the
+        caller has already removed stale buffered client-to-server messages for the participating clients, so only
+        current-round client models are aggregated.
+        """
+        server = network.server()
+        received_clients = [client for client in participating_clients if client in server.messages]
+        if not received_clients:
+            return
+
+        reference_x = iop.copy(server.x)
+        client_models = [server.messages[client] for client in received_clients]
+        average_model = self._weighted_average(
+            client_models,
+            weights=[1.0] * len(received_clients),
+            total_weight=float(len(received_clients)),
+        )
+        model_delta_sum = iop.sum(iop.stack([model - reference_x for model in client_models], dim=0), dim=0)
+        server.aux_vars["h"] -= self.alpha * model_delta_sum / len(network.clients())
+        server.x = average_model - server.aux_vars["h"] / self.alpha

--- a/decent_bench/algorithms/federated/_fed_dyn.py
+++ b/decent_bench/algorithms/federated/_fed_dyn.py
@@ -23,13 +23,16 @@ class FedDyn(FedAlgorithm):
     Federated Dynamic Regularization (FedDyn) with local gradient steps :footcite:p:`Alg_FedDyn`.
 
     FedDyn keeps one dynamic state :math:`g_i` per client and one server auxiliary vector :math:`h`. In each
-    communication round, selected clients approximately minimize the dynamic-regularized local objective
+    communication round, the paper writes the selected-client update as the exact minimizer of the
+    dynamic-regularized local objective
 
     .. math::
         f_i(\theta) - \langle g_i, \theta \rangle
         + \frac{\alpha}{2}\|\theta - \theta^t\|^2
 
-    by running ``num_local_epochs`` gradient steps from the received server model, with local gradient
+    In practice, and following the local SGD device update used in the paper's experiments, this implementation
+    approximates that minimization by running ``num_local_epochs`` gradient steps
+    from the received server model, with local gradient
 
     .. math::
         \nabla f_i(\theta) - g_i + \alpha(\theta - \theta^t).

--- a/decent_bench/algorithms/federated/_fed_dyn.py
+++ b/decent_bench/algorithms/federated/_fed_dyn.py
@@ -98,7 +98,6 @@ class FedDyn(FedAlgorithm):
         participating_clients = self._clients_with_server_broadcast(network, selected_clients)
         if not participating_clients:
             return
-        self._clear_buffered_server_messages(network, participating_clients)
         self._run_local_updates(network, participating_clients)
         self.aggregate(network, participating_clients)
 
@@ -132,9 +131,7 @@ class FedDyn(FedAlgorithm):
         """
         Aggregate received FedDyn client models and apply the server dynamic correction.
 
-        When used with :class:`~decent_bench.networks.Network` ``buffer_messages=True``, this method assumes the
-        caller has already removed stale buffered client-to-server messages for the participating clients, so only
-        current-round client models are aggregated.
+        Only client models received in the current round are aggregated.
         """
         server = network.server()
         received_clients = [client for client in participating_clients if client in server.messages]

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -1,4 +1,3 @@
-import math
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -15,6 +14,10 @@ from ._fed_algorithm import FedAlgorithm
 if TYPE_CHECKING:
     from decent_bench.agents import Agent
     from decent_bench.utils.array import Array
+
+    SolverArgs = dict[str, float]
+else:
+    SolverArgs = dict
 
 
 @tags("federated")
@@ -50,29 +53,34 @@ class FedLT(FedAlgorithm):
     mini-batch sampling, so this behaves as local SGD. Generic :class:`~decent_bench.costs.Cost` objects use their
     normal full-gradient behavior, so this behaves as local GD.
 
-    The ``local_solver`` argument selects the method used for these local steps. The default ``"gd"`` uses the
-    gradient update above. The ``"accelerated"`` option uses each client cost's ``m_smooth`` and ``m_cvx`` metadata.
-    It initializes :math:`u_i^0=w^0_{i,k}`. With :math:`L_i=\texttt{m_smooth}` and
-    :math:`\mu_i=\texttt{m_cvx}`, it applies
+    Local solvers
+        The ``local_solver`` argument selects the method used for these local steps. The default ``"gd"`` uses the
+        gradient update above. Solver-specific hyperparameters are passed through ``solver_args``.
+
+    Nesterov
+        The ``"nesterov"`` option applies a Nesterov-style update to the same local gradient. It initializes
+        :math:`u_i^0=w^0_{i,k}` and uses ``step_size`` as the local step size:
 
     .. math::
-        u_i^{\ell+1} = w^\ell_{i,k} - \frac{1}{L_i + 1/\rho}\left(\nabla f_i(w^\ell_{i,k})
+        u_i^{\ell+1} = w^\ell_{i,k} - \gamma\left(\nabla f_i(w^\ell_{i,k})
         + \frac{1}{\rho}(w^\ell_{i,k} - v_{i,k})\right)
 
     .. math::
         w^{\ell+1}_{i,k} = u_i^{\ell+1}
-        + \frac{\sqrt{L_i + 1/\rho} - \sqrt{\mu_i + 1/\rho}}
-        {\sqrt{L_i + 1/\rho} + \sqrt{\mu_i + 1/\rho}}
-        \left(u_i^{\ell+1} - u_i^\ell\right).
+        + \beta\left(u_i^{\ell+1} - u_i^\ell\right).
 
-    If the client cost has :math:`\mu_i=0`, this coefficient reduces to the Fed-LT expression with
-    :math:`\sqrt{1/\rho}` in the second term. The constants must be finite and non-negative. The gradient call remains
-    cost-driven: empirical costs use their default mini-batches and generic costs use full gradients.
+        The momentum coefficient :math:`\beta` is ``solver_args["momentum"]`` and defaults to ``0.9``. One possible
+        centralized strongly-convex choice is
+        :math:`(\sqrt{L_i + 1/\rho} - \sqrt{\mu_i + 1/\rho}) / (\sqrt{L_i + 1/\rho} + \sqrt{\mu_i + 1/\rho})`,
+        with local step size :math:`1/(L_i + 1/\rho)`, where :math:`L_i=\texttt{m_smooth}` and
+        :math:`\mu_i=\texttt{m_cvx}`.
 
-    The ``"adam"`` option applies Adam to the same local gradient
-    :math:`\nabla f_i(w^\ell_{i,k}) + (w^\ell_{i,k} - v_{i,k})/\rho`. Adam moments are reset at the start of every
-    local solve because Fed-LT locally trains the current round's subproblem rather than maintaining a persistent
-    optimizer state across rounds.
+    Adam
+        The ``"adam"`` option applies Adam to the same local gradient
+        :math:`\nabla f_i(w^\ell_{i,k}) + (w^\ell_{i,k} - v_{i,k})/\rho`. Adam moments are reset at the start of every
+        local solve because Fed-LT locally trains the current round's subproblem rather than maintaining a persistent
+        optimizer state across rounds. ``solver_args`` may set ``beta1``, ``beta2``, and ``epsilon``; the defaults are
+        ``0.9``, ``0.999``, and ``1e-8``.
 
     .. math::
         g^\ell_{i,k} =
@@ -109,17 +117,13 @@ class FedLT(FedAlgorithm):
     num_local_epochs: int = 1
     rho: float = 1.0
     local_solver: str = "gd"
-    adam_beta1: float = 0.9
-    adam_beta2: float = 0.999
-    adam_epsilon: float = 1e-8
+    solver_args: SolverArgs = field(default_factory=dict)
     selection_scheme: ClientSelectionScheme | None = field(
         default_factory=lambda: UniformSelection(fraction_selected_clients=1.0)
     )
     x0: InitialStates = None
     z0: InitialStates = None
     name: str = "FedLT"
-    _accelerated_smoothness: dict["Agent", float] = field(init=False, default_factory=dict, repr=False)
-    _accelerated_momentum: dict["Agent", float] = field(init=False, default_factory=dict, repr=False)
 
     def __post_init__(self) -> None:
         """
@@ -135,19 +139,38 @@ class FedLT(FedAlgorithm):
             raise ValueError("`num_local_epochs` must be positive")
         if self.rho <= 0:
             raise ValueError("`rho` must be positive")
-        if self.local_solver not in {"gd", "accelerated", "adam"}:
-            raise ValueError("`local_solver` must be one of 'gd', 'accelerated', or 'adam'")
-        if not (0 <= self.adam_beta1 < 1):
-            raise ValueError("`adam_beta1` must satisfy 0 <= adam_beta1 < 1")
-        if not (0 <= self.adam_beta2 < 1):
-            raise ValueError("`adam_beta2` must satisfy 0 <= adam_beta2 < 1")
-        if self.adam_epsilon <= 0:
-            raise ValueError("`adam_epsilon` must be positive")
+        if self.local_solver not in {"gd", "nesterov", "adam"}:
+            raise ValueError("`local_solver` must be one of 'gd', 'nesterov', or 'adam'")
+        self._validate_solver_args()
+
+    def _validate_solver_args(self) -> None:
+        if self.local_solver == "adam":
+            allowed_args = {"beta1", "beta2", "epsilon"}
+            self.solver_args = {"beta1": 0.9, "beta2": 0.999, "epsilon": 1e-8, **self.solver_args}
+            beta1 = self.solver_args["beta1"]
+            beta2 = self.solver_args["beta2"]
+            epsilon = self.solver_args["epsilon"]
+            if not (0 <= beta1 < 1):
+                raise ValueError("`solver_args['beta1']` must satisfy 0 <= beta1 < 1")
+            if not (0 <= beta2 < 1):
+                raise ValueError("`solver_args['beta2']` must satisfy 0 <= beta2 < 1")
+            if epsilon <= 0:
+                raise ValueError("`solver_args['epsilon']` must be positive")
+        elif self.local_solver == "nesterov":
+            allowed_args = {"momentum"}
+            self.solver_args = {"momentum": 0.9, **self.solver_args}
+            momentum = self.solver_args["momentum"]
+            if not (0 <= momentum < 1):
+                raise ValueError("`solver_args['momentum']` must satisfy 0 <= momentum < 1")
+        else:
+            allowed_args = set()
+
+        unknown_args = set(self.solver_args) - allowed_args
+        if unknown_args:
+            names = ", ".join(sorted(unknown_args))
+            raise ValueError(f"Unsupported solver_args for local_solver='{self.local_solver}': {names}")
 
     def initialize(self, network: FedNetwork) -> None:
-        if self.local_solver == "accelerated":
-            self._initialize_accelerated_parameters(network)
-
         self.x0 = initial_states(self.x0, network)
         self.z0 = self.x0 if self.z0 is None else initial_states(self.z0, network)
 
@@ -156,29 +179,6 @@ class FedLT(FedAlgorithm):
         server.initialize(x=self.x0[server], aux_vars={"z_by_client": z_by_client})
         for client in network.clients():
             client.initialize(x=self.x0[client], aux_vars={"z": self.z0[client]})
-
-    def _initialize_accelerated_parameters(self, network: FedNetwork) -> None:
-        self._accelerated_smoothness = {}
-        self._accelerated_momentum = {}
-        for client in network.clients():
-            m_smooth = client.cost.m_smooth
-            m_cvx = client.cost.m_cvx
-            if not math.isfinite(m_smooth) or not math.isfinite(m_cvx) or m_smooth < 0 or m_cvx < 0:
-                raise ValueError(
-                    "`local_solver='accelerated'` requires finite non-negative `m_smooth` and `m_cvx` "
-                    "on every client cost"
-                )
-            if m_smooth < m_cvx:
-                raise ValueError("`local_solver='accelerated'` requires `m_smooth >= m_cvx` on every client cost")
-
-            smoothness = m_smooth + (1 / self.rho)
-            strong_convexity = m_cvx + (1 / self.rho)
-            sqrt_smoothness = math.sqrt(smoothness)
-            sqrt_strong_convexity = math.sqrt(strong_convexity)
-            self._accelerated_smoothness[client] = smoothness
-            self._accelerated_momentum[client] = (sqrt_smoothness - sqrt_strong_convexity) / (
-                sqrt_smoothness + sqrt_strong_convexity
-            )
 
     def step(self, network: FedNetwork, iteration: int) -> None:
         y = self._compute_server_y(network)
@@ -218,8 +218,8 @@ class FedLT(FedAlgorithm):
         v = (2 * y) - z
         local_x = iop.copy(client.x)
 
-        if self.local_solver == "accelerated":
-            local_x = self._compute_accelerated_local_update(client, local_x, v)
+        if self.local_solver == "nesterov":
+            local_x = self._compute_nesterov_local_update(client, local_x, v)
         elif self.local_solver == "adam":
             local_x = self._compute_adam_local_update(client, local_x, v)
         else:
@@ -230,29 +230,31 @@ class FedLT(FedAlgorithm):
         z_next = z + (2 * (local_x - y))
         return local_x, z_next
 
-    def _compute_accelerated_local_update(self, client: "Agent", local_x: "Array", v: "Array") -> "Array":
-        smoothness = self._accelerated_smoothness[client]
-        momentum = self._accelerated_momentum[client]
+    def _compute_nesterov_local_update(self, client: "Agent", local_x: "Array", v: "Array") -> "Array":
+        momentum = self.solver_args["momentum"]
         u_previous = iop.copy(local_x)
 
         for _ in range(self.num_local_epochs):
             grad = client.cost.gradient(local_x) + ((local_x - v) / self.rho)
-            u_next = local_x - ((1 / smoothness) * grad)
+            u_next = local_x - (self.step_size * grad)
             local_x = u_next + (momentum * (u_next - u_previous))
             u_previous = u_next
         return local_x
 
     def _compute_adam_local_update(self, client: "Agent", local_x: "Array", v: "Array") -> "Array":
+        beta1 = self.solver_args["beta1"]
+        beta2 = self.solver_args["beta2"]
+        epsilon = self.solver_args["epsilon"]
         m = iop.zeros_like(local_x)
         s = iop.zeros_like(local_x)
 
         for step in range(1, self.num_local_epochs + 1):
             grad = client.cost.gradient(local_x) + ((local_x - v) / self.rho)
-            m = (self.adam_beta1 * m) + ((1 - self.adam_beta1) * grad)
-            s = (self.adam_beta2 * s) + ((1 - self.adam_beta2) * (grad * grad))
-            m_hat = m / (1 - (self.adam_beta1**step))
-            s_hat = s / (1 - (self.adam_beta2**step))
-            local_x -= self.step_size * m_hat / (iop.sqrt(s_hat) + self.adam_epsilon)
+            m = (beta1 * m) + ((1 - beta1) * grad)
+            s = (beta2 * s) + ((1 - beta2) * (grad * grad))
+            m_hat = m / (1 - (beta1**step))
+            s_hat = s / (1 - (beta2**step))
+            local_x -= self.step_size * m_hat / (iop.sqrt(s_hat) + epsilon)
         return local_x
 
     def aggregate(

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -192,7 +192,6 @@ class FedLT(FedAlgorithm):
         participating_clients = self._clients_with_server_broadcast(network, selected_clients)
         if not participating_clients:
             return
-        self._clear_buffered_server_messages(network, participating_clients)
         self._run_local_updates(network, participating_clients)
         self.aggregate(network, participating_clients)
 

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -41,25 +41,34 @@ class FedLT(FedAlgorithm):
     by the server cost's proximal operator; with the default :class:`~decent_bench.costs.ZeroCost` server, this is the
     documented :math:`h=0` case and the server step is plain averaging.
 
-    A selected client :math:`i` sets :math:`w^0_{i,k}=x_{i,k}` and :math:`v_{i,k}=2y_{k+1}-z_{i,k}`, then performs
-    ``num_local_epochs`` local steps. The default local update uses
+    **Local solvers.**
+    A selected client :math:`i` sets :math:`w^0_{i,k}=x_{i,k}` and
+    :math:`v_{i,k}=2y_{k+1}-z_{i,k}`, then uses ``local_solver`` to approximately minimize the regularized local
+    objective
+
+    .. math::
+        f_i(w) + \frac{1}{2\rho}\|w - v_{i,k}\|^2.
+
+    The local gradient of this subproblem is
+
+    .. math::
+        \nabla f_i(w^\ell_{i,k}) + \frac{1}{\rho}(w^\ell_{i,k} - v_{i,k}).
+
+    Costs preserving the :class:`~decent_bench.costs.EmpiricalRiskCost` abstraction use its default mini-batch
+    sampling, so gradient-based local solvers use mini-batches. Generic :class:`~decent_bench.costs.Cost` objects use
+    their normal full-gradient behavior. Solver-specific hyperparameters are passed through ``solver_args``.
+
+    **Gradient descent.**
+    The default ``local_solver="gd"`` uses ``step_size`` as the local step size and expects empty ``solver_args``:
 
     .. math::
         w^{\ell+1}_{i,k} = w^\ell_{i,k} - \gamma\left(\nabla f_i(w^\ell_{i,k})
         + \frac{1}{\rho}(w^\ell_{i,k} - v_{i,k})\right).
 
-    The extra term :math:`(w^\ell_{i,k} - v_{i,k}) / \rho` is the quadratic local-training penalty from the Fed-LT
-    update. Costs preserving the :class:`~decent_bench.costs.EmpiricalRiskCost` abstraction use its default
-    mini-batch sampling, so this behaves as local SGD. Generic :class:`~decent_bench.costs.Cost` objects use their
-    normal full-gradient behavior, so this behaves as local GD.
-
-    Local solvers
-        The ``local_solver`` argument selects the method used for these local steps. The default ``"gd"`` uses the
-        gradient update above. Solver-specific hyperparameters are passed through ``solver_args``.
-
-    Nesterov
-        The ``"nesterov"`` option applies a Nesterov-style update to the same local gradient. It initializes
-        :math:`u_i^0=w^0_{i,k}` and uses ``step_size`` as the local step size:
+    **Nesterov.**
+    The ``local_solver="nesterov"`` option applies a Nesterov-style update to the same local gradient. It initializes
+    :math:`u_i^0=w^0_{i,k}` and uses ``step_size`` as the local step size. Its ``solver_args`` may contain
+    ``"momentum"``; the default is ``0.9``:
 
     .. math::
         u_i^{\ell+1} = w^\ell_{i,k} - \gamma\left(\nabla f_i(w^\ell_{i,k})
@@ -69,18 +78,16 @@ class FedLT(FedAlgorithm):
         w^{\ell+1}_{i,k} = u_i^{\ell+1}
         + \beta\left(u_i^{\ell+1} - u_i^\ell\right).
 
-        The momentum coefficient :math:`\beta` is ``solver_args["momentum"]`` and defaults to ``0.9``. One possible
-        centralized strongly-convex choice is
-        :math:`(\sqrt{L_i + 1/\rho} - \sqrt{\mu_i + 1/\rho}) / (\sqrt{L_i + 1/\rho} + \sqrt{\mu_i + 1/\rho})`,
-        with local step size :math:`1/(L_i + 1/\rho)`, where :math:`L_i=\texttt{m_smooth}` and
-        :math:`\mu_i=\texttt{m_cvx}`.
+    One possible centralized strongly-convex choice is
+    :math:`\beta=(\sqrt{L_i + 1/\rho} - \sqrt{\mu_i + 1/\rho}) / (\sqrt{L_i + 1/\rho}
+    + \sqrt{\mu_i + 1/\rho})`, with local step size :math:`1/(L_i + 1/\rho)`, where
+    :math:`L_i=\texttt{m_smooth}` and :math:`\mu_i=\texttt{m_cvx}`.
 
-    Adam
-        The ``"adam"`` option applies Adam to the same local gradient
-        :math:`\nabla f_i(w^\ell_{i,k}) + (w^\ell_{i,k} - v_{i,k})/\rho`. Adam moments are reset at the start of every
-        local solve because Fed-LT locally trains the current round's subproblem rather than maintaining a persistent
-        optimizer state across rounds. ``solver_args`` may set ``beta1``, ``beta2``, and ``epsilon``; the defaults are
-        ``0.9``, ``0.999``, and ``1e-8``.
+    **Adam.**
+    The ``local_solver="adam"`` option applies Adam to the same local gradient. Adam moments are reset at the start
+    of every local solve because Fed-LT locally trains the current round's subproblem rather than maintaining a
+    persistent optimizer state across rounds. Its ``solver_args`` may contain ``"beta1"``, ``"beta2"``, and
+    ``"epsilon"``; the defaults are ``0.9``, ``0.999``, and ``1e-8``:
 
     .. math::
         g^\ell_{i,k} =
@@ -97,6 +104,7 @@ class FedLT(FedAlgorithm):
 
     for :math:`\ell=1,\ldots,N_e`, with :math:`m^0_{i,k}=s^0_{i,k}=0`. The terms
     :math:`\hat m^\ell_{i,k}` and :math:`\hat s^\ell_{i,k}` are the Adam bias-corrected moments.
+
 
     After local training, the client sets
 
@@ -144,31 +152,39 @@ class FedLT(FedAlgorithm):
         self._validate_solver_args()
 
     def _validate_solver_args(self) -> None:
+        user_args = self.solver_args
         if self.local_solver == "adam":
-            allowed_args = {"beta1", "beta2", "epsilon"}
-            self.solver_args = {"beta1": 0.9, "beta2": 0.999, "epsilon": 1e-8, **self.solver_args}
-            beta1 = self.solver_args["beta1"]
-            beta2 = self.solver_args["beta2"]
-            epsilon = self.solver_args["epsilon"]
-            if not (0 <= beta1 < 1):
+            default_args = {"beta1": 0.9, "beta2": 0.999, "epsilon": 1e-8}
+            self.solver_args = {
+                "beta1": user_args.get("beta1", default_args["beta1"]),
+                "beta2": user_args.get("beta2", default_args["beta2"]),
+                "epsilon": user_args.get("epsilon", default_args["epsilon"]),
+            }
+            unknown_args = set(user_args) - set(default_args)
+            if unknown_args:
+                names = ", ".join(sorted(unknown_args))
+                raise ValueError(f"Unsupported solver_args for local_solver='{self.local_solver}': {names}")
+            if not (0 <= self.solver_args["beta1"] < 1):
                 raise ValueError("`solver_args['beta1']` must satisfy 0 <= beta1 < 1")
-            if not (0 <= beta2 < 1):
+            if not (0 <= self.solver_args["beta2"] < 1):
                 raise ValueError("`solver_args['beta2']` must satisfy 0 <= beta2 < 1")
-            if epsilon <= 0:
+            if self.solver_args["epsilon"] <= 0:
                 raise ValueError("`solver_args['epsilon']` must be positive")
         elif self.local_solver == "nesterov":
-            allowed_args = {"momentum"}
-            self.solver_args = {"momentum": 0.9, **self.solver_args}
-            momentum = self.solver_args["momentum"]
-            if not (0 <= momentum < 1):
+            default_args = {"momentum": 0.9}
+            self.solver_args = {"momentum": user_args.get("momentum", default_args["momentum"])}
+            unknown_args = set(user_args) - set(default_args)
+            if unknown_args:
+                names = ", ".join(sorted(unknown_args))
+                raise ValueError(f"Unsupported solver_args for local_solver='{self.local_solver}': {names}")
+            if not (0 <= self.solver_args["momentum"] < 1):
                 raise ValueError("`solver_args['momentum']` must satisfy 0 <= momentum < 1")
         else:
-            allowed_args = set()
-
-        unknown_args = set(self.solver_args) - allowed_args
-        if unknown_args:
-            names = ", ".join(sorted(unknown_args))
-            raise ValueError(f"Unsupported solver_args for local_solver='{self.local_solver}': {names}")
+            self.solver_args = {}
+            unknown_args = set(user_args)
+            if unknown_args:
+                names = ", ".join(sorted(unknown_args))
+                raise ValueError(f"Unsupported solver_args for local_solver='{self.local_solver}': {names}")
 
     def initialize(self, network: FedNetwork) -> None:
         self.x0 = initial_states(self.x0, network)

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -50,8 +50,9 @@ class FedLT(FedAlgorithm):
     mini-batch sampling, so this behaves as local SGD. Generic :class:`~decent_bench.costs.Cost` objects use their
     normal full-gradient behavior, so this behaves as local GD.
 
-    If ``use_acceleration`` is true, Fed-LT uses the accelerated local update with each client cost's ``m_smooth`` and
-    ``m_cvx`` metadata. It initializes :math:`u_i^0=w^0_{i,k}`. With :math:`L_i=\texttt{m_smooth}` and
+    The ``local_solver`` argument selects the method used for these local steps. The default ``"gd"`` uses the
+    gradient update above. The ``"accelerated"`` option uses each client cost's ``m_smooth`` and ``m_cvx`` metadata.
+    It initializes :math:`u_i^0=w^0_{i,k}`. With :math:`L_i=\texttt{m_smooth}` and
     :math:`\mu_i=\texttt{m_cvx}`, it applies
 
     .. math::
@@ -67,6 +68,27 @@ class FedLT(FedAlgorithm):
     If the client cost has :math:`\mu_i=0`, this coefficient reduces to the Fed-LT expression with
     :math:`\sqrt{1/\rho}` in the second term. The constants must be finite and non-negative. The gradient call remains
     cost-driven: empirical costs use their default mini-batches and generic costs use full gradients.
+
+    The ``"adam"`` option applies Adam to the same local gradient
+    :math:`\nabla f_i(w^\ell_{i,k}) + (w^\ell_{i,k} - v_{i,k})/\rho`. Adam moments are reset at the start of every
+    local solve because Fed-LT locally trains the current round's subproblem rather than maintaining a persistent
+    optimizer state across rounds.
+
+    .. math::
+        g^\ell_{i,k} =
+        \nabla f_i(w^{\ell-1}_{i,k}) + \frac{1}{\rho}(w^{\ell-1}_{i,k} - v_{i,k})
+
+    .. math::
+        m^\ell_{i,k} = \beta_1 m^{\ell-1}_{i,k} + (1-\beta_1)g^\ell_{i,k}, \qquad
+        s^\ell_{i,k} = \beta_2 s^{\ell-1}_{i,k} + (1-\beta_2)(g^\ell_{i,k})^2
+
+    .. math::
+        w^\ell_{i,k} =
+        w^{\ell-1}_{i,k}
+        - \gamma\frac{\hat m^\ell_{i,k}}{\sqrt{\hat s^\ell_{i,k}} + \epsilon},
+
+    for :math:`\ell=1,\ldots,N_e`, with :math:`m^0_{i,k}=s^0_{i,k}=0`. The terms
+    :math:`\hat m^\ell_{i,k}` and :math:`\hat s^\ell_{i,k}` are the Adam bias-corrected moments.
 
     After local training, the client sets
 
@@ -86,7 +108,10 @@ class FedLT(FedAlgorithm):
     step_size: float = 0.001
     num_local_epochs: int = 1
     rho: float = 1.0
-    use_acceleration: bool = False
+    local_solver: str = "gd"
+    adam_beta1: float = 0.9
+    adam_beta2: float = 0.999
+    adam_epsilon: float = 1e-8
     selection_scheme: ClientSelectionScheme | None = field(
         default_factory=lambda: UniformClientSelection(client_fraction=1.0)
     )
@@ -110,9 +135,17 @@ class FedLT(FedAlgorithm):
             raise ValueError("`num_local_epochs` must be positive")
         if self.rho <= 0:
             raise ValueError("`rho` must be positive")
+        if self.local_solver not in {"gd", "accelerated", "adam"}:
+            raise ValueError("`local_solver` must be one of 'gd', 'accelerated', or 'adam'")
+        if not (0 <= self.adam_beta1 < 1):
+            raise ValueError("`adam_beta1` must satisfy 0 <= adam_beta1 < 1")
+        if not (0 <= self.adam_beta2 < 1):
+            raise ValueError("`adam_beta2` must satisfy 0 <= adam_beta2 < 1")
+        if self.adam_epsilon <= 0:
+            raise ValueError("`adam_epsilon` must be positive")
 
     def initialize(self, network: FedNetwork) -> None:
-        if self.use_acceleration:
+        if self.local_solver == "accelerated":
             self._initialize_accelerated_parameters(network)
 
         self.x0 = initial_states(self.x0, network)
@@ -132,10 +165,11 @@ class FedLT(FedAlgorithm):
             m_cvx = client.cost.m_cvx
             if not math.isfinite(m_smooth) or not math.isfinite(m_cvx) or m_smooth < 0 or m_cvx < 0:
                 raise ValueError(
-                    "`use_acceleration=True` requires finite non-negative `m_smooth` and `m_cvx` on every client cost"
+                    "`local_solver='accelerated'` requires finite non-negative `m_smooth` and `m_cvx` "
+                    "on every client cost"
                 )
             if m_smooth < m_cvx:
-                raise ValueError("`use_acceleration=True` requires `m_smooth >= m_cvx` on every client cost")
+                raise ValueError("`local_solver='accelerated'` requires `m_smooth >= m_cvx` on every client cost")
 
             smoothness = m_smooth + (1 / self.rho)
             strong_convexity = m_cvx + (1 / self.rho)
@@ -185,8 +219,10 @@ class FedLT(FedAlgorithm):
         v = (2 * y) - z
         local_x = iop.copy(client.x)
 
-        if self.use_acceleration:
+        if self.local_solver == "accelerated":
             local_x = self._compute_accelerated_local_update(client, local_x, v)
+        elif self.local_solver == "adam":
+            local_x = self._compute_adam_local_update(client, local_x, v)
         else:
             for _ in range(self.num_local_epochs):
                 grad = client.cost.gradient(local_x) + ((local_x - v) / self.rho)
@@ -205,6 +241,19 @@ class FedLT(FedAlgorithm):
             u_next = local_x - ((1 / smoothness) * grad)
             local_x = u_next + (momentum * (u_next - u_previous))
             u_previous = u_next
+        return local_x
+
+    def _compute_adam_local_update(self, client: "Agent", local_x: "Array", v: "Array") -> "Array":
+        m = iop.zeros_like(local_x)
+        s = iop.zeros_like(local_x)
+
+        for step in range(1, self.num_local_epochs + 1):
+            grad = client.cost.gradient(local_x) + ((local_x - v) / self.rho)
+            m = (self.adam_beta1 * m) + ((1 - self.adam_beta1) * grad)
+            s = (self.adam_beta2 * s) + ((1 - self.adam_beta2) * (grad * grad))
+            m_hat = m / (1 - (self.adam_beta1**step))
+            s_hat = s / (1 - (self.adam_beta2**step))
+            local_x -= self.step_size * m_hat / (iop.sqrt(s_hat) + self.adam_epsilon)
         return local_x
 
     def aggregate(

--- a/decent_bench/algorithms/federated/_fed_nova.py
+++ b/decent_bench/algorithms/federated/_fed_nova.py
@@ -169,14 +169,13 @@ class FedNova(FedAlgorithm):
         participating_clients = self._clients_with_server_broadcast(network, selected_clients)
         if not participating_clients:
             return
-        self._clear_buffered_server_messages(network, participating_clients)
         self._run_local_updates(network, participating_clients)
         self._collect_received_normalizers(network, participating_clients)
         if not network.server().aux_vars["received_a_i"]:
             for client in participating_clients:
                 client.aux_vars.pop("_fednova_cumulative_gradient", None)
             return
-        self._clear_buffered_server_messages(network, participating_clients)
+        network._clear_received_messages(receivers=[network.server()], senders=participating_clients)  # noqa: SLF001
         self._communicate_cumulative_gradients(network, participating_clients)
         self.aggregate(network, participating_clients)
 
@@ -256,9 +255,8 @@ class FedNova(FedAlgorithm):
         This method assumes the current round has already cached the received FedNova coefficients ``a_i`` on the
         server and that the server's current messages contain the received cumulative local updates
         :math:`\mathbf{c}_i^t`. Client sample counts are looked up from the mapping stored on the server during
-        ``initialize``. When used with :class:`~decent_bench.networks.Network` ``buffer_messages=True``, the caller
-        must already have removed stale buffered client-to-server messages for the participating clients at the start
-        of the round and between the ``a_i`` and cumulative-gradient upload phases. If no client has both uploads
+        ``initialize``. The server inbox is cleared between the ``a_i`` and cumulative-gradient upload phases so
+        dropped second-phase messages cannot be confused with first-phase normalizers. If no client has both uploads
         available in the current round, this method returns without updating the server model.
 
         Raises:

--- a/decent_bench/algorithms/federated/_fed_nova.py
+++ b/decent_bench/algorithms/federated/_fed_nova.py
@@ -136,30 +136,6 @@ class FedNova(FedAlgorithm):
             raise ValueError("`gamma` must satisfy 0 <= gamma < 1")
         self._validate_num_local_steps()
 
-    def _validate_num_local_steps(self) -> None:
-        if isinstance(self.num_local_steps, int):
-            if self.num_local_steps <= 0:
-                raise ValueError("`num_local_steps` must be positive")
-            return
-        if isinstance(self.num_local_steps, dict):
-            for step in self.num_local_steps.values():
-                if step <= 0:
-                    raise ValueError("`num_local_steps` must have positive values")
-            return
-        raise TypeError("`num_local_steps` must be an int or a mapping from Agent to integer values")
-
-    def _settle_num_local_steps(self, network: FedNetwork) -> dict["Agent", int]:
-        clients = network.clients()
-        if isinstance(self.num_local_steps, int):
-            return dict.fromkeys(clients, self.num_local_steps)
-        missing_clients = [client for client in clients if client not in self.num_local_steps]
-        if missing_clients:
-            raise ValueError(
-                "`num_local_steps` mapping must provide a value for every network client; "
-                f"missing clients: {missing_clients}"
-            )
-        return {client: self.num_local_steps[client] for client in clients}
-
     def _resolve_client_sample_counts(self, network: FedNetwork) -> dict["Agent", float]:
         client_sample_counts: dict[Agent, float] = {}
         for client in network.clients():

--- a/decent_bench/algorithms/federated/_fed_opt.py
+++ b/decent_bench/algorithms/federated/_fed_opt.py
@@ -112,7 +112,6 @@ class FedOpt(FedAlgorithm, ABC):
         participating_clients = self._clients_with_server_broadcast(network, selected_clients)
         if not participating_clients:
             return
-        self._clear_buffered_server_messages(network, participating_clients)
         self._run_local_updates(network, participating_clients)
         self.aggregate(network, participating_clients)
 
@@ -144,9 +143,7 @@ class FedOpt(FedAlgorithm, ABC):
         """
         Aggregate client model deltas uniformly, then apply the server adaptive optimizer.
 
-        This method assumes clients upload final local model deltas. When used with
-        :class:`~decent_bench.networks.Network` ``buffer_messages=True``, the caller must already have removed stale
-        buffered client-to-server messages for the participating clients, so only current-round uploads are used.
+        This method assumes clients upload final local model deltas.
         """
         server = network.server()
         received_clients = [client for client in participating_clients if client in server.messages]

--- a/decent_bench/algorithms/federated/_fed_pd.py
+++ b/decent_bench/algorithms/federated/_fed_pd.py
@@ -1,0 +1,186 @@
+import random
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import decent_bench.utils.interoperability as iop
+from decent_bench.algorithms.utils import initial_states
+from decent_bench.networks import FedNetwork
+from decent_bench.utils._tags import tags
+from decent_bench.utils.types import InitialStates, LocalSteps
+
+from ._fed_algorithm import FedAlgorithm
+
+if TYPE_CHECKING:
+    from decent_bench.agents import Agent
+    from decent_bench.utils.array import Array
+
+
+@tags("federated")
+@dataclass(eq=False)
+class FedPD(FedAlgorithm):
+    r"""
+    Federated Primal-Dual (FedPD) with local gradient steps :footcite:p:`Alg_FedPD`.
+
+    FedPD rewrites federated learning as a global consensus problem with client primal variables
+    :math:`\mathbf{x}_i`, local centre variables :math:`\mathbf{x}_{0,i}`, and dual variables
+    :math:`\lambda_i`. In each round, all active clients run ``num_local_steps`` gradient steps on the local
+    augmented Lagrangian
+
+    .. math::
+        f_i(\mathbf{x}_i) + \langle \lambda_i, \mathbf{x}_i - \mathbf{x}_{0,i} \rangle
+        + \frac{1}{2 \eta}\|\mathbf{x}_i - \mathbf{x}_{0,i}\|^2.
+
+    The local gradient is
+
+    .. math::
+        \nabla f_i(\mathbf{x}_i) + \lambda_i
+        + \frac{1}{\eta}(\mathbf{x}_i - \mathbf{x}_{0,i}).
+
+    After the local gradient steps, clients update their dual variables and local centre candidates:
+
+    .. math::
+        \lambda_i^+ = \lambda_i + \frac{1}{\eta}(\mathbf{x}_i^+ - \mathbf{x}_{0,i}),
+        \qquad
+        \mathbf{x}_{0,i}^+ = \mathbf{x}_i^+ + \eta \lambda_i^+.
+
+    With probability ``1 - skip_probability``, clients upload their local centre candidates and the server uniformly
+    averages the candidates it actually receives. If at least one candidate is received, the server centre is then
+    sent back to all active clients; clients that do not receive the server's synchronized centre keep their local
+    centre candidate. With probability ``skip_probability``, aggregation is skipped and every participating client
+    keeps its local centre candidate.
+
+    Costs that preserve the :class:`~decent_bench.costs.EmpiricalRiskCost` abstraction use mini-batch local updates;
+    generic costs keep their usual full-gradient behavior. ``num_local_steps`` can be homogeneous (single integer) or
+    heterogeneous via a mapping keyed by client agent. Partial client participation is not supported.
+
+    .. footbibliography::
+    """
+
+    iterations: int = 100
+    step_size: float = 0.001
+    eta: float = 1.0
+    skip_probability: float = 0.0
+    num_local_steps: LocalSteps = 1
+    x0: InitialStates = None
+    name: str = "FedPD"
+    _num_local_steps_by_client: dict["Agent", int] = field(init=False, repr=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """
+        Validate hyperparameters.
+
+        Raises:
+            ValueError: if hyperparameters are invalid.
+
+        """
+        if self.step_size <= 0:
+            raise ValueError("`step_size` must be positive")
+        if self.eta <= 0:
+            raise ValueError("`eta` must be positive")
+        if not (0 <= self.skip_probability <= 1):
+            raise ValueError("`skip_probability` must satisfy 0 <= skip_probability <= 1")
+        self._validate_num_local_steps()
+
+    def initialize(self, network: FedNetwork) -> None:
+        self.x0 = initial_states(self.x0, network)
+        server = network.server()
+        server_x0 = self.x0[server]
+        server.initialize(x=server_x0)
+        for client in network.clients():
+            client_x0 = self.x0[client]
+            client.initialize(
+                x=client_x0,
+                aux_vars={
+                    "lambda": iop.zeros_like(client_x0),
+                    "center": iop.copy(server_x0),
+                },
+            )
+        self._num_local_steps_by_client = self._settle_num_local_steps(network)
+        self.num_local_steps = self._num_local_steps_by_client
+
+    def step(self, network: FedNetwork, _: int) -> None:
+        participating_clients = network.active_clients()
+        if not participating_clients:
+            return
+
+        self._run_local_updates(participating_clients)
+        if random.random() >= self.skip_probability:
+            self._clear_buffered_server_messages(network, participating_clients)
+            self._communicate_center_candidates(network, participating_clients)
+            self.aggregate_and_synchronize(network, participating_clients)
+
+    def _run_local_updates(self, participating_clients: Sequence["Agent"]) -> None:
+        for client in participating_clients:
+            previous_center = iop.copy(client.aux_vars["center"])
+            local_x = self._compute_local_update(client)
+            new_dual = client.aux_vars["lambda"] + (local_x - previous_center) / self.eta
+            client.x = local_x
+            client.aux_vars["lambda"] = new_dual
+            client.aux_vars["center"] = local_x + self.eta * new_dual
+
+    def _compute_local_update(self, client: "Agent") -> "Array":
+        """
+        Run local FedPD gradient steps using the batching semantics of ``client.cost.gradient``.
+
+        Costs that preserve the empirical-risk abstraction default ``gradient`` to ``indices="batch"``, so FedPD
+        performs mini-batch local updates automatically. Generic costs keep their usual full-gradient behavior. This
+        method assumes ``initialize`` has already normalized ``num_local_steps`` to a per-client mapping.
+        """
+        local_x = iop.copy(client.x)
+        center = iop.copy(client.aux_vars["center"])
+        dual = iop.copy(client.aux_vars["lambda"])
+        for _ in range(self._num_local_steps_by_client[client]):
+            grad = client.cost.gradient(local_x) + dual + (local_x - center) / self.eta
+            local_x -= self.step_size * grad
+        return local_x
+
+    def _communicate_center_candidates(
+        self,
+        network: FedNetwork,
+        participating_clients: Sequence["Agent"],
+    ) -> None:
+        for client in participating_clients:
+            network.send(sender=client, receiver=network.server(), msg=client.aux_vars["center"])
+
+    def aggregate(
+        self,
+        network: FedNetwork,
+        participating_clients: Sequence["Agent"],
+    ) -> None:
+        """
+        FedPD aggregates centre candidates through :meth:`aggregate_and_synchronize`.
+
+        Raises:
+            NotImplementedError: always, because FedPD aggregation also synchronizes the updated centre.
+
+        """
+        del network, participating_clients
+        raise NotImplementedError("FedPD uses `aggregate_and_synchronize` instead of `aggregate`")
+
+    def aggregate_and_synchronize(
+        self,
+        network: FedNetwork,
+        participating_clients: Sequence["Agent"],
+    ) -> None:
+        """
+        Aggregate received FedPD centre candidates and synchronize the updated centre.
+
+        If no centre candidates are received, the server state is left unchanged and no synchronization is sent.
+
+        When used with :class:`~decent_bench.networks.Network` ``buffer_messages=True``, this method assumes the
+        caller has already removed stale buffered client-to-server messages for the participating clients, so only
+        current-round centre candidates are aggregated.
+        """
+        server = network.server()
+        received_clients = [client for client in participating_clients if client in network.server().messages]
+        if not received_clients:
+            return
+        center_candidates = [server.messages[client] for client in received_clients]
+        weights = [1.0] * len(received_clients)
+        total_weight = float(len(received_clients))
+        server.x = self._weighted_average(center_candidates, weights, total_weight)
+        self.server_broadcast(network, participating_clients)
+        for client in participating_clients:
+            if server in client.messages:
+                client.aux_vars["center"] = self._get_server_broadcast(client, server)

--- a/decent_bench/algorithms/federated/_fed_pd.py
+++ b/decent_bench/algorithms/federated/_fed_pd.py
@@ -107,7 +107,7 @@ class FedPD(FedAlgorithm):
         self._run_local_updates(participating_clients)
         if random.random() >= self.skip_probability:
             self._communicate_center_candidates(network, participating_clients)
-            self.aggregate_and_synchronize(network, participating_clients)
+            self.aggregate(network, participating_clients)
 
     def _run_local_updates(self, participating_clients: Sequence["Agent"]) -> None:
         for client in participating_clients:
@@ -148,22 +148,11 @@ class FedPD(FedAlgorithm):
         participating_clients: Sequence["Agent"],
     ) -> None:
         """
-        FedPD aggregates centre candidates through :meth:`aggregate_and_synchronize`.
+        Aggregate received FedPD centre candidates and broadcast the synchronized centre.
 
-        Raises:
-            NotImplementedError: always, because FedPD aggregation also synchronizes the updated centre.
-
-        """
-        del network, participating_clients
-        raise NotImplementedError("FedPD uses `aggregate_and_synchronize` instead of `aggregate`")
-
-    def aggregate_and_synchronize(
-        self,
-        network: FedNetwork,
-        participating_clients: Sequence["Agent"],
-    ) -> None:
-        """
-        Aggregate received FedPD centre candidates and synchronize the updated centre.
+        Unlike most federated algorithms, a FedPD communication round couples aggregation with centre
+        synchronization: after the server averages the received centre candidates, it immediately broadcasts the
+        updated centre back to all participating clients.
 
         If no centre candidates are received, the server state is left unchanged and no synchronization is sent.
         """

--- a/decent_bench/algorithms/federated/_fed_pd.py
+++ b/decent_bench/algorithms/federated/_fed_pd.py
@@ -106,7 +106,6 @@ class FedPD(FedAlgorithm):
 
         self._run_local_updates(participating_clients)
         if random.random() >= self.skip_probability:
-            self._clear_buffered_server_messages(network, participating_clients)
             self._communicate_center_candidates(network, participating_clients)
             self.aggregate_and_synchronize(network, participating_clients)
 
@@ -167,12 +166,6 @@ class FedPD(FedAlgorithm):
         Aggregate received FedPD centre candidates and synchronize the updated centre.
 
         If no centre candidates are received, the server state is left unchanged and no synchronization is sent.
-
-        When used with :class:`~decent_bench.networks.Network` ``buffer_messages=True``, this method assumes the
-        caller has already removed stale buffered client-to-server messages for the participating clients, so only
-        current-round centre candidates are aggregated. The subsequent server synchronization uses
-        :meth:`~decent_bench.algorithms.federated.FedAlgorithm.server_broadcast`, which clears stale server-to-client
-        messages before sending, so clients update their centre only when they receive the current synchronization.
         """
         server = network.server()
         received_clients = [client for client in participating_clients if client in network.server().messages]

--- a/decent_bench/algorithms/federated/_fed_pd.py
+++ b/decent_bench/algorithms/federated/_fed_pd.py
@@ -170,7 +170,9 @@ class FedPD(FedAlgorithm):
 
         When used with :class:`~decent_bench.networks.Network` ``buffer_messages=True``, this method assumes the
         caller has already removed stale buffered client-to-server messages for the participating clients, so only
-        current-round centre candidates are aggregated.
+        current-round centre candidates are aggregated. The subsequent server synchronization uses
+        :meth:`~decent_bench.algorithms.federated.FedAlgorithm.server_broadcast`, which clears stale server-to-client
+        messages before sending, so clients update their centre only when they receive the current synchronization.
         """
         server = network.server()
         received_clients = [client for client in participating_clients if client in network.server().messages]

--- a/decent_bench/algorithms/federated/_fed_prox.py
+++ b/decent_bench/algorithms/federated/_fed_prox.py
@@ -88,7 +88,6 @@ class FedProx(FedAlgorithm):
         participating_clients = self._clients_with_server_broadcast(network, selected_clients)
         if not participating_clients:
             return
-        self._clear_buffered_server_messages(network, participating_clients)
         self._run_local_updates(network, participating_clients)
         self.aggregate(network, participating_clients)
 

--- a/decent_bench/algorithms/federated/_scaffold.py
+++ b/decent_bench/algorithms/federated/_scaffold.py
@@ -119,13 +119,11 @@ class Scaffold(FedAlgorithm):
         participating_clients = self._clients_with_server_broadcast(network, selected_clients)
         if not participating_clients:
             return
-        self._clear_buffered_server_messages(network, participating_clients)
         self._run_local_updates(network, participating_clients)
         self.aggregate(network, participating_clients)
 
     def server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
-        """Clear stale server broadcasts, then send the current server model and control variate."""
-        self._clear_buffered_client_server_messages(network, selected_clients)
+        """Send the current server model and control variate."""
         payload = iop.stack([network.server().x, network.server().aux_vars["c"]], dim=0)
         network.send(sender=network.server(), receiver=selected_clients, msg=payload)
 
@@ -168,9 +166,7 @@ class Scaffold(FedAlgorithm):
         """
         Aggregate received SCAFFOLD client deltas using uniform averaging.
 
-        When used with :class:`~decent_bench.networks.Network` ``buffer_messages=True``, this method assumes the
-        caller has already removed stale buffered client-to-server messages for the participating clients, so only
-        current-round updates are aggregated.
+        Only current-round client deltas received by the server are aggregated.
         """
         server = network.server()
         received_clients = [client for client in participating_clients if client in server.messages]

--- a/decent_bench/algorithms/federated/_scaffold.py
+++ b/decent_bench/algorithms/federated/_scaffold.py
@@ -58,6 +58,14 @@ class Scaffold(FedAlgorithm):
     where both aggregated deltas are averaged uniformly over the selected clients.
 
     .. footbibliography::
+
+    Note:
+        ``x0`` and ``c0`` follow the :obj:`~decent_bench.utils.types.InitialStates` convention and are resolved
+        per agent during ``initialize`` via
+        :func:`~decent_bench.algorithms.utils.initial_states`. For federated networks, ``c0`` dictionaries can
+        include both client control variates and the server control variate. If the server entry is missing, it is
+        inferred as the average of the client control variates.
+
     """
 
     iterations: int = 100
@@ -68,6 +76,7 @@ class Scaffold(FedAlgorithm):
         default_factory=lambda: UniformClientSelection(client_fraction=1.0)
     )
     x0: InitialStates = None
+    c0: InitialStates = None
     name: str = "Scaffold"
 
     def __post_init__(self) -> None:
@@ -87,17 +96,18 @@ class Scaffold(FedAlgorithm):
 
     def initialize(self, network: FedNetwork) -> None:
         self.x0 = initial_states(self.x0, network)
+        self.c0 = initial_states(self.c0, network)
         server = network.server()
         server_x0 = self.x0[server]
         server.initialize(
             x=server_x0,
-            aux_vars={"c": iop.zeros_like(server_x0)},
+            aux_vars={"c": self.c0[server]},
         )
         for client in network.clients():
             client_x0 = self.x0[client]
             client.initialize(
                 x=client_x0,
-                aux_vars={"c_i": iop.zeros_like(client_x0)},
+                aux_vars={"c_i": self.c0[client]},
             )
 
     def step(self, network: FedNetwork, iteration: int) -> None:

--- a/decent_bench/algorithms/federated/_scaffold.py
+++ b/decent_bench/algorithms/federated/_scaffold.py
@@ -124,7 +124,8 @@ class Scaffold(FedAlgorithm):
         self.aggregate(network, participating_clients)
 
     def server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
-        """Send the current server model and server control variate to the selected clients."""
+        """Clear stale server broadcasts, then send the current server model and control variate."""
+        self._clear_buffered_client_server_messages(network, selected_clients)
         payload = iop.stack([network.server().x, network.server().aux_vars["c"]], dim=0)
         network.send(sender=network.server(), receiver=selected_clients, msg=payload)
 

--- a/decent_bench/networks.py
+++ b/decent_bench/networks.py
@@ -37,11 +37,6 @@ class Network(ABC):  # noqa: B024
     Args:
         graph: underlying NetworkX graph defining the network topology.
             Nodes must be of type :class:`~decent_bench.agents.Agent`.
-        buffer_messages: whether to keep stored messages at the end of each iteration. If ``True``, messages
-            persist on the receiver until they are overwritten by a newer message from the same sender to the same
-            receiver. If ``False``, messages delivered to a receiver during iteration *k* are dropped when
-            the algorithm advances to iteration *k + 1*, so agents only see messages from the most recent
-            iteration.
         message_noise: noise scheme(s) to apply to messages sent by agents in the network. Can be a single
             :class:`~decent_bench.schemes.NoiseScheme` instance to apply the same scheme to all agents, a dictionary
             mapping each agent to its scheme, or ``None`` to apply no noise to any agent.
@@ -57,7 +52,6 @@ class Network(ABC):  # noqa: B024
     def __init__(
         self,
         graph: AgentGraph,
-        buffer_messages: bool = False,
         message_noise: NoiseScheme | dict[Agent, NoiseScheme] | None = None,
         message_compression: CompressionScheme | dict[Agent, CompressionScheme] | None = None,
         message_drop: DropScheme | dict[Agent, DropScheme] | None = None,
@@ -82,7 +76,6 @@ class Network(ABC):  # noqa: B024
         self._message_drop = self._initialize_message_schemes(message_drop, "drop", DropScheme, NoDrops)
         self._active_agents_cache: list[Agent] | None = None
         self._active_connected_agents_cache: dict[Agent, list[Agent]] = {}
-        self._buffer_messages = buffer_messages
         self._iteration = 0  # Current iteration, updated by the algorithm
 
     @staticmethod
@@ -309,12 +302,22 @@ class Network(ABC):  # noqa: B024
         self._active_agents_cache = None
         self._active_connected_agents_cache = {}
 
-        if self._buffer_messages:
-            return
+        self._clear_received_messages()
 
+    def _clear_received_messages(
+        self,
+        receivers: Sequence[Agent] | None = None,
+        senders: Sequence[Agent] | None = None,
+    ) -> None:
+        """Clear received messages, optionally scoped to specific receivers and senders."""
         # Use the _agents_cache to avoid overridden agents() in subclasses like FedNetwork
-        for agent in self._agents_cache:
-            agent._received_messages.clear()  # noqa: SLF001
+        receivers = self._agents_cache if receivers is None else receivers
+        for receiver in receivers:
+            if senders is None:
+                receiver._received_messages.clear()  # noqa: SLF001
+            else:
+                for sender in senders:
+                    receiver._received_messages.pop(sender, None)  # noqa: SLF001
 
 
 class P2PNetwork(Network):
@@ -329,11 +332,6 @@ class P2PNetwork(Network):
         agents: list of agents corresponding to the nodes in `graph` if `graph` is not a graph with
             :class:`~decent_bench.agents.Agent` nodes. The agents in the list are assigned in order to each node of the
             graph. This argument is ignored if `graph` is a graph with :class:`~decent_bench.agents.Agent` nodes.
-        buffer_messages: whether to keep stored messages at the end of each iteration. If ``True``, messages
-            persist on the receiver until they are overwritten by a newer message from the same sender to the same
-            receiver. If ``False``, messages delivered to a receiver during iteration *k* are dropped when
-            the algorithm advances to iteration *k + 1*, so agents only see messages from the most recent
-            iteration.
         message_noise: noise scheme(s) to apply to messages sent by agents in the network. Can be a single
             :class:`~decent_bench.schemes.NoiseScheme` instance to apply the same scheme to all agents, a dictionary
             mapping each agent to its scheme, or ``None`` to apply no noise to any agent.
@@ -351,7 +349,6 @@ class P2PNetwork(Network):
         graph: AnyGraph,
         agents: Sequence[Agent] | None = None,
         *,
-        buffer_messages: bool = False,
         message_noise: NoiseScheme | dict[Agent, NoiseScheme] | None = None,
         message_compression: CompressionScheme | dict[Agent, CompressionScheme] | None = None,
         message_drop: DropScheme | dict[Agent, DropScheme] | None = None,
@@ -359,7 +356,6 @@ class P2PNetwork(Network):
         if all(isinstance(node, Agent) for node in graph.nodes()):  # pass directly to super().__init__
             super().__init__(
                 graph=graph,
-                buffer_messages=buffer_messages,
                 message_noise=message_noise,
                 message_compression=message_compression,
                 message_drop=message_drop,
@@ -373,7 +369,6 @@ class P2PNetwork(Network):
             graph = nx.relabel_nodes(graph, agent_node_map)
             super().__init__(
                 graph=graph,
-                buffer_messages=buffer_messages,
                 message_noise=message_noise,
                 message_compression=message_compression,
                 message_drop=message_drop,
@@ -479,11 +474,6 @@ class FedNetwork(Network):
         clients: list of client agents in the network.
         server: server agent in the network. If ``None``, a default server with zero cost and always active scheme will
             be created. Custom servers must use :class:`~decent_bench.schemes.AlwaysActive`.
-        buffer_messages: whether to keep stored messages at the end of each iteration. If ``True``, messages
-            persist on the receiver until they are overwritten by a newer message from the same sender to the same
-            receiver. If ``False``, messages delivered to a receiver during iteration *k* are dropped when
-            the algorithm advances to iteration *k + 1*, so agents only see messages from the most recent
-            iteration.
         message_noise: noise scheme(s) to apply to messages sent by agents in the network. Can be a single
             :class:`~decent_bench.schemes.NoiseScheme` instance to apply the same scheme to all agents, a dictionary
             mapping each agent to its scheme, or ``None`` to apply no noise to any agent.
@@ -504,7 +494,6 @@ class FedNetwork(Network):
         self,
         clients: Sequence[Agent],
         server: Agent | None = None,
-        buffer_messages: bool = False,
         *,
         message_noise: NoiseScheme | dict[Agent, NoiseScheme] | None = None,
         message_compression: CompressionScheme | dict[Agent, CompressionScheme] | None = None,
@@ -535,7 +524,6 @@ class FedNetwork(Network):
 
         super().__init__(
             graph=graph,
-            buffer_messages=buffer_messages,
             message_noise=message_noise,
             message_compression=message_compression,
             message_drop=message_drop,

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -113,6 +113,17 @@
       url={https://arxiv.org/abs/2005.11418},
 }
 
+@misc{Alg_FedDyn,
+      title={Federated Learning Based on Dynamic Regularization},
+      author={Durmus Alp Emre Acar and Yue Zhao and Ramon Matas Navarro and Matthew Mattina and Paul N. Whatmough and Venkatesh Saligrama},
+      year={2021},
+      eprint={2111.04263},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      doi={10.48550/arXiv.2111.04263},
+      url={https://arxiv.org/abs/2111.04263},
+}
+
 @INPROCEEDINGS{Alg_Wang_1,
   author={Wang, Jing and Elia, Nicola},
   booktitle={2010 48th Annual Allerton Conference on Communication, Control, and Computing (Allerton)}, 

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -148,15 +148,16 @@
       url={https://arxiv.org/abs/1610.02132},
 }
 
-@misc{Alg_FedPD,
-      title={FedPD: A Federated Learning Framework with Optimal Rates and Adaptivity to Non-IID Data},
-      author={Xinwei Zhang and Mingyi Hong and Sairaj V. Dhople and Wotao Yin and Yang Liu},
-      year={2020},
-      eprint={2005.11418},
-      archivePrefix={arXiv},
-      primaryClass={cs.LG},
-      doi={10.48550/arXiv.2005.11418},
-      url={https://arxiv.org/abs/2005.11418},
+@ARTICLE{Alg_FedPD,
+  author={Zhang, Xinwei and Hong, Mingyi and Dhople, Sairaj and Yin, Wotao and Liu, Yang},
+  journal={IEEE Transactions on Signal Processing},
+  title={FedPD: A Federated Learning Framework With Adaptivity to Non-IID Data},
+  year={2021},
+  volume={69},
+  number={},
+  pages={6055-6070},
+  keywords={Signal processing algorithms;Distributed algorithms;Complexity theory;Servers;Computational modeling;Data models;Distributed databases;Distributed algorithms;machine learning algorithms;federated learning;data heterogeneity;convergence analysis},
+  doi={10.1109/TSP.2021.3115952}
 }
 
 @misc{Alg_FedDyn,

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -78,6 +78,17 @@
       url={https://arxiv.org/abs/2007.07481},
 }
 
+@misc{Alg_FedPD,
+      title={FedPD: A Federated Learning Framework with Optimal Rates and Adaptivity to Non-IID Data},
+      author={Xinwei Zhang and Mingyi Hong and Sairaj V. Dhople and Wotao Yin and Yang Liu},
+      year={2020},
+      eprint={2005.11418},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      doi={10.48550/arXiv.2005.11418},
+      url={https://arxiv.org/abs/2005.11418},
+}
+
 @INPROCEEDINGS{Alg_Wang_1,
   author={Wang, Jing and Elia, Nicola},
   booktitle={2010 48th Annual Allerton Conference on Communication, Control, and Computing (Allerton)}, 

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -127,6 +127,18 @@ The ``num_local_steps`` argument can be either a single integer for
 homogeneous local work or a per-client mapping for heterogeneous local step
 counts.
 
+:class:`~decent_bench.algorithms.federated.FedPD` implements the FedPD
+primal-dual update. Clients keep persistent local primal variables, dual
+variables, and centre candidates. Each round uses ``num_local_steps`` local
+gradient steps on the augmented Lagrangian, with ``step_size`` controlling the
+local learning rate and ``eta`` controlling the FedPD quadratic
+penalty/dual-update parameter. The ``skip_probability`` argument controls the
+paper's optional communication skipping: ``0`` aggregates every round and ``1``
+always keeps local centre candidates without server aggregation. Like
+``FedNova``, ``num_local_steps`` can be either a single integer or a per-client
+mapping. FedPD always uses all active clients; partial participation is not
+supported.
+
 Federated aggregation
 ^^^^^^^^^^^^^^^^^^^^^
 For the built-in federated algorithms, aggregation affects only how client
@@ -155,6 +167,12 @@ to the corresponding FedNova variants controlled by ``beta``, ``mu``, and
 ``gamma``. Plain FedNova matches FedAvg only when the participating clients use
 the same number of local steps and FedNova's and FedAvg both use data-proportional aggregation
 weights.
+
+:class:`~decent_bench.algorithms.federated.FedPD` aggregates received centre
+candidates uniformly when communication is not skipped. The synchronized centre
+is sent back through the network to all active clients only if at least one
+centre candidate was received; if the network drops that server message, the
+affected client keeps its local centre candidate.
 
 :class:`~decent_bench.algorithms.federated.Scaffold` matches the standard
 SCAFFOLD algorithm and always uses uniform averaging over the selected clients.

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -140,7 +140,9 @@ counts.
 :class:`~decent_bench.algorithms.federated.FedLT` implements Federated Local
 Training with cost-driven local gradients. Its ``local_solver`` option supports
 ``"gd"``, ``"nesterov"``, and ``"adam"`` local updates. Solver-specific
-hyperparameters are passed through ``solver_args``.
+hyperparameters are passed through ``solver_args``. If ``solver_args`` is omitted 
+or left empty, solver-specific defaults are used: ``"nesterov"`` uses ``momentum=0.9``, 
+``"adam"`` uses ``beta1=0.9``, ``beta2=0.999``, and ``epsilon=1e-8``, and ``"gd"`` uses no additional solver arguments.
 :class:`~decent_bench.costs.EmpiricalRiskCost` objects use their default
 mini-batch gradient behavior, so gradient-based local solvers use mini-batches,
 while generic :class:`~decent_bench.costs.Cost` objects use full gradients.

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -167,6 +167,12 @@ always keeps local centre candidates without server aggregation. Like
 mapping. FedPD always uses all active clients; partial participation is not
 supported.
 
+:class:`~decent_bench.algorithms.federated.FedDyn` implements Federated Dynamic
+Regularization. Clients keep a persistent dynamic state ``g`` and the server
+keeps an auxiliary vector ``h``. Selected clients run ``num_local_epochs`` local
+gradient steps on the dynamic-regularized local objective using ``step_size`` as
+the local learning rate and ``alpha`` as the regularization coefficient.
+
 Federated aggregation
 ^^^^^^^^^^^^^^^^^^^^^
 For the built-in federated algorithms, aggregation affects only how client
@@ -201,6 +207,13 @@ aggregation weights.
 
 :class:`~decent_bench.algorithms.federated.FedPD` aggregates received centre
 candidates uniformly when communication is not skipped.
+
+:class:`~decent_bench.algorithms.federated.FedDyn` averages the received
+selected-client models uniformly, so the local-model average is scaled by the
+number of received selected clients. The next server model also includes the
+FedDyn dynamic correction from the server auxiliary vector ``h``. The ``h``
+update uses only received client models and scales their model deltas by the
+total number of clients.
 
 :class:`~decent_bench.algorithms.federated.Scaffold` matches the standard
 SCAFFOLD algorithm and always uses uniform averaging over the selected clients.

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -139,7 +139,8 @@ counts.
 
 :class:`~decent_bench.algorithms.federated.FedLT` implements Federated Local
 Training with cost-driven local gradients. Its ``local_solver`` option supports
-``"gd"``, ``"accelerated"``, and ``"adam"`` local updates.
+``"gd"``, ``"nesterov"``, and ``"adam"`` local updates. Solver-specific
+hyperparameters are passed through ``solver_args``.
 :class:`~decent_bench.costs.EmpiricalRiskCost` objects use their default
 mini-batch gradient behavior, so gradient-based local solvers use mini-batches,
 while generic :class:`~decent_bench.costs.Cost` objects use full gradients.

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -138,12 +138,13 @@ homogeneous local work or a per-client mapping for heterogeneous local step
 counts.
 
 :class:`~decent_bench.algorithms.federated.FedLT` implements Federated Local
-Training with cost-driven local gradients and optional acceleration through
-``use_acceleration``. :class:`~decent_bench.costs.EmpiricalRiskCost` objects use
-their default mini-batch gradient behavior, so they behave as local SGD, while
-generic :class:`~decent_bench.costs.Cost` objects use full gradients and behave
-as local GD. Fed-LT compression and Fed-PLT-style noisy-message experiments are
-configured through :class:`~decent_bench.networks.FedNetwork`
+Training with cost-driven local gradients. Its ``local_solver`` option supports
+``"gd"``, ``"accelerated"``, and ``"adam"`` local updates.
+:class:`~decent_bench.costs.EmpiricalRiskCost` objects use their default
+mini-batch gradient behavior, so gradient-based local solvers use mini-batches,
+while generic :class:`~decent_bench.costs.Cost` objects use full gradients.
+Fed-LT compression and Fed-PLT-style noisy-message experiments are configured
+through :class:`~decent_bench.networks.FedNetwork`
 ``message_compression`` and ``message_noise`` schemes rather than algorithm
 arguments.
 

--- a/test/test_distributed_algorithms.py
+++ b/test/test_distributed_algorithms.py
@@ -7,6 +7,7 @@ from decent_bench.algorithms.federated import (
     FedAdam,
     FedAlgorithm,
     FedAvg,
+    FedDyn,
     FedLT,
     FedNova,
     FedPD,
@@ -75,6 +76,7 @@ all_fed_algs = pytest.mark.parametrize(
     ("algorithm_cls", "kwargs"),
     [
         (FedAvg, {"iterations": 10, "step_size": 0.1}),
+        (FedDyn, {"iterations": 10, "step_size": 0.1}),
         (FedLT, {"iterations": 10, "step_size": 0.1}),
         (FedProx, {"iterations": 10, "step_size": 0.1}),
         (FedAdagrad, {"iterations": 10, "step_size": 0.1}),

--- a/test/test_distributed_algorithms.py
+++ b/test/test_distributed_algorithms.py
@@ -2,7 +2,17 @@ import networkx as nx
 import pytest
 
 from decent_bench.agents import Agent
-from decent_bench.algorithms.federated import FedAdagrad, FedAdam, FedAlgorithm, FedAvg, FedProx, FedNova, FedYogi, Scaffold
+from decent_bench.algorithms.federated import (
+    FedAdagrad,
+    FedAdam,
+    FedAlgorithm,
+    FedAvg,
+    FedNova,
+    FedPD,
+    FedProx,
+    FedYogi,
+    Scaffold,
+)
 from decent_bench.algorithms.p2p import (
     ADMM,
     ATC,
@@ -67,6 +77,7 @@ all_fed_algs = pytest.mark.parametrize(
         (FedProx, {"iterations": 10, "step_size": 0.1}),
         (FedAdagrad, {"iterations": 10, "step_size": 0.1}),
         (FedNova, {"iterations": 10, "step_size": 0.1}),
+        (FedPD, {"iterations": 10, "step_size": 0.1}),
         (FedYogi, {"iterations": 10, "step_size": 0.1}),
         (FedAdam, {"iterations": 10, "step_size": 0.1}),
         (Scaffold, {"iterations": 10, "step_size": 0.1}),

--- a/test/test_feddyn.py
+++ b/test/test_feddyn.py
@@ -1,0 +1,195 @@
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+import pytest
+
+from decent_bench.agents import Agent
+from decent_bench.algorithms.federated import FedDyn
+from decent_bench.costs import Cost, ZeroCost
+from decent_bench.networks import FedNetwork
+from decent_bench.schemes import ClientSelectionScheme, DropScheme, NoDrops
+from decent_bench.utils.types import SupportedDevices, SupportedFrameworks
+
+
+class TrackingCost(Cost):
+    def __init__(self, gradient_value: float = 1.0):
+        self.gradient_kwargs: list[dict[str, Any]] = []
+        self._gradient = np.array([gradient_value], dtype=float)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return (1,)
+
+    @property
+    def framework(self) -> SupportedFrameworks:
+        return SupportedFrameworks.NUMPY
+
+    @property
+    def device(self) -> SupportedDevices:
+        return SupportedDevices.CPU
+
+    @property
+    def m_smooth(self) -> float:
+        return 0.0
+
+    @property
+    def m_cvx(self) -> float:
+        return 0.0
+
+    def function(self, x: np.ndarray, **kwargs: Any) -> float:
+        del x, kwargs
+        return 0.0
+
+    def gradient(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+        del x
+        self.gradient_kwargs.append(dict(kwargs))
+        return self._gradient.copy()
+
+    def hessian(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+        del x, kwargs
+        return np.zeros((1, 1), dtype=float)
+
+    def proximal(self, x: np.ndarray, rho: float, **kwargs: Any) -> np.ndarray:
+        del rho, kwargs
+        return x
+
+
+class DropOnCalls(DropScheme):
+    def __init__(self, dropped_calls: set[int]):
+        self._dropped_calls = dropped_calls
+        self._call_count = 0
+
+    def should_drop(self) -> bool:
+        self._call_count += 1
+        return self._call_count in self._dropped_calls
+
+
+class FirstClientSelection(ClientSelectionScheme):
+    def select(self, clients: Sequence[Agent], iteration: int) -> list[Agent]:
+        del iteration
+        return [clients[0]]
+
+
+def test_feddyn_initializes_server_and_client_dynamic_states() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedDyn(iterations=1, x0=np.array([2.0]))
+
+    algorithm.initialize(network)
+
+    np.testing.assert_allclose(network.server().x, np.array([2.0]))
+    np.testing.assert_allclose(network.server().aux_vars["h"], np.array([0.0]))
+    for client in clients:
+        np.testing.assert_allclose(client.x, np.array([2.0]))
+        np.testing.assert_allclose(client.aux_vars["g"], np.array([0.0]))
+
+
+def test_feddyn_one_round_update_follows_dynamic_regularization_formula() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedDyn(iterations=1, step_size=1.0, alpha=1.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(clients[0].x, np.array([-1.0]))
+    np.testing.assert_allclose(clients[1].x, np.array([-3.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["g"], np.array([1.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["g"], np.array([3.0]))
+    np.testing.assert_allclose(network.server().aux_vars["h"], np.array([2.0]))
+    np.testing.assert_allclose(network.server().x, np.array([-4.0]))
+
+
+def test_feddyn_uses_dynamic_state_in_later_local_updates() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedDyn(iterations=2, step_size=1.0, alpha=1.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+    network._step(1)  # noqa: SLF001
+    algorithm.step(network, 1)
+
+    np.testing.assert_allclose(clients[0].x, np.array([-4.0]))
+    np.testing.assert_allclose(clients[1].x, np.array([-4.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["g"], np.array([1.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["g"], np.array([3.0]))
+    np.testing.assert_allclose(network.server().aux_vars["h"], np.array([2.0]))
+    np.testing.assert_allclose(network.server().x, np.array([-6.0]))
+
+
+def test_feddyn_partial_participation_leaves_unselected_client_state_unchanged() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedDyn(iterations=1, step_size=1.0, alpha=1.0, selection_scheme=FirstClientSelection())
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(clients[0].x, np.array([-1.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["g"], np.array([1.0]))
+    np.testing.assert_allclose(clients[1].x, np.array([0.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["g"], np.array([0.0]))
+    np.testing.assert_allclose(network.server().aux_vars["h"], np.array([0.5]))
+    np.testing.assert_allclose(network.server().x, np.array([-1.5]))
+
+
+def test_feddyn_aggregate_uses_only_received_client_models() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedDyn(iterations=1, alpha=1.0)
+    algorithm.initialize(network)
+
+    network.send(sender=clients[0], receiver=network.server(), msg=np.array([2.0]))
+
+    algorithm.aggregate(network, clients)
+
+    np.testing.assert_allclose(network.server().aux_vars["h"], np.array([-1.0]))
+    np.testing.assert_allclose(network.server().x, np.array([3.0]))
+
+
+def test_feddyn_aggregate_keeps_server_state_when_no_models_are_received() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedDyn(iterations=1, alpha=1.0)
+    algorithm.initialize(network)
+    network.server().x = np.array([7.0])
+    network.server().aux_vars["h"] = np.array([4.0])
+
+    algorithm.aggregate(network, clients)
+
+    np.testing.assert_allclose(network.server().x, np.array([7.0]))
+    np.testing.assert_allclose(network.server().aux_vars["h"], np.array([4.0]))
+
+
+def test_feddyn_clients_without_server_broadcast_do_not_participate() -> None:
+    client = Agent(0, TrackingCost(1.0))
+    server = Agent(1, ZeroCost((1,)))
+    network = FedNetwork(clients=[client], server=server, message_drop={server: DropOnCalls({1}), client: NoDrops()})
+    algorithm = FedDyn(iterations=1, step_size=1.0, alpha=1.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(network.server().x, np.array([0.0]))
+    np.testing.assert_allclose(network.server().aux_vars["h"], np.array([0.0]))
+    np.testing.assert_allclose(client.x, np.array([0.0]))
+    np.testing.assert_allclose(client.aux_vars["g"], np.array([0.0]))
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_message"),
+    [
+        pytest.param({"step_size": 0.0}, "`step_size` must be positive", id="step-size-zero"),
+        pytest.param({"alpha": 0.0}, "`alpha` must be positive", id="alpha-zero"),
+        pytest.param({"num_local_epochs": 0}, "`num_local_epochs` must be positive", id="local-epochs-zero"),
+    ],
+)
+def test_feddyn_rejects_invalid_hyperparameters(kwargs: dict[str, float | int], expected_message: str) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        FedDyn(iterations=1, **kwargs)

--- a/test/test_federated_aggregation.py
+++ b/test/test_federated_aggregation.py
@@ -193,6 +193,37 @@ def test_buffered_stale_client_messages_are_not_aggregated(algorithm_cls: type, 
 @pytest.mark.parametrize(
     ("algorithm_cls", "kwargs"),
     [
+        pytest.param(FedAvg, {"iterations": 2, "step_size": 1.0}, id="fedavg"),
+        pytest.param(FedProx, {"iterations": 2, "step_size": 1.0}, id="fedprox"),
+    ],
+)
+def test_buffered_stale_server_broadcasts_do_not_make_clients_participate(
+    algorithm_cls: type, kwargs: dict[str, float | int]
+) -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    server = Agent(2, TrackingCost(0.0))
+    network = FedNetwork(
+        clients=clients,
+        server=server,
+        buffer_messages=True,
+        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
+    )
+    algorithm = algorithm_cls(**kwargs)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+    np.testing.assert_allclose(network.server().x, np.array([-2.0]))
+
+    network._step(1)  # noqa: SLF001
+    algorithm.step(network, 1)
+
+    np.testing.assert_allclose(network.server().x, np.array([-5.0]))
+
+
+@pytest.mark.parametrize(
+    ("algorithm_cls", "kwargs"),
+    [
         pytest.param(
             FedAdagrad,
             {"iterations": 1, "step_size": 1.0, "server_step_size": 1.0, "beta_1": 0.0, "tau": 1.0},
@@ -523,6 +554,66 @@ def test_fedopt_buffered_stale_client_messages_are_not_aggregated(
         server=server,
         buffer_messages=True,
         message_drop={server: NoDrops(), clients[0]: DropOnCalls({2}), clients[1]: NoDrops()},
+    )
+    algorithm = algorithm_cls(**kwargs)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    network._step(1)  # noqa: SLF001
+    algorithm.step(network, 1)
+
+    np.testing.assert_allclose(network.server().x, np.array([expected_x]))
+
+
+@pytest.mark.parametrize(
+    ("algorithm_cls", "kwargs", "expected_x"),
+    [
+        pytest.param(
+            FedAdagrad,
+            {"iterations": 2, "step_size": 1.0, "server_step_size": 1.0, "beta_1": 0.0, "tau": 1.0},
+            -0.6666666666666666 + (-3.0 / (np.sqrt(13.0) + 1.0)),
+            id="fedadagrad",
+        ),
+        pytest.param(
+            FedYogi,
+            {
+                "iterations": 2,
+                "step_size": 1.0,
+                "server_step_size": 1.0,
+                "beta_1": 0.0,
+                "beta_2": 0.25,
+                "tau": 1.0,
+            },
+            (-2.0 / (np.sqrt(3.0) + 1.0)) + (-3.0 / (np.sqrt(9.75) + 1.0)),
+            id="fedyogi",
+        ),
+        pytest.param(
+            FedAdam,
+            {
+                "iterations": 2,
+                "step_size": 1.0,
+                "server_step_size": 1.0,
+                "beta_1": 0.0,
+                "beta_2": 0.25,
+                "tau": 1.0,
+            },
+            (-2.0 / (np.sqrt(3.0) + 1.0)) + (-3.0 / (np.sqrt(7.5) + 1.0)),
+            id="fedadam",
+        ),
+    ],
+)
+def test_fedopt_buffered_stale_server_broadcasts_do_not_make_clients_participate(
+    algorithm_cls: type, kwargs: dict[str, float | int], expected_x: float
+) -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    server = Agent(2, TrackingCost(0.0))
+    network = FedNetwork(
+        clients=clients,
+        server=server,
+        buffer_messages=True,
+        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
     )
     algorithm = algorithm_cls(**kwargs)
     algorithm.initialize(network)

--- a/test/test_federated_aggregation.py
+++ b/test/test_federated_aggregation.py
@@ -164,66 +164,6 @@ def test_clients_without_server_broadcast_do_not_participate(
 @pytest.mark.parametrize(
     ("algorithm_cls", "kwargs"),
     [
-        pytest.param(FedAvg, {"iterations": 2, "step_size": 1.0}, id="fedavg"),
-        pytest.param(FedProx, {"iterations": 2, "step_size": 1.0}, id="fedprox"),
-    ],
-)
-def test_buffered_stale_client_messages_are_not_aggregated(algorithm_cls: type, kwargs: dict[str, float | int]) -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, TrackingCost(0.0))
-    network = FedNetwork(
-        clients=clients,
-        server=server,
-        buffer_messages=True,
-        message_drop={server: NoDrops(), clients[0]: DropOnCalls({2}), clients[1]: NoDrops()},
-    )
-    algorithm = algorithm_cls(**kwargs)
-    algorithm.initialize(network)
-
-    network._step(0)  # noqa: SLF001
-    algorithm.step(network, 0)
-    np.testing.assert_allclose(network.server().x, np.array([-2.0]))
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([-5.0]))
-
-
-@pytest.mark.parametrize(
-    ("algorithm_cls", "kwargs"),
-    [
-        pytest.param(FedAvg, {"iterations": 2, "step_size": 1.0}, id="fedavg"),
-        pytest.param(FedProx, {"iterations": 2, "step_size": 1.0}, id="fedprox"),
-    ],
-)
-def test_buffered_stale_server_broadcasts_do_not_make_clients_participate(
-    algorithm_cls: type, kwargs: dict[str, float | int]
-) -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, TrackingCost(0.0))
-    network = FedNetwork(
-        clients=clients,
-        server=server,
-        buffer_messages=True,
-        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
-    )
-    algorithm = algorithm_cls(**kwargs)
-    algorithm.initialize(network)
-
-    network._step(0)  # noqa: SLF001
-    algorithm.step(network, 0)
-    np.testing.assert_allclose(network.server().x, np.array([-2.0]))
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([-5.0]))
-
-
-@pytest.mark.parametrize(
-    ("algorithm_cls", "kwargs"),
-    [
         pytest.param(
             FedAdagrad,
             {"iterations": 1, "step_size": 1.0, "server_step_size": 1.0, "beta_1": 0.0, "tau": 1.0},
@@ -508,126 +448,6 @@ def test_fedopt_clients_without_server_broadcast_do_not_participate(
 
 
 @pytest.mark.parametrize(
-    ("algorithm_cls", "kwargs", "expected_x"),
-    [
-        pytest.param(
-            FedAdagrad,
-            {"iterations": 2, "step_size": 1.0, "server_step_size": 1.0, "beta_1": 0.0, "tau": 1.0},
-            -0.6666666666666666 + (-3.0 / (np.sqrt(13.0) + 1.0)),
-            id="fedadagrad",
-        ),
-        pytest.param(
-            FedYogi,
-            {
-                "iterations": 2,
-                "step_size": 1.0,
-                "server_step_size": 1.0,
-                "beta_1": 0.0,
-                "beta_2": 0.25,
-                "tau": 1.0,
-            },
-            (-2.0 / (np.sqrt(3.0) + 1.0)) + (-3.0 / (np.sqrt(9.75) + 1.0)),
-            id="fedyogi",
-        ),
-        pytest.param(
-            FedAdam,
-            {
-                "iterations": 2,
-                "step_size": 1.0,
-                "server_step_size": 1.0,
-                "beta_1": 0.0,
-                "beta_2": 0.25,
-                "tau": 1.0,
-            },
-            (-2.0 / (np.sqrt(3.0) + 1.0)) + (-3.0 / (np.sqrt(7.5) + 1.0)),
-            id="fedadam",
-        ),
-    ],
-)
-def test_fedopt_buffered_stale_client_messages_are_not_aggregated(
-    algorithm_cls: type, kwargs: dict[str, float | int], expected_x: float
-) -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, TrackingCost(0.0))
-    network = FedNetwork(
-        clients=clients,
-        server=server,
-        buffer_messages=True,
-        message_drop={server: NoDrops(), clients[0]: DropOnCalls({2}), clients[1]: NoDrops()},
-    )
-    algorithm = algorithm_cls(**kwargs)
-    algorithm.initialize(network)
-
-    network._step(0)  # noqa: SLF001
-    algorithm.step(network, 0)
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([expected_x]))
-
-
-@pytest.mark.parametrize(
-    ("algorithm_cls", "kwargs", "expected_x"),
-    [
-        pytest.param(
-            FedAdagrad,
-            {"iterations": 2, "step_size": 1.0, "server_step_size": 1.0, "beta_1": 0.0, "tau": 1.0},
-            -0.6666666666666666 + (-3.0 / (np.sqrt(13.0) + 1.0)),
-            id="fedadagrad",
-        ),
-        pytest.param(
-            FedYogi,
-            {
-                "iterations": 2,
-                "step_size": 1.0,
-                "server_step_size": 1.0,
-                "beta_1": 0.0,
-                "beta_2": 0.25,
-                "tau": 1.0,
-            },
-            (-2.0 / (np.sqrt(3.0) + 1.0)) + (-3.0 / (np.sqrt(9.75) + 1.0)),
-            id="fedyogi",
-        ),
-        pytest.param(
-            FedAdam,
-            {
-                "iterations": 2,
-                "step_size": 1.0,
-                "server_step_size": 1.0,
-                "beta_1": 0.0,
-                "beta_2": 0.25,
-                "tau": 1.0,
-            },
-            (-2.0 / (np.sqrt(3.0) + 1.0)) + (-3.0 / (np.sqrt(7.5) + 1.0)),
-            id="fedadam",
-        ),
-    ],
-)
-def test_fedopt_buffered_stale_server_broadcasts_do_not_make_clients_participate(
-    algorithm_cls: type, kwargs: dict[str, float | int], expected_x: float
-) -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, TrackingCost(0.0))
-    network = FedNetwork(
-        clients=clients,
-        server=server,
-        buffer_messages=True,
-        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
-    )
-    algorithm = algorithm_cls(**kwargs)
-    algorithm.initialize(network)
-
-    network._step(0)  # noqa: SLF001
-    algorithm.step(network, 0)
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([expected_x]))
-
-
-@pytest.mark.parametrize(
     ("algorithm_cls", "kwargs"),
     [
         pytest.param(FedAdagrad, {"iterations": 1, "step_size": 1.0}, id="fedadagrad"),
@@ -644,7 +464,6 @@ def test_fedopt_local_uploads_are_model_deltas(algorithm_cls: type, kwargs: dict
     selected_clients = network.clients()
     algorithm.server_broadcast(network, selected_clients)
     participating_clients = algorithm._clients_with_server_broadcast(network, selected_clients)
-    algorithm._clear_buffered_server_messages(network, participating_clients)
     algorithm._run_local_updates(network, participating_clients)
 
     np.testing.assert_allclose(network.server().messages[clients[0]], np.array([-1.0]))

--- a/test/test_federated_cost_routing.py
+++ b/test/test_federated_cost_routing.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from decent_bench.agents import Agent
-from decent_bench.algorithms.federated import FedAdagrad, FedAdam, FedAvg, FedPD, FedProx, FedYogi, Scaffold
+from decent_bench.algorithms.federated import FedAdagrad, FedAdam, FedAvg, FedDyn, FedPD, FedProx, FedYogi, Scaffold
 from decent_bench.costs import BaseRegularizerCost, Cost, EmpiricalRiskCost, ZeroCost
 from decent_bench.utils.types import (
     Dataset,
@@ -193,6 +193,8 @@ def _run_federated_local_update(
         algorithm = FedAdam(iterations=1, step_size=step_size, num_local_epochs=num_local_epochs)
     elif algorithm_name == "fedprox":
         algorithm = FedProx(iterations=1, step_size=step_size, num_local_epochs=num_local_epochs, mu=mu)
+    elif algorithm_name == "feddyn":
+        algorithm = FedDyn(iterations=1, step_size=step_size, alpha=1.0, num_local_epochs=num_local_epochs)
     elif algorithm_name == "fedpd":
         algorithm = FedPD(iterations=1, step_size=step_size, eta=1.0, num_local_steps=num_local_epochs)
     elif algorithm_name == "scaffold":
@@ -203,6 +205,8 @@ def _run_federated_local_update(
     aux_vars = None
     if isinstance(algorithm, Scaffold):
         aux_vars = {"c_i": np.zeros(cost.shape, dtype=float)}
+    elif isinstance(algorithm, FedDyn):
+        aux_vars = {"g": np.zeros(cost.shape, dtype=float)}
     elif isinstance(algorithm, FedPD):
         aux_vars = {
             "lambda": np.zeros(cost.shape, dtype=float),
@@ -218,11 +222,12 @@ def _run_federated_local_update(
         client._received_messages[server] = np.zeros(cost.shape, dtype=float)  # noqa: SLF001
     if isinstance(algorithm, FedPD):
         algorithm._num_local_steps_by_client = {client: num_local_epochs}  # noqa: SLF001
-    local_update = (
-        algorithm._compute_local_update(client)
-        if isinstance(algorithm, FedPD)
-        else algorithm._compute_local_update(client, server)
-    )
+    if isinstance(algorithm, FedPD):
+        local_update = algorithm._compute_local_update(client)
+    elif isinstance(algorithm, FedDyn):
+        local_update = algorithm._compute_local_update(client, client.messages[server])
+    else:
+        local_update = algorithm._compute_local_update(client, server)
     if isinstance(algorithm, Scaffold):
         return local_update[0]
     return local_update
@@ -236,6 +241,7 @@ def _run_federated_local_update(
         pytest.param("fedyogi", -3.0, id="fedyogi"),
         pytest.param("fedadam", -3.0, id="fedadam"),
         pytest.param("fedprox", -1.75, id="fedprox"),
+        pytest.param("feddyn", -1.0, id="feddyn"),
         pytest.param("fedpd", -1.0, id="fedpd"),
         pytest.param("scaffold", -3.0, id="scaffold"),
     ],
@@ -259,6 +265,7 @@ def test_empirical_costs_use_minibatch_local_updates(algorithm_name: str, expect
         pytest.param("fedyogi", -3.0, id="fedyogi"),
         pytest.param("fedadam", -3.0, id="fedadam"),
         pytest.param("fedprox", -1.75, id="fedprox"),
+        pytest.param("feddyn", -1.0, id="feddyn"),
         pytest.param("fedpd", -1.0, id="fedpd"),
         pytest.param("scaffold", -3.0, id="scaffold"),
     ],
@@ -288,6 +295,7 @@ def test_empirical_regularized_costs_keep_minibatch_local_updates(algorithm_name
         pytest.param("fedyogi", -6.0, id="fedyogi"),
         pytest.param("fedadam", -6.0, id="fedadam"),
         pytest.param("fedprox", -3.5, id="fedprox"),
+        pytest.param("feddyn", -2.0, id="feddyn"),
         pytest.param("fedpd", -2.0, id="fedpd"),
         pytest.param("scaffold", -6.0, id="scaffold"),
     ],
@@ -314,6 +322,7 @@ def test_scaled_empirical_costs_keep_minibatch_local_updates(algorithm_name: str
         pytest.param("fedyogi", -3.0, id="fedyogi"),
         pytest.param("fedadam", -3.0, id="fedadam"),
         pytest.param("fedprox", -1.75, id="fedprox"),
+        pytest.param("feddyn", -1.0, id="feddyn"),
         pytest.param("fedpd", -1.0, id="fedpd"),
         pytest.param("scaffold", -3.0, id="scaffold"),
     ],
@@ -328,7 +337,9 @@ def test_plain_costs_use_full_gradient_local_updates(algorithm_name: str, expect
     assert all(kwargs == {} for kwargs in cost.gradient_kwargs)
 
 
-@pytest.mark.parametrize("algorithm_name", ["fedavg", "fedadagrad", "fedyogi", "fedadam", "fedpd", "scaffold"])
+@pytest.mark.parametrize(
+    "algorithm_name", ["fedavg", "fedadagrad", "fedyogi", "fedadam", "feddyn", "fedpd", "scaffold"]
+)
 def test_sum_costs_over_non_empirical_terms_use_full_gradient_local_updates(algorithm_name: str) -> None:
     cost_a = TrackingCost(gradient_value=1.0)
     cost_b = TrackingCost(gradient_value=2.0)
@@ -336,7 +347,7 @@ def test_sum_costs_over_non_empirical_terms_use_full_gradient_local_updates(algo
 
     updated = _run_federated_local_update(algorithm_name, objective, num_local_epochs=2)
 
-    expected = -3.0 if algorithm_name == "fedpd" else -6.0
+    expected = -3.0 if algorithm_name in {"feddyn", "fedpd"} else -6.0
     np.testing.assert_allclose(updated, np.array([expected]))
     assert len(cost_a.gradient_kwargs) == 2
     assert len(cost_b.gradient_kwargs) == 2
@@ -352,6 +363,7 @@ def test_sum_costs_over_non_empirical_terms_use_full_gradient_local_updates(algo
         pytest.param("fedyogi", -4.0, 2, id="fedyogi"),
         pytest.param("fedadam", -4.0, 2, id="fedadam"),
         pytest.param("fedprox", -3.5, 3, id="fedprox"),
+        pytest.param("feddyn", -2.0, 2, id="feddyn"),
         pytest.param("fedpd", -2.0, 2, id="fedpd"),
         pytest.param("scaffold", -4.0, 2, id="scaffold"),
     ],
@@ -377,6 +389,7 @@ def test_scaled_costs_over_non_empirical_terms_use_full_gradient_local_updates(
         pytest.param("fedyogi", -2.0, 2, id="fedyogi"),
         pytest.param("fedadam", -2.0, 2, id="fedadam"),
         pytest.param("fedprox", -1.75, 3, id="fedprox"),
+        pytest.param("feddyn", -1.0, 2, id="feddyn"),
         pytest.param("fedpd", -1.0, 2, id="fedpd"),
         pytest.param("scaffold", -2.0, 2, id="scaffold"),
     ],
@@ -393,7 +406,9 @@ def test_regularizers_follow_the_non_batched_local_update_path(
     assert all(kwargs == {} for kwargs in regularizer.gradient_kwargs)
 
 
-@pytest.mark.parametrize("algorithm_name", ["fedavg", "fedadagrad", "fedyogi", "fedadam", "fedpd", "scaffold"])
+@pytest.mark.parametrize(
+    "algorithm_name", ["fedavg", "fedadagrad", "fedyogi", "fedadam", "feddyn", "fedpd", "scaffold"]
+)
 def test_zero_costs_do_not_need_special_local_update_handling(algorithm_name: str) -> None:
     cost = TrackingZeroCost()
 

--- a/test/test_federated_cost_routing.py
+++ b/test/test_federated_cost_routing.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from decent_bench.agents import Agent
-from decent_bench.algorithms.federated import FedAdagrad, FedAdam, FedAvg, FedProx, FedYogi, Scaffold
+from decent_bench.algorithms.federated import FedAdagrad, FedAdam, FedAvg, FedPD, FedProx, FedYogi, Scaffold
 from decent_bench.costs import BaseRegularizerCost, Cost, EmpiricalRiskCost, ZeroCost
 from decent_bench.utils.types import (
     Dataset,
@@ -193,6 +193,8 @@ def _run_federated_local_update(
         algorithm = FedAdam(iterations=1, step_size=step_size, num_local_epochs=num_local_epochs)
     elif algorithm_name == "fedprox":
         algorithm = FedProx(iterations=1, step_size=step_size, num_local_epochs=num_local_epochs, mu=mu)
+    elif algorithm_name == "fedpd":
+        algorithm = FedPD(iterations=1, step_size=step_size, eta=1.0, num_local_steps=num_local_epochs)
     elif algorithm_name == "scaffold":
         algorithm = Scaffold(iterations=1, step_size=step_size, num_local_epochs=num_local_epochs)
     else:
@@ -201,15 +203,26 @@ def _run_federated_local_update(
     aux_vars = None
     if isinstance(algorithm, Scaffold):
         aux_vars = {"c_i": np.zeros(cost.shape, dtype=float)}
+    elif isinstance(algorithm, FedPD):
+        aux_vars = {
+            "lambda": np.zeros(cost.shape, dtype=float),
+            "center": np.zeros(cost.shape, dtype=float),
+        }
     client.initialize(x=np.zeros(cost.shape, dtype=float), aux_vars=aux_vars)
     server.initialize(x=np.zeros(cost.shape, dtype=float))
     if isinstance(algorithm, Scaffold):
         client._received_messages[server] = np.stack(  # noqa: SLF001
             [np.zeros(cost.shape, dtype=float), np.zeros(cost.shape, dtype=float)]
         )
-    else:
+    elif not isinstance(algorithm, FedPD):
         client._received_messages[server] = np.zeros(cost.shape, dtype=float)  # noqa: SLF001
-    local_update = algorithm._compute_local_update(client, server)
+    if isinstance(algorithm, FedPD):
+        algorithm._num_local_steps_by_client = {client: num_local_epochs}  # noqa: SLF001
+    local_update = (
+        algorithm._compute_local_update(client)
+        if isinstance(algorithm, FedPD)
+        else algorithm._compute_local_update(client, server)
+    )
     if isinstance(algorithm, Scaffold):
         return local_update[0]
     return local_update
@@ -223,6 +236,7 @@ def _run_federated_local_update(
         pytest.param("fedyogi", -3.0, id="fedyogi"),
         pytest.param("fedadam", -3.0, id="fedadam"),
         pytest.param("fedprox", -1.75, id="fedprox"),
+        pytest.param("fedpd", -1.0, id="fedpd"),
         pytest.param("scaffold", -3.0, id="scaffold"),
     ],
 )
@@ -245,6 +259,7 @@ def test_empirical_costs_use_minibatch_local_updates(algorithm_name: str, expect
         pytest.param("fedyogi", -3.0, id="fedyogi"),
         pytest.param("fedadam", -3.0, id="fedadam"),
         pytest.param("fedprox", -1.75, id="fedprox"),
+        pytest.param("fedpd", -1.0, id="fedpd"),
         pytest.param("scaffold", -3.0, id="scaffold"),
     ],
 )
@@ -273,6 +288,7 @@ def test_empirical_regularized_costs_keep_minibatch_local_updates(algorithm_name
         pytest.param("fedyogi", -6.0, id="fedyogi"),
         pytest.param("fedadam", -6.0, id="fedadam"),
         pytest.param("fedprox", -3.5, id="fedprox"),
+        pytest.param("fedpd", -2.0, id="fedpd"),
         pytest.param("scaffold", -6.0, id="scaffold"),
     ],
 )
@@ -298,6 +314,7 @@ def test_scaled_empirical_costs_keep_minibatch_local_updates(algorithm_name: str
         pytest.param("fedyogi", -3.0, id="fedyogi"),
         pytest.param("fedadam", -3.0, id="fedadam"),
         pytest.param("fedprox", -1.75, id="fedprox"),
+        pytest.param("fedpd", -1.0, id="fedpd"),
         pytest.param("scaffold", -3.0, id="scaffold"),
     ],
 )
@@ -311,7 +328,7 @@ def test_plain_costs_use_full_gradient_local_updates(algorithm_name: str, expect
     assert all(kwargs == {} for kwargs in cost.gradient_kwargs)
 
 
-@pytest.mark.parametrize("algorithm_name", ["fedavg", "fedadagrad", "fedyogi", "fedadam", "scaffold"])
+@pytest.mark.parametrize("algorithm_name", ["fedavg", "fedadagrad", "fedyogi", "fedadam", "fedpd", "scaffold"])
 def test_sum_costs_over_non_empirical_terms_use_full_gradient_local_updates(algorithm_name: str) -> None:
     cost_a = TrackingCost(gradient_value=1.0)
     cost_b = TrackingCost(gradient_value=2.0)
@@ -319,7 +336,8 @@ def test_sum_costs_over_non_empirical_terms_use_full_gradient_local_updates(algo
 
     updated = _run_federated_local_update(algorithm_name, objective, num_local_epochs=2)
 
-    np.testing.assert_allclose(updated, np.array([-6.0]))
+    expected = -3.0 if algorithm_name == "fedpd" else -6.0
+    np.testing.assert_allclose(updated, np.array([expected]))
     assert len(cost_a.gradient_kwargs) == 2
     assert len(cost_b.gradient_kwargs) == 2
     assert all(kwargs == {} for kwargs in cost_a.gradient_kwargs)
@@ -334,6 +352,7 @@ def test_sum_costs_over_non_empirical_terms_use_full_gradient_local_updates(algo
         pytest.param("fedyogi", -4.0, 2, id="fedyogi"),
         pytest.param("fedadam", -4.0, 2, id="fedadam"),
         pytest.param("fedprox", -3.5, 3, id="fedprox"),
+        pytest.param("fedpd", -2.0, 2, id="fedpd"),
         pytest.param("scaffold", -4.0, 2, id="scaffold"),
     ],
 )
@@ -358,6 +377,7 @@ def test_scaled_costs_over_non_empirical_terms_use_full_gradient_local_updates(
         pytest.param("fedyogi", -2.0, 2, id="fedyogi"),
         pytest.param("fedadam", -2.0, 2, id="fedadam"),
         pytest.param("fedprox", -1.75, 3, id="fedprox"),
+        pytest.param("fedpd", -1.0, 2, id="fedpd"),
         pytest.param("scaffold", -2.0, 2, id="scaffold"),
     ],
 )
@@ -373,7 +393,7 @@ def test_regularizers_follow_the_non_batched_local_update_path(
     assert all(kwargs == {} for kwargs in regularizer.gradient_kwargs)
 
 
-@pytest.mark.parametrize("algorithm_name", ["fedavg", "fedadagrad", "fedyogi", "fedadam", "scaffold"])
+@pytest.mark.parametrize("algorithm_name", ["fedavg", "fedadagrad", "fedyogi", "fedadam", "fedpd", "scaffold"])
 def test_zero_costs_do_not_need_special_local_update_handling(algorithm_name: str) -> None:
     cost = TrackingZeroCost()
 

--- a/test/test_fedlt.py
+++ b/test/test_fedlt.py
@@ -5,10 +5,10 @@ import numpy as np
 import pytest
 
 from decent_bench.agents import Agent
-from decent_bench.costs import Cost, EmpiricalRiskCost, L1RegularizerCost, QuadraticCost, ZeroCost
 from decent_bench.algorithms.federated import FedLT
+from decent_bench.costs import Cost, EmpiricalRiskCost, L1RegularizerCost, QuadraticCost, ZeroCost
 from decent_bench.networks import FedNetwork
-from decent_bench.schemes import ClientSelectionScheme, GaussianNoise, Quantization
+from decent_bench.schemes import ClientSelectionScheme, DropScheme, GaussianNoise, NoDrops, Quantization
 from decent_bench.utils.types import (
     Dataset,
     EmpiricalRiskIndices,
@@ -159,6 +159,16 @@ class FirstClientSelection(ClientSelectionScheme):
         return [clients[0]]
 
 
+class DropOnCalls(DropScheme):
+    def __init__(self, dropped_calls: set[int]):
+        self._dropped_calls = dropped_calls
+        self._call_count = 0
+
+    def should_drop(self) -> bool:
+        self._call_count += 1
+        return self._call_count in self._dropped_calls
+
+
 def _make_network(*costs: Cost) -> FedNetwork:
     return FedNetwork(clients=[Agent(i, cost) for i, cost in enumerate(costs)])
 
@@ -303,6 +313,31 @@ def test_fedlt_supports_partial_participation_and_keeps_stale_server_z() -> None
     np.testing.assert_allclose(clients[1].x, np.array([0.0]))
     np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[0]], np.array([-2.0]))
     np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[1]], np.array([0.0]))
+
+
+def test_fedlt_ignores_buffered_stale_server_broadcasts() -> None:
+    clients = [Agent(0, ConstantGradientCost(1.0)), Agent(1, ConstantGradientCost(3.0))]
+    server = Agent(2, ZeroCost((1,)))
+    network = FedNetwork(
+        clients=clients,
+        server=server,
+        buffer_messages=True,
+        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
+    )
+    algorithm = FedLT(iterations=2, step_size=1.0, num_local_epochs=1, rho=1.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+    np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[0]], np.array([-2.0]))
+    np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[1]], np.array([-6.0]))
+
+    network._step(1)  # noqa: SLF001
+    algorithm.step(network, 1)
+
+    np.testing.assert_allclose(network.server().x, np.array([-4.0]))
+    np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[0]], np.array([-2.0]))
+    np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[1]], np.array([-8.0]))
 
 
 def test_fedlt_smoke_with_network_noise_and_compression() -> None:

--- a/test/test_fedlt.py
+++ b/test/test_fedlt.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+import math
 from typing import Any
 
 import numpy as np
@@ -173,13 +174,26 @@ def _make_network(*costs: Cost) -> FedNetwork:
     return FedNetwork(clients=[Agent(i, cost) for i, cost in enumerate(costs)])
 
 
-@pytest.mark.parametrize("use_acceleration", [False, True])
-def test_fedlt_runs_with_default_and_accelerated_local_updates(use_acceleration: bool) -> None:
+@pytest.mark.parametrize("local_solver", ["gd", "accelerated"])
+def test_fedlt_runs_with_default_and_accelerated_local_updates(local_solver: str) -> None:
     network = _make_network(
         QuadraticCost(A=np.array([[1.0]]), b=np.array([-1.0])),
         QuadraticCost(A=np.array([[2.0]]), b=np.array([1.0])),
     )
-    algorithm = FedLT(iterations=3, step_size=0.2, num_local_epochs=2, rho=1.0, use_acceleration=use_acceleration)
+    algorithm = FedLT(iterations=3, step_size=0.2, num_local_epochs=2, rho=1.0, local_solver=local_solver)
+
+    algorithm.run(network)
+
+    assert np.isfinite(network.server().x).all()
+    assert all(np.isfinite(client.x).all() for client in network.clients())
+
+
+def test_fedlt_accepts_adam_local_solver() -> None:
+    network = _make_network(
+        QuadraticCost(A=np.array([[1.0]]), b=np.array([-1.0])),
+        QuadraticCost(A=np.array([[2.0]]), b=np.array([1.0])),
+    )
+    algorithm = FedLT(iterations=3, step_size=0.2, num_local_epochs=2, rho=1.0, local_solver="adam")
 
     algorithm.run(network)
 
@@ -193,9 +207,15 @@ def test_fedlt_runs_with_default_and_accelerated_local_updates(use_acceleration:
         ({"rho": 0.0}, "`rho` must be positive"),
         ({"num_local_epochs": 0}, "`num_local_epochs` must be positive"),
         ({"step_size": 0.0}, "`step_size` must be positive"),
+        ({"local_solver": "bad"}, "`local_solver` must be one of"),
+        ({"adam_beta1": -0.1}, "`adam_beta1` must satisfy 0 <= adam_beta1 < 1"),
+        ({"adam_beta1": 1.0}, "`adam_beta1` must satisfy 0 <= adam_beta1 < 1"),
+        ({"adam_beta2": -0.1}, "`adam_beta2` must satisfy 0 <= adam_beta2 < 1"),
+        ({"adam_beta2": 1.0}, "`adam_beta2` must satisfy 0 <= adam_beta2 < 1"),
+        ({"adam_epsilon": 0.0}, "`adam_epsilon` must be positive"),
     ],
 )
-def test_fedlt_rejects_invalid_parameters(kwargs: dict[str, float | int], error: str) -> None:
+def test_fedlt_rejects_invalid_parameters(kwargs: dict[str, float | int | str], error: str) -> None:
     with pytest.raises(ValueError, match=error):
         FedLT(iterations=1, **kwargs)
 
@@ -216,7 +236,7 @@ def test_fedlt_initializes_auxiliary_variables_from_z0() -> None:
 
 def test_fedlt_accelerated_solver_requires_valid_client_constants() -> None:
     network = _make_network(ConstantGradientCost(m_smooth=np.inf, m_cvx=0.0))
-    algorithm = FedLT(iterations=1, use_acceleration=True)
+    algorithm = FedLT(iterations=1, local_solver="accelerated")
 
     with pytest.raises(ValueError, match="requires finite non-negative"):
         algorithm.initialize(network)
@@ -234,6 +254,93 @@ def test_fedlt_local_gradient_step_uses_penalty_term() -> None:
 
     np.testing.assert_allclose(local_x, np.array([-1.0]))
     np.testing.assert_allclose(z_next, np.array([-2.0]))
+
+
+def test_fedlt_adam_one_step_matches_formula() -> None:
+    client = Agent(0, ConstantGradientCost(gradient_value=2.0))
+    server = Agent(1, ZeroCost((1,)))
+    algorithm = FedLT(iterations=1, step_size=0.5, num_local_epochs=1, rho=1.0, local_solver="adam")
+    client.initialize(x=np.array([0.0]), aux_vars={"z": np.array([0.0])})
+    server.initialize(x=np.array([0.0]))
+    client._received_messages[server] = np.array([0.0])  # noqa: SLF001
+
+    local_x, z_next = algorithm._compute_local_update(client, server)
+
+    expected_x = np.array([-0.5 * 2.0 / (math.sqrt(4.0) + algorithm.adam_epsilon)])
+    np.testing.assert_allclose(local_x, expected_x)
+    np.testing.assert_allclose(z_next, 2 * expected_x)
+
+
+def _manual_adam_steps(
+    *,
+    x0: float,
+    step_size: float,
+    beta1: float,
+    beta2: float,
+    epsilon: float,
+    num_steps: int,
+) -> float:
+    x = x0
+    m = 0.0
+    v = 0.0
+    for step in range(1, num_steps + 1):
+        grad = 2 * x
+        m = (beta1 * m) + ((1 - beta1) * grad)
+        v = (beta2 * v) + ((1 - beta2) * (grad * grad))
+        m_hat = m / (1 - (beta1**step))
+        v_hat = v / (1 - (beta2**step))
+        x -= step_size * m_hat / (math.sqrt(v_hat) + epsilon)
+    return x
+
+
+def test_fedlt_adam_multi_step_matches_formula_on_quadratic() -> None:
+    client = Agent(0, QuadraticCost(A=np.array([[1.0]]), b=np.array([0.0])))
+    server = Agent(1, ZeroCost((1,)))
+    algorithm = FedLT(
+        iterations=1,
+        step_size=0.1,
+        num_local_epochs=3,
+        rho=1.0,
+        local_solver="adam",
+        adam_beta1=0.8,
+        adam_beta2=0.9,
+        adam_epsilon=1e-6,
+    )
+    client.initialize(x=np.array([1.0]), aux_vars={"z": np.array([0.0])})
+    server.initialize(x=np.array([0.0]))
+    client._received_messages[server] = np.array([0.0])  # noqa: SLF001
+
+    local_x, z_next = algorithm._compute_local_update(client, server)
+
+    expected_x = _manual_adam_steps(
+        x0=1.0,
+        step_size=algorithm.step_size,
+        beta1=algorithm.adam_beta1,
+        beta2=algorithm.adam_beta2,
+        epsilon=algorithm.adam_epsilon,
+        num_steps=algorithm.num_local_epochs,
+    )
+    np.testing.assert_allclose(local_x, np.array([expected_x]))
+    np.testing.assert_allclose(z_next, np.array([2 * expected_x]))
+
+
+def test_fedlt_adam_moments_reset_each_local_solve() -> None:
+    client = Agent(0, QuadraticCost(A=np.array([[1.0]]), b=np.array([0.0])))
+    server = Agent(1, ZeroCost((1,)))
+    algorithm = FedLT(iterations=1, step_size=0.1, num_local_epochs=2, rho=1.0, local_solver="adam")
+    server.initialize(x=np.array([0.0]))
+
+    def run_local_solve() -> tuple[np.ndarray, np.ndarray]:
+        client.initialize(x=np.array([1.0]), aux_vars={"z": np.array([0.0])})
+        client._received_messages[server] = np.array([0.0])  # noqa: SLF001
+        return algorithm._compute_local_update(client, server)
+
+    local_x_1, z_next_1 = run_local_solve()
+    local_x_2, z_next_2 = run_local_solve()
+
+    np.testing.assert_allclose(local_x_1, local_x_2)
+    np.testing.assert_allclose(z_next_1, z_next_2)
+    assert set(client.aux_vars) == {"z"}
 
 
 def test_fedlt_server_step_uses_server_cost_proximal_for_optional_global_regularizer() -> None:

--- a/test/test_fedlt.py
+++ b/test/test_fedlt.py
@@ -174,8 +174,8 @@ def _make_network(*costs: Cost) -> FedNetwork:
     return FedNetwork(clients=[Agent(i, cost) for i, cost in enumerate(costs)])
 
 
-@pytest.mark.parametrize("local_solver", ["gd", "accelerated"])
-def test_fedlt_runs_with_default_and_accelerated_local_updates(local_solver: str) -> None:
+@pytest.mark.parametrize("local_solver", ["gd", "nesterov"])
+def test_fedlt_runs_with_default_and_nesterov_local_updates(local_solver: str) -> None:
     network = _make_network(
         QuadraticCost(A=np.array([[1.0]]), b=np.array([-1.0])),
         QuadraticCost(A=np.array([[2.0]]), b=np.array([1.0])),
@@ -201,6 +201,14 @@ def test_fedlt_accepts_adam_local_solver() -> None:
     assert all(np.isfinite(client.x).all() for client in network.clients())
 
 
+def test_fedlt_sets_default_solver_args() -> None:
+    nesterov = FedLT(iterations=1, local_solver="nesterov")
+    adam = FedLT(iterations=1, local_solver="adam")
+
+    assert nesterov.solver_args == {"momentum": 0.9}
+    assert adam.solver_args == {"beta1": 0.9, "beta2": 0.999, "epsilon": 1e-8}
+
+
 @pytest.mark.parametrize(
     ("kwargs", "error"),
     [
@@ -208,14 +216,39 @@ def test_fedlt_accepts_adam_local_solver() -> None:
         ({"num_local_epochs": 0}, "`num_local_epochs` must be positive"),
         ({"step_size": 0.0}, "`step_size` must be positive"),
         ({"local_solver": "bad"}, "`local_solver` must be one of"),
-        ({"adam_beta1": -0.1}, "`adam_beta1` must satisfy 0 <= adam_beta1 < 1"),
-        ({"adam_beta1": 1.0}, "`adam_beta1` must satisfy 0 <= adam_beta1 < 1"),
-        ({"adam_beta2": -0.1}, "`adam_beta2` must satisfy 0 <= adam_beta2 < 1"),
-        ({"adam_beta2": 1.0}, "`adam_beta2` must satisfy 0 <= adam_beta2 < 1"),
-        ({"adam_epsilon": 0.0}, "`adam_epsilon` must be positive"),
+        (
+            {"local_solver": "adam", "solver_args": {"beta1": -0.1}},
+            "`solver_args\\['beta1'\\]` must satisfy 0 <= beta1 < 1",
+        ),
+        (
+            {"local_solver": "adam", "solver_args": {"beta1": 1.0}},
+            "`solver_args\\['beta1'\\]` must satisfy 0 <= beta1 < 1",
+        ),
+        (
+            {"local_solver": "adam", "solver_args": {"beta2": -0.1}},
+            "`solver_args\\['beta2'\\]` must satisfy 0 <= beta2 < 1",
+        ),
+        (
+            {"local_solver": "adam", "solver_args": {"beta2": 1.0}},
+            "`solver_args\\['beta2'\\]` must satisfy 0 <= beta2 < 1",
+        ),
+        ({"local_solver": "adam", "solver_args": {"epsilon": 0.0}}, "`solver_args\\['epsilon'\\]` must be positive"),
+        (
+            {"local_solver": "nesterov", "solver_args": {"momentum": -0.1}},
+            "`solver_args\\['momentum'\\]` must satisfy 0 <= momentum < 1",
+        ),
+        (
+            {"local_solver": "nesterov", "solver_args": {"momentum": 1.0}},
+            "`solver_args\\['momentum'\\]` must satisfy 0 <= momentum < 1",
+        ),
+        ({"solver_args": {"momentum": 0.5}}, "Unsupported solver_args for local_solver='gd': momentum"),
+        (
+            {"local_solver": "adam", "solver_args": {"momentum": 0.5}},
+            "Unsupported solver_args for local_solver='adam': momentum",
+        ),
     ],
 )
-def test_fedlt_rejects_invalid_parameters(kwargs: dict[str, float | int | str], error: str) -> None:
+def test_fedlt_rejects_invalid_parameters(kwargs: dict[str, float | int | str | dict[str, float]], error: str) -> None:
     with pytest.raises(ValueError, match=error):
         FedLT(iterations=1, **kwargs)
 
@@ -234,12 +267,45 @@ def test_fedlt_initializes_auxiliary_variables_from_z0() -> None:
     np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[1]], np.array([-1.0]))
 
 
-def test_fedlt_accelerated_solver_requires_valid_client_constants() -> None:
-    network = _make_network(ConstantGradientCost(m_smooth=np.inf, m_cvx=0.0))
-    algorithm = FedLT(iterations=1, local_solver="accelerated")
+def test_fedlt_nesterov_update_uses_step_size_and_momentum() -> None:
+    client = Agent(0, ConstantGradientCost(gradient_value=2.0))
+    server = Agent(1, ZeroCost((1,)))
+    algorithm = FedLT(
+        iterations=1,
+        step_size=0.25,
+        num_local_epochs=2,
+        rho=1.0,
+        local_solver="nesterov",
+        solver_args={"momentum": 0.5},
+    )
+    client.initialize(x=np.array([1.0]), aux_vars={"z": np.array([0.0])})
+    server.initialize(x=np.array([0.0]))
+    client._received_messages[server] = np.array([0.0])  # noqa: SLF001
 
-    with pytest.raises(ValueError, match="requires finite non-negative"):
-        algorithm.initialize(network)
+    local_x, z_next = algorithm._compute_local_update(client, server)
+
+    np.testing.assert_allclose(local_x, np.array([-1.015625]))
+    np.testing.assert_allclose(z_next, np.array([-2.03125]))
+
+
+def test_fedlt_nesterov_default_momentum_is_used() -> None:
+    client = Agent(0, ConstantGradientCost(gradient_value=2.0))
+    server = Agent(1, ZeroCost((1,)))
+    algorithm = FedLT(
+        iterations=1,
+        step_size=0.25,
+        num_local_epochs=2,
+        rho=1.0,
+        local_solver="nesterov",
+    )
+    client.initialize(x=np.array([1.0]), aux_vars={"z": np.array([0.0])})
+    server.initialize(x=np.array([0.0]))
+    client._received_messages[server] = np.array([0.0])  # noqa: SLF001
+
+    local_x, z_next = algorithm._compute_local_update(client, server)
+
+    np.testing.assert_allclose(local_x, np.array([-1.780625]))
+    np.testing.assert_allclose(z_next, np.array([-3.56125]))
 
 
 def test_fedlt_local_gradient_step_uses_penalty_term() -> None:
@@ -266,7 +332,7 @@ def test_fedlt_adam_one_step_matches_formula() -> None:
 
     local_x, z_next = algorithm._compute_local_update(client, server)
 
-    expected_x = np.array([-0.5 * 2.0 / (math.sqrt(4.0) + algorithm.adam_epsilon)])
+    expected_x = np.array([-0.5 * 2.0 / (math.sqrt(4.0) + 1e-8)])
     np.testing.assert_allclose(local_x, expected_x)
     np.testing.assert_allclose(z_next, 2 * expected_x)
 
@@ -302,9 +368,7 @@ def test_fedlt_adam_multi_step_matches_formula_on_quadratic() -> None:
         num_local_epochs=3,
         rho=1.0,
         local_solver="adam",
-        adam_beta1=0.8,
-        adam_beta2=0.9,
-        adam_epsilon=1e-6,
+        solver_args={"beta1": 0.8, "beta2": 0.9, "epsilon": 1e-6},
     )
     client.initialize(x=np.array([1.0]), aux_vars={"z": np.array([0.0])})
     server.initialize(x=np.array([0.0]))
@@ -315,9 +379,9 @@ def test_fedlt_adam_multi_step_matches_formula_on_quadratic() -> None:
     expected_x = _manual_adam_steps(
         x0=1.0,
         step_size=algorithm.step_size,
-        beta1=algorithm.adam_beta1,
-        beta2=algorithm.adam_beta2,
-        epsilon=algorithm.adam_epsilon,
+        beta1=algorithm.solver_args["beta1"],
+        beta2=algorithm.solver_args["beta2"],
+        epsilon=algorithm.solver_args["epsilon"],
         num_steps=algorithm.num_local_epochs,
     )
     np.testing.assert_allclose(local_x, np.array([expected_x]))

--- a/test/test_fedlt.py
+++ b/test/test_fedlt.py
@@ -422,29 +422,24 @@ def test_fedlt_supports_partial_participation_and_keeps_stale_server_z() -> None
     np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[1]], np.array([0.0]))
 
 
-def test_fedlt_ignores_buffered_stale_server_broadcasts() -> None:
+def test_fedlt_keeps_stale_server_z_when_client_upload_is_dropped() -> None:
     clients = [Agent(0, ConstantGradientCost(1.0)), Agent(1, ConstantGradientCost(3.0))]
-    server = Agent(2, ZeroCost((1,)))
     network = FedNetwork(
         clients=clients,
-        server=server,
-        buffer_messages=True,
-        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
+        message_drop={clients[0]: DropOnCalls({1}), clients[1]: NoDrops()},
     )
-    algorithm = FedLT(iterations=2, step_size=1.0, num_local_epochs=1, rho=1.0)
+    algorithm = FedLT(iterations=1, step_size=1.0, num_local_epochs=1, rho=1.0)
     algorithm.initialize(network)
 
     network._step(0)  # noqa: SLF001
     algorithm.step(network, 0)
-    np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[0]], np.array([-2.0]))
+
+    np.testing.assert_allclose(clients[0].x, np.array([-1.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["z"], np.array([-2.0]))
+    np.testing.assert_allclose(clients[1].x, np.array([-3.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["z"], np.array([-6.0]))
+    np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[0]], np.array([0.0]))
     np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[1]], np.array([-6.0]))
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([-4.0]))
-    np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[0]], np.array([-2.0]))
-    np.testing.assert_allclose(network.server().aux_vars["z_by_client"][clients[1]], np.array([-8.0]))
 
 
 def test_fedlt_smoke_with_network_noise_and_compression() -> None:

--- a/test/test_fednova.py
+++ b/test/test_fednova.py
@@ -451,6 +451,28 @@ def test_fednova_uses_only_clients_with_both_uploads(dropped_calls: set[int]) ->
     np.testing.assert_allclose(network.server().x, np.array([-10.0]))
 
 
+def test_fednova_ignores_buffered_stale_server_broadcasts() -> None:
+    clients = [Agent(0, TrackingCost(1.0, n_samples=1)), Agent(1, TrackingCost(3.0, n_samples=1))]
+    server = Agent(2, TrackingCost(0.0))
+    network = FedNetwork(
+        clients=clients,
+        server=server,
+        buffer_messages=True,
+        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
+    )
+    algorithm = FedNova(iterations=2, step_size=1.0, num_local_steps=1)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+    np.testing.assert_allclose(network.server().x, np.array([-2.0]))
+
+    network._step(1)  # noqa: SLF001
+    algorithm.step(network, 1)
+
+    np.testing.assert_allclose(network.server().x, np.array([-5.0]))
+
+
 def test_fednova_differs_from_fedavg_when_local_steps_are_heterogeneous() -> None:
     fednova_network = _make_fed_network(1.0, 3.0)
     fedavg_network = _make_fed_network(1.0, 3.0)

--- a/test/test_fednova.py
+++ b/test/test_fednova.py
@@ -321,14 +321,13 @@ def test_fednova_uploads_normalizer_then_cumulative_gradient() -> None:
     selected_clients = network.clients()
     algorithm.server_broadcast(network, selected_clients)
     participating_clients = algorithm._clients_with_server_broadcast(network, selected_clients)
-    algorithm._clear_buffered_server_messages(network, participating_clients)
     algorithm._run_local_updates(network, participating_clients)
 
     np.testing.assert_allclose(network.server().messages[clients[0]], np.array([2.0]))
     np.testing.assert_allclose(network.server().messages[clients[1]], np.array([1.0]))
 
     algorithm._collect_received_normalizers(network, participating_clients)
-    algorithm._clear_buffered_server_messages(network, participating_clients)
+    network._clear_received_messages(receivers=[network.server()], senders=participating_clients)  # noqa: SLF001
     algorithm._communicate_cumulative_gradients(network, participating_clients)
 
     np.testing.assert_allclose(network.server().messages[clients[0]], np.array([4.0]))
@@ -357,10 +356,9 @@ def test_fednova_renormalizes_client_weights_over_received_subset() -> None:
     selected_clients = network.clients()
     algorithm.server_broadcast(network, selected_clients)
     participating_clients = algorithm._clients_with_server_broadcast(network, selected_clients)
-    algorithm._clear_buffered_server_messages(network, participating_clients)
     algorithm._run_local_updates(network, participating_clients)
     algorithm._collect_received_normalizers(network, participating_clients)
-    algorithm._clear_buffered_server_messages(network, participating_clients)
+    network._clear_received_messages(receivers=[network.server()], senders=participating_clients)  # noqa: SLF001
     algorithm._communicate_cumulative_gradients(network, participating_clients)
     network.server()._received_messages.pop(clients[1])  # noqa: SLF001
 
@@ -379,10 +377,9 @@ def test_fednova_aggregate_rejects_non_positive_normalizer() -> None:
     selected_clients = network.clients()
     algorithm.server_broadcast(network, selected_clients)
     participating_clients = algorithm._clients_with_server_broadcast(network, selected_clients)
-    algorithm._clear_buffered_server_messages(network, participating_clients)
     algorithm._run_local_updates(network, participating_clients)
     algorithm._collect_received_normalizers(network, participating_clients)
-    algorithm._clear_buffered_server_messages(network, participating_clients)
+    network._clear_received_messages(receivers=[network.server()], senders=participating_clients)  # noqa: SLF001
     algorithm._communicate_cumulative_gradients(network, participating_clients)
     network.server().aux_vars["received_a_i"][clients[0]] = 0.0
 
@@ -405,7 +402,6 @@ def test_fednova_collect_received_normalizers_stores_empty_dict_when_all_are_dro
     selected_clients = network.clients()
     algorithm.server_broadcast(network, selected_clients)
     participating_clients = algorithm._clients_with_server_broadcast(network, selected_clients)
-    algorithm._clear_buffered_server_messages(network, participating_clients)
     algorithm._run_local_updates(network, participating_clients)
 
     algorithm._collect_received_normalizers(network, participating_clients)
@@ -449,28 +445,6 @@ def test_fednova_uses_only_clients_with_both_uploads(dropped_calls: set[int]) ->
     algorithm.step(network, 0)
 
     np.testing.assert_allclose(network.server().x, np.array([-10.0]))
-
-
-def test_fednova_ignores_buffered_stale_server_broadcasts() -> None:
-    clients = [Agent(0, TrackingCost(1.0, n_samples=1)), Agent(1, TrackingCost(3.0, n_samples=1))]
-    server = Agent(2, TrackingCost(0.0))
-    network = FedNetwork(
-        clients=clients,
-        server=server,
-        buffer_messages=True,
-        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
-    )
-    algorithm = FedNova(iterations=2, step_size=1.0, num_local_steps=1)
-    algorithm.initialize(network)
-
-    network._step(0)  # noqa: SLF001
-    algorithm.step(network, 0)
-    np.testing.assert_allclose(network.server().x, np.array([-2.0]))
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([-5.0]))
 
 
 def test_fednova_differs_from_fedavg_when_local_steps_are_heterogeneous() -> None:

--- a/test/test_fednova.py
+++ b/test/test_fednova.py
@@ -535,6 +535,12 @@ def test_fednova_rejects_invalid_scalar_num_local_steps(num_local_steps: int) ->
         FedNova(iterations=1, step_size=1.0, num_local_steps=num_local_steps)
 
 
+@pytest.mark.parametrize("num_local_steps", [1.5])
+def test_fednova_rejects_non_integer_scalar_num_local_steps(num_local_steps: object) -> None:
+    with pytest.raises(TypeError, match="`num_local_steps` must be an int or a mapping from Agent"):
+        FedNova(iterations=1, step_size=1.0, num_local_steps=num_local_steps)
+
+
 @pytest.mark.parametrize("num_local_steps", [{}, {"not-an-agent": 1}, {1: 1}])
 def test_fednova_rejects_local_step_mappings_missing_network_clients(num_local_steps: object) -> None:
     network = _make_fed_network(1.0, 3.0)
@@ -548,6 +554,13 @@ def test_fednova_rejects_local_step_mappings_missing_network_clients(num_local_s
 def test_fednova_rejects_invalid_local_step_mapping_values(step_value: float) -> None:
     client = Agent(0, TrackingCost())
     with pytest.raises(ValueError, match="`num_local_steps` must have positive values"):
+        FedNova(iterations=1, step_size=1.0, num_local_steps={client: step_value})
+
+
+@pytest.mark.parametrize("step_value", [2.0])
+def test_fednova_rejects_non_integer_local_step_mapping_values(step_value: object) -> None:
+    client = Agent(0, TrackingCost())
+    with pytest.raises(TypeError, match="`num_local_steps` mapping values must be integers"):
         FedNova(iterations=1, step_size=1.0, num_local_steps={client: step_value})
 
 

--- a/test/test_fedpd.py
+++ b/test/test_fedpd.py
@@ -249,6 +249,32 @@ def test_fedpd_keeps_local_center_when_server_sync_message_is_dropped() -> None:
     np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-4.0]))
 
 
+def test_fedpd_ignores_buffered_stale_server_sync_messages() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    server = Agent(2, ZeroCost((1,)))
+    network = FedNetwork(
+        clients=clients,
+        server=server,
+        buffer_messages=True,
+        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
+    )
+    algorithm = FedPD(iterations=2, step_size=1.0, eta=1.0, skip_probability=0.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+    np.testing.assert_allclose(network.server().x, np.array([-4.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["center"], np.array([-4.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-4.0]))
+
+    network._step(1)  # noqa: SLF001
+    algorithm.step(network, 1)
+
+    np.testing.assert_allclose(network.server().x, np.array([-6.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["center"], np.array([-5.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-6.0]))
+
+
 def test_fedpd_probabilistic_communication_is_reproducible_when_seeded() -> None:
     def run_once() -> tuple[np.ndarray, list[np.ndarray]]:
         iop.set_seed(123, frameworks=[])

--- a/test/test_fedpd.py
+++ b/test/test_fedpd.py
@@ -249,32 +249,6 @@ def test_fedpd_keeps_local_center_when_server_sync_message_is_dropped() -> None:
     np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-4.0]))
 
 
-def test_fedpd_ignores_buffered_stale_server_sync_messages() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, ZeroCost((1,)))
-    network = FedNetwork(
-        clients=clients,
-        server=server,
-        buffer_messages=True,
-        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
-    )
-    algorithm = FedPD(iterations=2, step_size=1.0, eta=1.0, skip_probability=0.0)
-    algorithm.initialize(network)
-
-    network._step(0)  # noqa: SLF001
-    algorithm.step(network, 0)
-    np.testing.assert_allclose(network.server().x, np.array([-4.0]))
-    np.testing.assert_allclose(clients[0].aux_vars["center"], np.array([-4.0]))
-    np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-4.0]))
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([-6.0]))
-    np.testing.assert_allclose(clients[0].aux_vars["center"], np.array([-5.0]))
-    np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-6.0]))
-
-
 def test_fedpd_probabilistic_communication_is_reproducible_when_seeded() -> None:
     def run_once() -> tuple[np.ndarray, list[np.ndarray]]:
         iop.set_seed(123, frameworks=[])

--- a/test/test_fedpd.py
+++ b/test/test_fedpd.py
@@ -1,0 +1,318 @@
+from typing import Any
+
+import numpy as np
+import pytest
+
+import decent_bench.utils.interoperability as iop
+from decent_bench.agents import Agent
+from decent_bench.algorithms.federated import FedPD
+from decent_bench.costs import Cost, ZeroCost
+from decent_bench.networks import FedNetwork
+from decent_bench.schemes import DropScheme, NoDrops
+from decent_bench.utils.types import (
+    SupportedDevices,
+    SupportedFrameworks,
+)
+
+
+class TrackingCost(Cost):
+    def __init__(self, gradient_value: float = 1.0):
+        self.gradient_kwargs: list[dict[str, Any]] = []
+        self._gradient = np.array([gradient_value], dtype=float)
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return (1,)
+
+    @property
+    def framework(self) -> SupportedFrameworks:
+        return SupportedFrameworks.NUMPY
+
+    @property
+    def device(self) -> SupportedDevices:
+        return SupportedDevices.CPU
+
+    @property
+    def m_smooth(self) -> float:
+        return 0.0
+
+    @property
+    def m_cvx(self) -> float:
+        return 0.0
+
+    def function(self, x: np.ndarray, **kwargs: Any) -> float:
+        del x, kwargs
+        return 0.0
+
+    def gradient(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+        del x
+        self.gradient_kwargs.append(dict(kwargs))
+        return self._gradient.copy()
+
+    def hessian(self, x: np.ndarray, **kwargs: Any) -> np.ndarray:
+        del x, kwargs
+        return np.zeros((1, 1), dtype=float)
+
+    def proximal(self, x: np.ndarray, rho: float, **kwargs: Any) -> np.ndarray:
+        del rho, kwargs
+        return x
+
+
+class DropOnCalls(DropScheme):
+    def __init__(self, dropped_calls: set[int]):
+        self._dropped_calls = dropped_calls
+        self._call_count = 0
+
+    def should_drop(self) -> bool:
+        self._call_count += 1
+        return self._call_count in self._dropped_calls
+
+
+def test_fedpd_initializes_primal_dual_and_center_states() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedPD(iterations=1, x0=np.array([2.0]))
+
+    algorithm.initialize(network)
+
+    np.testing.assert_allclose(network.server().x, np.array([2.0]))
+    for client in clients:
+        np.testing.assert_allclose(client.x, np.array([2.0]))
+        np.testing.assert_allclose(client.aux_vars["lambda"], np.array([0.0]))
+        np.testing.assert_allclose(client.aux_vars["center"], np.array([2.0]))
+
+
+def test_fedpd_p_zero_always_aggregates_and_synchronizes_centers() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedPD(iterations=1, step_size=1.0, eta=1.0, skip_probability=0.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(network.server().x, np.array([-4.0]))
+    np.testing.assert_allclose(clients[0].x, np.array([-1.0]))
+    np.testing.assert_allclose(clients[1].x, np.array([-3.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["lambda"], np.array([-1.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["lambda"], np.array([-3.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["center"], np.array([-4.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-4.0]))
+
+
+def test_fedpd_supports_heterogeneous_local_steps() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedPD(
+        iterations=1,
+        step_size=0.5,
+        eta=1.0,
+        skip_probability=0.0,
+        num_local_steps={clients[0]: 1, clients[1]: 2},
+    )
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(clients[0].x, np.array([-0.5]))
+    np.testing.assert_allclose(clients[1].x, np.array([-2.25]))
+    np.testing.assert_allclose(network.server().x, np.array([-2.75]))
+
+
+def test_fedpd_always_selects_all_active_clients() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0)), Agent(2, TrackingCost(3.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedPD(iterations=1, step_size=1.0, eta=1.0, skip_probability=1.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(clients[0].x, np.array([-1.0]))
+    np.testing.assert_allclose(clients[1].x, np.array([-2.0]))
+    np.testing.assert_allclose(clients[2].x, np.array([-3.0]))
+
+
+def test_fedpd_rejects_selection_scheme_argument() -> None:
+    with pytest.raises(TypeError, match="selection_scheme"):
+        FedPD(selection_scheme=object())
+
+
+def test_fedpd_p_one_always_skips_aggregation() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedPD(iterations=1, step_size=1.0, eta=1.0, skip_probability=1.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(network.server().x, np.array([0.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["center"], np.array([-2.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-6.0]))
+    assert network.server().messages == {}
+
+
+def test_fedpd_dual_update_uses_previous_center() -> None:
+    algorithm = FedPD(iterations=1, step_size=1.0, eta=2.0, skip_probability=1.0)
+    client = Agent(0, TrackingCost(gradient_value=0.0))
+    network = FedNetwork(clients=[client])
+    algorithm.initialize(network)
+    client.x = np.array([1.0])
+    client.aux_vars["lambda"] = np.array([0.5])
+    client.aux_vars["center"] = np.array([2.0])
+
+    algorithm._run_local_updates([client])
+
+    np.testing.assert_allclose(client.x, np.array([1.0]))
+    np.testing.assert_allclose(client.aux_vars["lambda"], np.array([0.0]))
+    np.testing.assert_allclose(client.aux_vars["center"], np.array([1.0]))
+
+
+def test_fedpd_aggregate_and_synchronize_uses_only_received_center_candidates() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedPD(iterations=1)
+    algorithm.initialize(network)
+    network.server().x = np.array([10.0])
+
+    network.send(sender=clients[0], receiver=network.server(), msg=np.array([2.0]))
+
+    algorithm.aggregate_and_synchronize(network, clients)
+
+    np.testing.assert_allclose(network.server().x, np.array([2.0]))
+
+
+def test_fedpd_aggregate_direct_call_is_not_supported() -> None:
+    clients = [Agent(0, TrackingCost(1.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedPD(iterations=1)
+    algorithm.initialize(network)
+
+    with pytest.raises(NotImplementedError, match="aggregate_and_synchronize"):
+        algorithm.aggregate(network, clients)
+
+
+def test_fedpd_synchronizes_all_active_clients_after_aggregating_received_candidates() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(
+        clients=clients,
+        message_drop={clients[0]: DropOnCalls({1}), clients[1]: NoDrops()},
+    )
+    algorithm = FedPD(iterations=1, step_size=1.0, eta=1.0, skip_probability=0.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(network.server().x, np.array([-6.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["center"], np.array([-6.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-6.0]))
+
+
+def test_fedpd_does_not_synchronize_when_no_center_candidates_are_received() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(
+        clients=clients,
+        message_drop={clients[0]: DropOnCalls({1}), clients[1]: DropOnCalls({1})},
+    )
+    algorithm = FedPD(iterations=1, step_size=1.0, eta=1.0, skip_probability=0.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(network.server().x, np.array([0.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["center"], np.array([-2.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-6.0]))
+    assert network.server() not in clients[0].messages
+    assert network.server() not in clients[1].messages
+
+
+def test_fedpd_keeps_local_center_when_server_sync_message_is_dropped() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    server = Agent(2, ZeroCost((1,)))
+    network = FedNetwork(
+        clients=clients,
+        server=server,
+        message_drop={server: DropOnCalls({1}), clients[0]: NoDrops(), clients[1]: NoDrops()},
+    )
+    algorithm = FedPD(iterations=1, step_size=1.0, eta=1.0, skip_probability=0.0)
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+
+    np.testing.assert_allclose(network.server().x, np.array([-4.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["center"], np.array([-2.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["center"], np.array([-4.0]))
+
+
+def test_fedpd_probabilistic_communication_is_reproducible_when_seeded() -> None:
+    def run_once() -> tuple[np.ndarray, list[np.ndarray]]:
+        iop.set_seed(123, frameworks=[])
+        clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+        network = FedNetwork(clients=clients)
+        algorithm = FedPD(iterations=5, step_size=1.0, eta=1.0, skip_probability=0.5)
+        algorithm.initialize(network)
+        for iteration in range(algorithm.iterations):
+            network._step(iteration)  # noqa: SLF001
+            algorithm.step(network, iteration)
+        return np.copy(network.server().x), [np.copy(client.aux_vars["center"]) for client in clients]
+
+    server_x_1, centers_1 = run_once()
+    server_x_2, centers_2 = run_once()
+
+    np.testing.assert_allclose(server_x_1, server_x_2)
+    for center_1, center_2 in zip(centers_1, centers_2, strict=True):
+        np.testing.assert_allclose(center_1, center_2)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_message"),
+    [
+        pytest.param({"step_size": 0.0}, "`step_size` must be positive", id="step-size-zero"),
+        pytest.param({"eta": 0.0}, "`eta` must be positive", id="eta-zero"),
+        pytest.param(
+            {"skip_probability": -0.1},
+            "`skip_probability` must satisfy 0 <= skip_probability <= 1",
+            id="skip-probability-negative",
+        ),
+        pytest.param(
+            {"skip_probability": 1.1},
+            "`skip_probability` must satisfy 0 <= skip_probability <= 1",
+            id="skip-probability-too-large",
+        ),
+        pytest.param({"num_local_steps": 0}, "`num_local_steps` must be positive", id="local-steps-zero"),
+    ],
+)
+def test_fedpd_rejects_invalid_hyperparameters(kwargs: dict[str, float | int], expected_message: str) -> None:
+    with pytest.raises(ValueError, match=expected_message):
+        FedPD(iterations=1, **kwargs)
+
+
+def test_fedpd_normalizes_scalar_local_steps_to_client_mapping_on_initialize() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = FedPD(iterations=1, num_local_steps=2)
+
+    algorithm.initialize(network)
+
+    assert algorithm.num_local_steps == {clients[0]: 2, clients[1]: 2}
+
+
+@pytest.mark.parametrize("num_local_steps", [{}, {"not-an-agent": 1}, {1: 1}])
+def test_fedpd_rejects_local_step_mappings_missing_network_clients(num_local_steps: object) -> None:
+    network = FedNetwork(clients=[Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))])
+    algorithm = FedPD(iterations=1, num_local_steps=num_local_steps)
+
+    with pytest.raises(ValueError, match="`num_local_steps` mapping must provide a value for every network client"):
+        algorithm.initialize(network)
+
+
+@pytest.mark.parametrize("step_value", [0, -1])
+def test_fedpd_rejects_invalid_local_step_mapping_values(step_value: float) -> None:
+    client = Agent(0, TrackingCost())
+    with pytest.raises(ValueError, match="`num_local_steps` must have positive values"):
+        FedPD(iterations=1, num_local_steps={client: step_value})

--- a/test/test_fedpd.py
+++ b/test/test_fedpd.py
@@ -170,7 +170,7 @@ def test_fedpd_dual_update_uses_previous_center() -> None:
     np.testing.assert_allclose(client.aux_vars["center"], np.array([1.0]))
 
 
-def test_fedpd_aggregate_and_synchronize_uses_only_received_center_candidates() -> None:
+def test_fedpd_aggregate_uses_only_received_center_candidates() -> None:
     clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedPD(iterations=1)
@@ -179,19 +179,9 @@ def test_fedpd_aggregate_and_synchronize_uses_only_received_center_candidates() 
 
     network.send(sender=clients[0], receiver=network.server(), msg=np.array([2.0]))
 
-    algorithm.aggregate_and_synchronize(network, clients)
+    algorithm.aggregate(network, clients)
 
     np.testing.assert_allclose(network.server().x, np.array([2.0]))
-
-
-def test_fedpd_aggregate_direct_call_is_not_supported() -> None:
-    clients = [Agent(0, TrackingCost(1.0))]
-    network = FedNetwork(clients=clients)
-    algorithm = FedPD(iterations=1)
-    algorithm.initialize(network)
-
-    with pytest.raises(NotImplementedError, match="aggregate_and_synchronize"):
-        algorithm.aggregate(network, clients)
 
 
 def test_fedpd_synchronizes_all_active_clients_after_aggregating_received_candidates() -> None:

--- a/test/test_fedpd.py
+++ b/test/test_fedpd.py
@@ -292,6 +292,12 @@ def test_fedpd_rejects_invalid_hyperparameters(kwargs: dict[str, float | int], e
         FedPD(iterations=1, **kwargs)
 
 
+@pytest.mark.parametrize("num_local_steps", [1.5])
+def test_fedpd_rejects_non_integer_scalar_num_local_steps(num_local_steps: object) -> None:
+    with pytest.raises(TypeError, match="`num_local_steps` must be an int or a mapping from Agent"):
+        FedPD(iterations=1, num_local_steps=num_local_steps)
+
+
 def test_fedpd_normalizes_scalar_local_steps_to_client_mapping_on_initialize() -> None:
     clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
     network = FedNetwork(clients=clients)
@@ -315,4 +321,11 @@ def test_fedpd_rejects_local_step_mappings_missing_network_clients(num_local_ste
 def test_fedpd_rejects_invalid_local_step_mapping_values(step_value: float) -> None:
     client = Agent(0, TrackingCost())
     with pytest.raises(ValueError, match="`num_local_steps` must have positive values"):
+        FedPD(iterations=1, num_local_steps={client: step_value})
+
+
+@pytest.mark.parametrize("step_value", [2.0])
+def test_fedpd_rejects_non_integer_local_step_mapping_values(step_value: object) -> None:
+    client = Agent(0, TrackingCost())
+    with pytest.raises(TypeError, match="`num_local_steps` mapping values must be integers"):
         FedPD(iterations=1, num_local_steps={client: step_value})

--- a/test/test_networks.py
+++ b/test/test_networks.py
@@ -293,21 +293,11 @@ def test_send_rejects_inactive_receiver() -> None:
         net.send(sender=sender, receiver=inactive_receiver, msg=msg)
 
 
-@pytest.mark.parametrize(
-    ("buffer_messages", "expect_message_after_step"),
-    [
-        (False, False),
-        (True, True),
-    ],
-)
-def test_step_clears_or_preserves_messages_based_on_buffer_setting(
-    buffer_messages: bool, expect_message_after_step: bool
-) -> None:
+def test_step_clears_messages() -> None:
     sender = Agent(0, L2RegularizerCost((2,)))
     receiver = Agent(1, L2RegularizerCost((2,)))
     net = P2PNetwork(
         graph=nx.Graph([(sender, receiver)]),
-        buffer_messages=buffer_messages,
     )
     msg = iop.to_array([1.0, -1.0], framework=sender.cost.framework, device=sender.cost.device)
 
@@ -316,7 +306,7 @@ def test_step_clears_or_preserves_messages_based_on_buffer_setting(
 
     net._step(1)  # noqa: SLF001
 
-    assert (sender in receiver.messages) is expect_message_after_step
+    assert sender not in receiver.messages
 
 
 def test_send_applies_drop_compression_and_noise_schemes() -> None:

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -96,6 +96,43 @@ def _run_scaffold_local_update(
     return local_x, client.aux_vars["c_i"], control_delta
 
 
+def test_scaffold_initializes_control_variates_from_c0() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = Scaffold(
+        iterations=1,
+        c0={
+            clients[0]: np.array([1.0]),
+            clients[1]: np.array([3.0]),
+            network.server(): np.array([7.0]),
+        },
+    )
+
+    algorithm.initialize(network)
+
+    np.testing.assert_allclose(network.server().aux_vars["c"], np.array([7.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["c_i"], np.array([1.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["c_i"], np.array([3.0]))
+
+
+def test_scaffold_infers_server_control_from_client_c0() -> None:
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    network = FedNetwork(clients=clients)
+    algorithm = Scaffold(
+        iterations=1,
+        c0={
+            clients[0]: np.array([1.0]),
+            clients[1]: np.array([3.0]),
+        },
+    )
+
+    algorithm.initialize(network)
+
+    np.testing.assert_allclose(network.server().aux_vars["c"], np.array([2.0]))
+    np.testing.assert_allclose(clients[0].aux_vars["c_i"], np.array([1.0]))
+    np.testing.assert_allclose(clients[1].aux_vars["c_i"], np.array([3.0]))
+
+
 def test_control_variate_correction_changes_the_local_step() -> None:
     cost = TrackingCost(gradient_value=1.0)
 

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -334,3 +334,27 @@ def test_scaffold_ignores_buffered_stale_client_messages() -> None:
 
     np.testing.assert_allclose(network.server().x, np.array([-4.0]))
     np.testing.assert_allclose(network.server().aux_vars["c"], np.array([2.0]))
+
+
+def test_scaffold_ignores_buffered_stale_server_broadcasts() -> None:
+    algorithm = Scaffold(iterations=2, step_size=1.0, num_local_epochs=1)
+    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    server = Agent(2, ZeroCost((1,)))
+    network = FedNetwork(
+        clients=clients,
+        server=server,
+        buffer_messages=True,
+        message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
+    )
+    algorithm.initialize(network)
+
+    network._step(0)  # noqa: SLF001
+    algorithm.step(network, 0)
+    np.testing.assert_allclose(network.server().x, np.array([-2.0]))
+    np.testing.assert_allclose(network.server().aux_vars["c"], np.array([2.0]))
+
+    network._step(1)  # noqa: SLF001
+    algorithm.step(network, 1)
+
+    np.testing.assert_allclose(network.server().x, np.array([-4.0]))
+    np.testing.assert_allclose(network.server().aux_vars["c"], np.array([2.0]))

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -312,38 +312,13 @@ def test_scaffold_skips_participation_when_broadcast_is_dropped() -> None:
     np.testing.assert_allclose(client.aux_vars["c_i"], np.array([0.0]))
 
 
-def test_scaffold_ignores_buffered_stale_client_messages() -> None:
+def test_scaffold_dropped_server_broadcasts_do_not_make_clients_participate() -> None:
     algorithm = Scaffold(iterations=2, step_size=1.0, num_local_epochs=1)
     clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
     server = Agent(2, ZeroCost((1,)))
     network = FedNetwork(
         clients=clients,
         server=server,
-        buffer_messages=True,
-        message_drop={server: NoDrops(), clients[0]: DropOnCalls({2}), clients[1]: NoDrops()},
-    )
-    algorithm.initialize(network)
-
-    network._step(0)  # noqa: SLF001
-    algorithm.step(network, 0)
-    np.testing.assert_allclose(network.server().x, np.array([-2.0]))
-    np.testing.assert_allclose(network.server().aux_vars["c"], np.array([2.0]))
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([-4.0]))
-    np.testing.assert_allclose(network.server().aux_vars["c"], np.array([2.0]))
-
-
-def test_scaffold_ignores_buffered_stale_server_broadcasts() -> None:
-    algorithm = Scaffold(iterations=2, step_size=1.0, num_local_epochs=1)
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, ZeroCost((1,)))
-    network = FedNetwork(
-        clients=clients,
-        server=server,
-        buffer_messages=True,
         message_drop={server: DropOnCalls({3}), clients[0]: NoDrops(), clients[1]: NoDrops()},
     )
     algorithm.initialize(network)


### PR DESCRIPTION
- Add FedPD and FedDyn algorithms
- Extend FedLT with an Adam local solver
- Allow Scaffold control variate initialization

- Remove 'Network(buffer_messages=...)`. Received messages are always cleared at network step boundaries.

Closes #307 