### PR TITLE
enh(decent-bench): fix several issues and make small enhancements

### DIFF
--- a/decent_bench/agents.py
+++ b/decent_bench/agents.py
@@ -5,7 +5,8 @@ import contextlib
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, cast
+from typing import Any, Self, cast
+from uuid import UUID, uuid4
 
 import decent_bench.utils.interoperability as iop
 from decent_bench.costs import Cost, EmpiricalRiskCost
@@ -15,10 +16,13 @@ from decent_bench.utils.array import Array
 
 class Agent:
     """
-    Agent with unique id, local cost function, activation scheme and state snapshot period.
+    Agent with local cost function, activation scheme, state snapshot period, and optional data.
+
+    At initialization, the agent is assigned a unique id (accessible via ``Agent.id``) which serves as its hash. The
+    agent can also be assigned an index (``Agent.index``). This assignment is performed when initializing a network,
+    and is useful to index arrays by Agent or for user-friendly representation of Agents.
 
     Args:
-        agent_id: agent's identifier
         cost: local cost function; once assigned, it should not be modified
         activation: activation scheme to model synchrony/asynchrony; defaults to synchrony (activate at all iterations)
         state_snapshot_period: how often to record the agent's state when executing an algorithm
@@ -29,9 +33,18 @@ class Agent:
 
     """
 
+    _id: UUID
+    _index: int
+
+    def __new__(cls, *_: object, _id: UUID | None = None, **__: object) -> Self:
+        """Ensure agent id and index are defined early (including during unpickling/deepcopy)."""
+        obj = super().__new__(cls)
+        obj._id = uuid4() if _id is None else _id
+        obj._index = -1
+        return obj
+
     def __init__(
         self,
-        agent_id: int,
         cost: Cost,
         activation: AgentActivationScheme | None = None,
         state_snapshot_period: int = 1,
@@ -40,7 +53,7 @@ class Agent:
         if state_snapshot_period <= 0:
             raise ValueError("state_snapshot_period must be a positive integer")
 
-        self._id = agent_id
+        self._index = -1
         self._cost = cost
         self._activation = AlwaysActive() if activation is None else activation
         self._state_snapshot_period = state_snapshot_period
@@ -64,9 +77,18 @@ class Agent:
         cost.proximal = self._call_counting_proximal  # type: ignore[method-assign]
 
     @property
-    def id(self) -> int:
+    def id(self) -> UUID:
         """Unique id for the agent."""
         return self._id
+
+    @property
+    def index(self) -> int:
+        """Agent index within a network, -1 if unassigned."""
+        return self._index
+
+    @index.setter
+    def index(self, value: int) -> None:
+        self._index = value
 
     @property
     def cost(self) -> Cost:
@@ -217,12 +239,26 @@ class Agent:
         return res
 
     def __index__(self) -> int:
-        """Enable using agent as index, for example ``W[a1, a2]`` instead of ``W[a1.id, a2.id]``."""
-        return self._id
+        """Enable using agent as index, for example ``W[a1, a2]`` instead of ``W[a1.index, a2.index]``."""
+        return self._index
 
     def __repr__(self) -> str:
         """Human readable representation of the agent."""
-        return f"Agent(id={self._id}, instance_id={id(self)})"
+        return f"Agent {hash(self._id) if self._index == -1 else self._index} (instance_id={id(self)})"
+
+    def __getnewargs_ex__(self) -> tuple[tuple[()], dict[str, UUID]]:
+        """Preserve Agent._id in pickle/deepcopy by passing it to :meth:`__new__`."""
+        return (), {"_id": self._id}
+
+    def __hash__(self) -> int:
+        """Hash of the agent, which coincides with the unique identifier."""
+        return hash(self._id)
+
+    def __eq__(self, other: object) -> bool:
+        """Agent instances are equal if they have the same id."""
+        if not isinstance(other, Agent):
+            return NotImplemented
+        return self._id == other._id
 
     @staticmethod
     @contextlib.contextmanager

--- a/decent_bench/agents.py
+++ b/decent_bench/agents.py
@@ -63,9 +63,9 @@ class Agent:
         self._auxiliary_variables: dict[str, Any] = {}
         self._received_messages: dict[Agent, Array] = {}
         self._n_x_updates = 0
-        self._n_sent_messages = 0
-        self._n_received_messages = 0
-        self._n_sent_messages_dropped = 0
+        self._n_sent_messages: float = 0
+        self._n_received_messages: float = 0
+        self._n_sent_messages_dropped: float = 0
         self._n_times_selected = 0
         self._is_server = False
         self._n_function_calls: float = 0
@@ -433,9 +433,9 @@ class AgentMetricsView:
     n_gradient_calls: float
     n_hessian_calls: float
     n_proximal_calls: float
-    n_sent_messages: int
-    n_received_messages: int
-    n_sent_messages_dropped: int
+    n_sent_messages: float
+    n_received_messages: float
+    n_sent_messages_dropped: float
     n_times_selected: int
     is_server: bool
 

--- a/decent_bench/agents.py
+++ b/decent_bench/agents.py
@@ -426,6 +426,7 @@ class AgentHistory:
 class AgentMetricsView:
     """Immutable view of agent that exposes useful properties for calculating metrics."""
 
+    id: UUID
     cost: Cost
     x_history: AgentHistory
     n_x_updates: int
@@ -443,6 +444,7 @@ class AgentMetricsView:
     def from_agent(agent: Agent) -> AgentMetricsView:
         """Create from agent."""
         return AgentMetricsView(
+            id=agent.id,
             cost=agent.cost,
             x_history=agent._x_history,  # noqa: SLF001
             n_x_updates=agent._n_x_updates,  # noqa: SLF001

--- a/decent_bench/algorithms/p2p/_dlm.py
+++ b/decent_bench/algorithms/p2p/_dlm.py
@@ -75,9 +75,7 @@ class DLM(P2PAlgorithm):
         else:
             # step 1: update primal variable
             for i in network.active_agents():
-                i.x = i.x - self.step_size * (  # noqa: PLR6104
-                    i.cost.gradient(i.x) + self.penalty * i.aux_vars["s"] + i.aux_vars["y"]
-                )
+                i.x = i.x - self.step_size * (i.cost.gradient(i.x) + self.penalty * i.aux_vars["s"] + i.aux_vars["y"])
 
             # step 2: communication round
             for i in network.active_agents():

--- a/decent_bench/benchmark/_benchmark.py
+++ b/decent_bench/benchmark/_benchmark.py
@@ -427,7 +427,7 @@ def _is_multiprocessing_main_guard_error(exc: RuntimeError) -> bool:
     return "start a new process before the" in msg and "bootstrapping phase" in msg
 
 
-def _run_trials(  # noqa: PLR0917
+def _run_trials(
     algorithms: list[Algorithm[Network]],
     n_trials: int,
     problem: BenchmarkProblem,
@@ -538,7 +538,7 @@ def _derive_trial_seed(base_seed: int | None, algorithm_index: int, trial: int) 
     return int((base_seed + 0x9E3779B9 * (algorithm_index + 1) + 0x85EBCA6B * (trial + 1)) % (2**32))
 
 
-def _run_trial(  # noqa: PLR0917
+def _run_trial(
     algorithm: Algorithm[Network],
     problem: BenchmarkProblem,
     progress_bar_handle: "ProgressBarHandle",

--- a/decent_bench/benchmark/_benchmark.py
+++ b/decent_bench/benchmark/_benchmark.py
@@ -133,13 +133,13 @@ def resume_benchmark(  # noqa: PLR0912
             if metadata is None or "n_trials" not in metadata:
                 raise ValueError("Invalid or missing metadata in checkpoint directory")
 
-            algorithms = checkpoint_manager.load_initial_algorithms()
-            if algorithms is None:
-                raise ValueError("Initial algorithms not found in checkpoint metadata")
-
             problem = checkpoint_manager.load_benchmark_problem()
             if problem is None:
                 raise ValueError("Benchmark problem not found in checkpoint metadata")
+
+            algorithms = checkpoint_manager.load_initial_algorithms(network=problem.network)
+            if algorithms is None:
+                raise ValueError("Initial algorithms not found in checkpoint metadata")
 
             log_listener, manager, mp_context = _init_logging_and_multiprocessing(log_level, max_processes, problem)
 

--- a/decent_bench/benchmark/_benchmark.py
+++ b/decent_bench/benchmark/_benchmark.py
@@ -385,7 +385,7 @@ def _benchmark(
         checkpoint_manager,
         runtime_metrics,
     )
-    LOGGER.info("Benchmark execution complete, thanks for using decent-bench")
+    LOGGER.info("Benchmark execution complete")
     return BenchmarkResult(problem=benchmark_problem, states=resulting_nw_states)
 
 

--- a/decent_bench/benchmark/_compute.py
+++ b/decent_bench/benchmark/_compute.py
@@ -113,7 +113,9 @@ def compute_metrics(
     # compute table and plot results
     resulting_agent_states: dict[Algorithm[Network], list[list[AgentMetricsView]]] = {}
     for alg, networks in benchmark_result.states.items():
-        resulting_agent_states[alg] = [[AgentMetricsView.from_agent(a) for a in nw.agents()] for nw in networks]
+        resulting_agent_states[alg] = [
+            [AgentMetricsView.from_agent(a) for a in nw.snapshot_agents()] for nw in networks
+        ]
     table_results = compute_tables(resulting_agent_states, benchmark_result.problem, table_metrics, confidence_level)
     plot_results = compute_plots(resulting_agent_states, benchmark_result.problem, plot_metrics)
 
@@ -141,8 +143,8 @@ def compute_metrics(
 
 def _resolve_default_metrics(
     table_metrics: list[Metric] | None,
-    plot_metrics: list[Metric] | list[list[Metric]] | None,
-) -> tuple[list[Metric], list[Metric] | list[list[Metric]]]:
+    plot_metrics: list[Metric] | None,
+) -> tuple[list[Metric], list[Metric]]:
     if table_metrics is None:
         table_metrics = ml._DEFAULT_TABLE_METRICS  # noqa: SLF001
     if plot_metrics is None:

--- a/decent_bench/benchmark/_compute.py
+++ b/decent_bench/benchmark/_compute.py
@@ -1,7 +1,7 @@
 import logging
 from copy import deepcopy
 from json import JSONDecodeError
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal
 
 from rich.status import Status
 
@@ -17,7 +17,7 @@ from decent_bench.metrics import (
 )
 from decent_bench.metrics import metric_library as ml
 from decent_bench.networks import Network
-from decent_bench.utils._metric_helpers import _find_duplicates, _flatten_plot_metrics
+from decent_bench.utils._metric_helpers import _find_duplicates
 from decent_bench.utils.logger import LOGGER, start_logger
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ def compute_metrics(
     checkpoint_manager: "CheckpointManager | None" = None,
     *,
     table_metrics: list[Metric] = ml.DEFAULT_TABLE_METRICS,
-    plot_metrics: list[Metric] | list[list[Metric]] = ml.DEFAULT_PLOT_METRICS,
+    plot_metrics: list[Metric] = ml.DEFAULT_PLOT_METRICS,
     confidence_level: float = 0.95,
     log_level: int = logging.INFO,
 ) -> MetricResult:
@@ -46,8 +46,6 @@ def compute_metrics(
             :const:`~decent_bench.metrics.metric_library.DEFAULT_TABLE_METRICS`
         plot_metrics: metrics to plot after the execution, defaults to
             :const:`~decent_bench.metrics.metric_library.DEFAULT_PLOT_METRICS`.
-            If a list of lists is provided, each inner list will be plotted in a separate figure. Otherwise up to 3
-            metrics will be grouped and plotted in their own figure with subplots.
         confidence_level: confidence level for computing confidence intervals of the table metrics, expressed as a value
             between 0 and 1 (e.g., 0.95 for 95% confidence, 0.99 for 99% confidence). Higher values result in
             wider confidence intervals.
@@ -59,7 +57,7 @@ def compute_metrics(
     Raises:
         ValueError: If neither ``benchmark_result`` nor ``checkpoint_manager`` is provided, or
             if the checkpoint manager does not contain a valid benchmark result to load.
-        ValueError: If duplicate metrics (i.e. with same ``table_description`` or ``plot_description``) are provided
+        ValueError: If duplicate metrics (i.e. with same ``description``) are provided
             in ``table_metrics`` or ``plot_metrics``.
 
     Note:
@@ -100,19 +98,13 @@ def compute_metrics(
     table_metrics = deepcopy(table_metrics)
     plot_metrics = deepcopy(plot_metrics)
 
-    # check metrics are unique, which also checks that plot_metrics is either list or list of lists
-    _validate_unique_metric_descriptions(table_metrics, plot_metrics)
+    # check metrics are unique
+    _validate_unique_descriptions(table_metrics, "table")
+    _validate_unique_descriptions(plot_metrics, "plot")
 
-    # remove unavailable tables
+    # remove unavailable metrics
     table_metrics = _remove_unavailable(table_metrics, benchmark_result.problem, "table")
-
-    if any(isinstance(metric, list) for metric in plot_metrics):
-        grouped_plot_metrics = cast("list[list[Metric]]", plot_metrics)
-        for i, group in enumerate(grouped_plot_metrics):
-            grouped_plot_metrics[i] = _remove_unavailable(group, benchmark_result.problem, "plot")
-        plot_metrics = grouped_plot_metrics
-    else:
-        plot_metrics = _remove_unavailable(cast("list[Metric]", plot_metrics), benchmark_result.problem, "plot")
+    plot_metrics = _remove_unavailable(plot_metrics, benchmark_result.problem, "plot")
 
     # compute table and plot results
     resulting_agent_states: dict[Algorithm[Network], list[list[AgentMetricsView]]] = {}
@@ -131,10 +123,9 @@ def compute_metrics(
 
     if checkpoint_manager is not None:
         with Status("Saving computed metrics..."):
-            flat_metrics = _flatten_plot_metrics(plot_metrics)
             metadata = {
-                "table_metrics": [metric.table_description for metric in table_metrics],
-                "plot_metrics": [metric.plot_description for metric in flat_metrics],
+                "table_metrics": [metric.description for metric in table_metrics],
+                "plot_metrics": [metric.description for metric in plot_metrics],
             }
             checkpoint_manager.save_metrics_result(result)
             checkpoint_manager.append_metadata(metadata)
@@ -144,21 +135,11 @@ def compute_metrics(
     return result
 
 
-def _validate_unique_metric_descriptions(
-    table_metrics: list[Metric],
-    plot_metrics: list[Metric] | list[list[Metric]],
-) -> None:
-    duplicate_table_descriptions = _find_duplicates([metric.table_description for metric in table_metrics])
-    if duplicate_table_descriptions:
-        duplicates = ", ".join(duplicate_table_descriptions)
-        raise ValueError(f"Table metric descriptions must be unique, duplicates found: {duplicates}")
-
-    duplicate_plot_descriptions = _find_duplicates([
-        metric.plot_description for metric in _flatten_plot_metrics(plot_metrics)
-    ])
-    if duplicate_plot_descriptions:
-        duplicates = ", ".join(duplicate_plot_descriptions)
-        raise ValueError(f"Plot metric descriptions must be unique, duplicates found: {duplicates}")
+def _validate_unique_descriptions(metrics: list[Metric], type_: Literal["table", "plot"]) -> None:
+    duplicate_metric_descriptions = _find_duplicates([metric.description for metric in metrics])
+    if duplicate_metric_descriptions:
+        duplicates = ", ".join(duplicate_metric_descriptions)
+        raise ValueError(f"{type_.capitalize()} metric descriptions must be unique, duplicates found: {duplicates}")
 
 
 def _remove_unavailable(
@@ -168,8 +149,7 @@ def _remove_unavailable(
     for metric in metrics:
         available, reason = metric.is_available(problem)
         if not available:
-            description = metric.table_description if type_ == "table" else metric.plot_description
-            LOGGER.warning(f"Skipping {type_} metric '{description}' because it is unavailable: {reason}")
+            LOGGER.warning(f"Skipping {type_} metric '{metric.description}' because it is unavailable: {reason}")
             continue
 
         available_metrics.append(metric)

--- a/decent_bench/benchmark/_compute.py
+++ b/decent_bench/benchmark/_compute.py
@@ -76,6 +76,7 @@ def compute_metrics(
 
     """
     start_logger(log_level=log_level)
+    LOGGER.info("Starting metrics computation")
 
     if benchmark_result is None:
         if checkpoint_manager is None:

--- a/decent_bench/benchmark/_display.py
+++ b/decent_bench/benchmark/_display.py
@@ -110,6 +110,7 @@ def display_metrics(  # noqa: PLR0912
 
     """
     logger.start_logger(log_level=log_level)
+    LOGGER.info("Displaying metrics")
 
     if metrics_result is None:
         if checkpoint_manager is None:

--- a/decent_bench/benchmark/_display.py
+++ b/decent_bench/benchmark/_display.py
@@ -12,7 +12,6 @@ from decent_bench.metrics import (
     display_tables,
 )
 from decent_bench.utils import logger
-from decent_bench.utils._metric_helpers import _flatten_plot_metrics
 from decent_bench.utils.logger import LOGGER
 
 if TYPE_CHECKING:
@@ -26,7 +25,7 @@ def display_metrics(  # noqa: PLR0912
     checkpoint_manager: "CheckpointManager | None" = None,
     *,
     table_metrics: list[Metric | str] | None = None,
-    plot_metrics: list[Metric | str] | list[list[Metric | str]] | None = None,
+    plot_metrics: list[Metric | str] | None = None,
     algorithms: list["Algorithm[Network] | str"] | None = None,
     table_fmt: Literal["grid", "latex"] = "grid",
     plot_grid: bool = True,
@@ -49,12 +48,12 @@ def display_metrics(  # noqa: PLR0912
         checkpoint_manager: if provided, will be used to load metrics result.
         table_metrics: metrics to tabulate, defaults to ``None`` which will display all metrics in the metrics_result.
             Entries can be :class:`~decent_bench.metrics.Metric` objects or strings
-            (matching :attr:`~decent_bench.metrics.Metric.table_description`).
+            (matching :attr:`~decent_bench.metrics.Metric.description`).
         plot_metrics: metrics to plot, defaults to ``None`` which will display all metrics in the metrics_result.
             Entries can be :class:`~decent_bench.metrics.Metric` objects or strings
-            (matching :attr:`~decent_bench.metrics.Metric.plot_description`).
-            If a list of lists is provided, each inner list will be plotted in a separate figure. Otherwise up to 3
-            metrics will be grouped and plotted in their own figure with subplots.
+            (matching :attr:`~decent_bench.metrics.Metric.description`).
+            If ``individual_plots`` is True, each metric is plotted in its own figure;
+            otherwise a maximum of 3 metrics are plotted as subplots in the same figure.
         algorithms: algorithms to display. If provided, only these algorithms are included in tables and plots.
             Entries can be :class:`~decent_bench.algorithms.Algorithm` objects or strings
             (matching :attr:`~decent_bench.algorithms.Algorithm.name`).
@@ -137,10 +136,10 @@ def display_metrics(  # noqa: PLR0912
     }
 
     if table_metrics is not None:
-        metrics_result.table_metrics = _get_new_table_metrics(metrics_result, table_metrics)
+        metrics_result.table_metrics = _get_new_metrics(metrics_result.table_metrics, table_metrics, "table")
 
     if plot_metrics is not None:
-        metrics_result.plot_metrics = _get_new_plot_metrics(metrics_result, plot_metrics)
+        metrics_result.plot_metrics = _get_new_metrics(metrics_result.plot_metrics, plot_metrics, "plot")
 
     if algorithms is not None:
         metrics_result = _filter_algorithms(metrics_result, algorithms)
@@ -215,70 +214,32 @@ def _filter_algorithms(
     return metrics_result
 
 
-def _get_new_table_metrics(
-    metrics_result: MetricResult,
-    table_metrics: list[Metric | str],
+def _get_new_metrics(
+    metrics: list[Metric] | None,
+    requested_metrics: list[Metric | str],
+    type_: Literal["table", "plot"],
 ) -> list[Metric]:
-    if metrics_result.table_metrics is None:
+    if metrics is None:
         return []
 
-    table_lookup = _build_metric_lookup(metrics_result.table_metrics, description_type="table")
+    lookup = _build_metric_lookup(metrics)
 
-    new_table_metrics = []
-    for metric_or_name in table_metrics:
-        metric_name = _get_name_or_value(metric_or_name, "table_description")
-        original_metric = table_lookup.get(metric_name)
+    new_metrics: list[Metric] = []
+    for metric_or_name in requested_metrics:
+        metric_name = _get_name_or_value(metric_or_name, "description")
+        original_metric = lookup.get(metric_name)
         if original_metric is None:
-            LOGGER.warning(f"Requested table metric '{metric_name}' not found in metrics result, skipping")
+            LOGGER.warning(f"Requested {type_} metric '{metric_name}' not found in metrics result, skipping")
             continue
-        new_table_metrics.append(original_metric)
+        new_metrics.append(original_metric)
 
-    return new_table_metrics
-
-
-def _get_new_plot_metrics(
-    metrics_result: MetricResult,
-    plot_metrics: list[Metric | str] | list[list[Metric | str]],
-) -> list[Metric] | list[list[Metric]]:
-    if metrics_result.plot_metrics is None:
-        return []
-
-    are_lists = [isinstance(item, list) for item in plot_metrics]
-    if any(are_lists) and not all(are_lists):
-        raise ValueError("If passing lists in ``plot_metrics``, all items must be lists.")
-
-    flat_metrics = _flatten_plot_metrics(metrics_result.plot_metrics)
-    plot_lookup = _build_metric_lookup(flat_metrics, description_type="plot")
-
-    new_plot_metrics = []
-    for group in plot_metrics:
-        if isinstance(group, list):
-            new_group = []
-            for metric_or_name in group:
-                metric_name = _get_name_or_value(metric_or_name, "plot_description")
-                original_metric = plot_lookup.get(metric_name)
-                if original_metric is None:
-                    LOGGER.warning(f"Requested plot metric '{metric_name}' not found in metrics result, skipping")
-                    continue
-                new_group.append(original_metric)
-            if new_group:
-                new_plot_metrics.append(new_group)
-        else:
-            metric_name = _get_name_or_value(group, "plot_description")
-            original_metric = plot_lookup.get(metric_name)
-            if original_metric is None:
-                LOGGER.warning(f"Requested plot metric '{metric_name}' not found in metrics result, skipping")
-                continue
-            new_plot_metrics.append(original_metric)  # type: ignore[arg-type]
-
-    return new_plot_metrics
+    return new_metrics
 
 
-def _build_metric_lookup(metrics: list[Metric], *, description_type: Literal["table", "plot"]) -> dict[str, Metric]:
+def _build_metric_lookup(metrics: list[Metric]) -> dict[str, Metric]:
     lookup: dict[str, Metric] = {}
     for metric in metrics:
-        description = metric.table_description if description_type == "table" else metric.plot_description
-        lookup.setdefault(description, metric)
+        lookup.setdefault(metric.description, metric)
 
     return lookup
 

--- a/decent_bench/benchmark/_metric_result.py
+++ b/decent_bench/benchmark/_metric_result.py
@@ -114,13 +114,15 @@ class MetricResult:
             for algorithm, table_metric_results in self.table_results.items():
                 for metric, statistics in table_metric_results.items():
                     for statistic_name, (mean, margin_of_error) in statistics.items():
-                        table_rows.append({
-                            "algorithm": algorithm.name,
-                            "metric": metric.description,
-                            "statistic": statistic_name,
-                            "mean": mean,
-                            "margin_of_error": margin_of_error,
-                        })
+                        table_rows.append(
+                            {
+                                "algorithm": algorithm.name,
+                                "metric": metric.description,
+                                "statistic": statistic_name,
+                                "mean": mean,
+                                "margin_of_error": margin_of_error,
+                            }
+                        )
 
             table_frame = pd.DataFrame.from_records(
                 table_rows,
@@ -139,14 +141,16 @@ class MetricResult:
                         y_max_values,
                         strict=True,
                     ):
-                        plot_rows.append({
-                            "algorithm": algorithm.name,
-                            "metric": metric.description,
-                            "x": x_value,
-                            "y_mean": y_mean,
-                            "y_min": y_min,
-                            "y_max": y_max,
-                        })
+                        plot_rows.append(
+                            {
+                                "algorithm": algorithm.name,
+                                "metric": metric.description,
+                                "x": x_value,
+                                "y_mean": y_mean,
+                                "y_min": y_min,
+                                "y_max": y_max,
+                            }
+                        )
 
             plot_frame = pd.DataFrame.from_records(
                 plot_rows,

--- a/decent_bench/benchmark/_metric_result.py
+++ b/decent_bench/benchmark/_metric_result.py
@@ -5,7 +5,6 @@ from decent_bench.agents import AgentMetricsView
 from decent_bench.algorithms import Algorithm
 from decent_bench.metrics import Metric
 from decent_bench.networks import Network
-from decent_bench.utils._metric_helpers import _flatten_plot_metrics
 
 
 @dataclass
@@ -33,7 +32,7 @@ class MetricResult:
 
     agent_metrics: Mapping[Algorithm[Network], Sequence[Sequence[AgentMetricsView]]] | None
     table_metrics: list[Metric] | None
-    plot_metrics: list[Metric] | list[list[Metric]] | None
+    plot_metrics: list[Metric] | None
     table_results: Mapping[Algorithm[Network], Mapping[Metric, Mapping[str, tuple[float, float]]]] | None
     plot_results: (
         Mapping[
@@ -55,10 +54,10 @@ class MetricResult:
 
     @property
     def available_table_metrics(self) -> list[str]:
-        """Return ``table_description`` of available metrics, which can be used for filtering in :func:`~decent_bench.benchmark.display_metrics`."""  # noqa: E501
-        return sorted({metric.table_description for metric in (self.table_metrics or [])})
+        """Return ``description`` of available table metrics, which can be used for filtering in :func:`~decent_bench.benchmark.display_metrics`."""  # noqa: E501
+        return sorted({metric.description for metric in (self.table_metrics or [])})
 
     @property
     def available_plot_metrics(self) -> list[str]:
-        """Return ``plot_descriptions`` of available metrics, which can be used for filtering in :func:`~decent_bench.benchmark.display_metrics`."""  # noqa: E501
-        return sorted({metric.plot_description for metric in (_flatten_plot_metrics(self.plot_metrics or []))})
+        """Return ``description`` of available plot metrics, which can be used for filtering in :func:`~decent_bench.benchmark.display_metrics`."""  # noqa: E501
+        return sorted({metric.description for metric in (self.plot_metrics or [])})

--- a/decent_bench/benchmark/_metric_result.py
+++ b/decent_bench/benchmark/_metric_result.py
@@ -1,23 +1,12 @@
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from importlib import import_module
-from types import ModuleType
-from typing import TYPE_CHECKING
+
+import pandas as pd
 
 from decent_bench.agents import AgentMetricsView
 from decent_bench.algorithms import Algorithm
 from decent_bench.metrics import Metric
 from decent_bench.networks import Network
-
-if TYPE_CHECKING:
-    import pandas
-
-
-def _import_pandas() -> ModuleType:
-    try:
-        return import_module("pandas")
-    except ImportError as exc:  # pragma: no cover - exercised when pandas is unavailable
-        raise ImportError("pandas is required to convert MetricResult to dataframes") from exc
 
 
 @dataclass
@@ -82,7 +71,7 @@ class MetricResult:
         """Return ``description`` of available plot metrics, which can be used for filtering in :func:`~decent_bench.benchmark.display_metrics`."""  # noqa: E501
         return sorted({metric.description for metric in (self.plot_metrics or [])})
 
-    def to_dataframe(self) -> tuple["pandas.DataFrame | None", "pandas.DataFrame | None"]:
+    def to_dataframe(self) -> tuple["pd.DataFrame | None", "pd.DataFrame | None"]:
         """
         Convert the stored metric results into pandas dataframes.
 
@@ -106,8 +95,6 @@ class MetricResult:
                 y_mean_values = loss_rows["y_mean"]
 
         """
-        pd = _import_pandas()
-
         table_frame = None
         if self.table_results is not None:
             table_rows: list[dict[str, object]] = []

--- a/decent_bench/benchmark/_metric_result.py
+++ b/decent_bench/benchmark/_metric_result.py
@@ -10,7 +10,7 @@ from decent_bench.metrics import Metric
 from decent_bench.networks import Network
 
 if TYPE_CHECKING:
-    from pandas import DataFrame
+    import pandas
 
 
 def _import_pandas() -> ModuleType:
@@ -75,7 +75,7 @@ class MetricResult:
         """Return ``description`` of available plot metrics, which can be used for filtering in :func:`~decent_bench.benchmark.display_metrics`."""  # noqa: E501
         return sorted({metric.description for metric in (self.plot_metrics or [])})
 
-    def to_dataframe(self) -> tuple["DataFrame | None", "DataFrame | None"]:
+    def to_dataframe(self) -> tuple["pandas.DataFrame | None", "pandas.DataFrame | None"]:
         """
         Convert the stored metric results into pandas dataframes.
 
@@ -104,18 +104,16 @@ class MetricResult:
         table_frame = None
         if self.table_results is not None:
             table_rows: list[dict[str, object]] = []
-            for algorithm, metric_results in self.table_results.items():
-                for metric, statistics in metric_results.items():
+            for algorithm, table_metric_results in self.table_results.items():
+                for metric, statistics in table_metric_results.items():
                     for statistic_name, (mean, margin_of_error) in statistics.items():
-                        table_rows.append(
-                            {
-                                "algorithm": algorithm.name,
-                                "metric": metric.description,
-                                "statistic": statistic_name,
-                                "mean": mean,
-                                "margin_of_error": margin_of_error,
-                            }
-                        )
+                        table_rows.append({
+                            "algorithm": algorithm.name,
+                            "metric": metric.description,
+                            "statistic": statistic_name,
+                            "mean": mean,
+                            "margin_of_error": margin_of_error,
+                        })
 
             table_frame = pd.DataFrame.from_records(
                 table_rows,
@@ -125,8 +123,8 @@ class MetricResult:
         plot_frame = None
         if self.plot_results is not None:
             plot_rows: list[dict[str, object]] = []
-            for algorithm, metric_results in self.plot_results.items():
-                for metric, (x_values, y_mean_values, y_min_values, y_max_values) in metric_results.items():
+            for algorithm, plot_metric_results in self.plot_results.items():
+                for metric, (x_values, y_mean_values, y_min_values, y_max_values) in plot_metric_results.items():
                     for x_value, y_mean, y_min, y_max in zip(
                         x_values,
                         y_mean_values,
@@ -134,16 +132,14 @@ class MetricResult:
                         y_max_values,
                         strict=True,
                     ):
-                        plot_rows.append(
-                            {
-                                "algorithm": algorithm.name,
-                                "metric": metric.description,
-                                "x": x_value,
-                                "y_mean": y_mean,
-                                "y_min": y_min,
-                                "y_max": y_max,
-                            }
-                        )
+                        plot_rows.append({
+                            "algorithm": algorithm.name,
+                            "metric": metric.description,
+                            "x": x_value,
+                            "y_mean": y_mean,
+                            "y_min": y_min,
+                            "y_max": y_max,
+                        })
 
             plot_frame = pd.DataFrame.from_records(
                 plot_rows,

--- a/decent_bench/benchmark/_metric_result.py
+++ b/decent_bench/benchmark/_metric_result.py
@@ -1,10 +1,23 @@
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from importlib import import_module
+from types import ModuleType
+from typing import TYPE_CHECKING
 
 from decent_bench.agents import AgentMetricsView
 from decent_bench.algorithms import Algorithm
 from decent_bench.metrics import Metric
 from decent_bench.networks import Network
+
+if TYPE_CHECKING:
+    from pandas import DataFrame
+
+
+def _import_pandas() -> ModuleType:
+    try:
+        return import_module("pandas")
+    except ImportError as exc:  # pragma: no cover - exercised when pandas is unavailable
+        raise ImportError("pandas is required to convert MetricResult to dataframes") from exc
 
 
 @dataclass
@@ -61,3 +74,80 @@ class MetricResult:
     def available_plot_metrics(self) -> list[str]:
         """Return ``description`` of available plot metrics, which can be used for filtering in :func:`~decent_bench.benchmark.display_metrics`."""  # noqa: E501
         return sorted({metric.description for metric in (self.plot_metrics or [])})
+
+    def to_dataframe(self) -> tuple["DataFrame | None", "DataFrame | None"]:
+        """
+        Convert the stored metric results into pandas dataframes.
+
+        Returns:
+            ``table_results``: a dataframe with columns ``algorithm``, ``metric``, ``statistic``, ``mean``, and
+                ``margin_of_error``.
+            ``plot_results``: a dataframe with columns ``algorithm``, ``metric``, ``x``, ``y_mean``, ``y_min``,
+                and ``y_max``.
+
+        Examples:
+            Access the table dataframe and filter for a specific algorithm:
+
+                table_df, plot_df = metric_result.to_dataframe()
+                a_rows = table_df[table_df["algorithm"] == "A"]
+
+            Access the full x and y_mean vectors for one algorithm and metric:
+
+                table_df, plot_df = metric_result.to_dataframe()
+                loss_rows = plot_df[(plot_df["algorithm"] == "A") & (plot_df["metric"] == "loss")]
+                x_values = loss_rows["x"]
+                y_mean_values = loss_rows["y_mean"]
+
+        """
+        pd = _import_pandas()
+
+        table_frame = None
+        if self.table_results is not None:
+            table_rows: list[dict[str, object]] = []
+            for algorithm, metric_results in self.table_results.items():
+                for metric, statistics in metric_results.items():
+                    for statistic_name, (mean, margin_of_error) in statistics.items():
+                        table_rows.append(
+                            {
+                                "algorithm": algorithm.name,
+                                "metric": metric.description,
+                                "statistic": statistic_name,
+                                "mean": mean,
+                                "margin_of_error": margin_of_error,
+                            }
+                        )
+
+            table_frame = pd.DataFrame.from_records(
+                table_rows,
+                columns=["algorithm", "metric", "statistic", "mean", "margin_of_error"],
+            )
+
+        plot_frame = None
+        if self.plot_results is not None:
+            plot_rows: list[dict[str, object]] = []
+            for algorithm, metric_results in self.plot_results.items():
+                for metric, (x_values, y_mean_values, y_min_values, y_max_values) in metric_results.items():
+                    for x_value, y_mean, y_min, y_max in zip(
+                        x_values,
+                        y_mean_values,
+                        y_min_values,
+                        y_max_values,
+                        strict=True,
+                    ):
+                        plot_rows.append(
+                            {
+                                "algorithm": algorithm.name,
+                                "metric": metric.description,
+                                "x": x_value,
+                                "y_mean": y_mean,
+                                "y_min": y_min,
+                                "y_max": y_max,
+                            }
+                        )
+
+            plot_frame = pd.DataFrame.from_records(
+                plot_rows,
+                columns=["algorithm", "metric", "x", "y_mean", "y_min", "y_max"],
+            )
+
+        return table_frame, plot_frame

--- a/decent_bench/benchmark/_utils.py
+++ b/decent_bench/benchmark/_utils.py
@@ -18,8 +18,9 @@ SOLVE_STOP_TOL = 1e-20
 SOLVE_MAX_TOL = 1e-16
 
 
-def create_classification_problem(  # noqa: PLR0917
+def create_classification_problem(
     cost_cls: type[LogisticRegressionCost | PyTorchCost] = LogisticRegressionCost,
+    *,
     device: SupportedDevices = SupportedDevices.CPU,
     n_agents: int = 100,
     batch_size: EmpiricalRiskBatchSize = "all",
@@ -108,10 +109,9 @@ def create_classification_problem(  # noqa: PLR0917
             LogisticRegressionCost(dataset=p, batch_size=batch_size) for p in dataset.get_partitions()
         ]
         LOGGER.info("... done!")
-        sum_cost = reduce(add, classification_costs)
-        if sum_cost.batch_size < sum_cost.n_samples:
-            sum_cost._batch_size = sum_cost.n_samples  # noqa: SLF001
         if compute_x_optimal:
+            # agents have the same n_samples, so minimizing a single logistic cost with all data is equivalent
+            sum_cost = LogisticRegressionCost(dataset=dataset.get_datapoints(), batch_size="all")
             x_optimal = ca.solve(
                 sum_cost,
                 max_iter=SOLVE_MAX_ITER,
@@ -126,13 +126,13 @@ def create_classification_problem(  # noqa: PLR0917
     return costs, x_optimal, test_data.get_datapoints()
 
 
-def create_regression_problem(  # noqa: PLR0917
+def create_regression_problem(
     cost_cls: type[LinearRegressionCost | PyTorchCost] = LinearRegressionCost,
+    *,
     device: SupportedDevices = SupportedDevices.CPU,
     n_agents: int = 100,
     batch_size: EmpiricalRiskBatchSize = "all",
     compute_x_optimal: bool = True,
-    show_progress: bool = True,
 ) -> tuple[Sequence[Cost], Array | None, Dataset]:
     """
     Create out-of-the-box regression problems.
@@ -143,8 +143,7 @@ def create_regression_problem(  # noqa: PLR0917
         n_agents: number of agents
         batch_size: size of mini-batches for stochastic methods, or "all" for full-batch
         compute_x_optimal: if the optimal solution should be computed
-            (using :func:`~decent_bench.centralized_algorithms.solve`). It is ignored when PyTorchCost is selected.
-        show_progress: whether to display a progress bar while computing ``x_optimal``. Defaults to ``True``.
+            (by solving the linear system of equations). It is ignored when PyTorchCost is selected.
 
     Note:
         If cost_cls is :class:`~decent_bench.costs.PyTorchCost`, x_optimal is not computed and set to None.
@@ -208,16 +207,14 @@ def create_regression_problem(  # noqa: PLR0917
             LinearRegressionCost(dataset=p, batch_size=batch_size) for p in dataset.get_partitions()
         ]
         LOGGER.info("... done!")
-        sum_cost = reduce(add, regression_costs)
-        if sum_cost.batch_size < sum_cost.n_samples:
-            sum_cost._batch_size = sum_cost.n_samples  # noqa: SLF001
+
         if compute_x_optimal:
             x_optimal = ca.solve(
-                sum_cost,
+                reduce(add, regression_costs),
                 max_iter=SOLVE_MAX_ITER,
                 stop_tol=SOLVE_STOP_TOL,
                 max_tol=SOLVE_MAX_TOL,
-                show_progress=show_progress,
+                show_progress=False,
             )
         costs = regression_costs
     else:
@@ -250,9 +247,8 @@ def create_quadratic_problem(
     costs = [QuadraticCost(A[i], b[i]) for i in range(n_agents)]
     LOGGER.info("... done!")
 
-    sum_cost = reduce(add, costs)
     x_optimal = ca.solve(
-        sum_cost,
+        reduce(add, costs),
         max_iter=SOLVE_MAX_ITER,
         stop_tol=SOLVE_STOP_TOL,
         max_tol=SOLVE_MAX_TOL,

--- a/decent_bench/benchmark/_utils.py
+++ b/decent_bench/benchmark/_utils.py
@@ -18,11 +18,12 @@ SOLVE_STOP_TOL = 1e-20
 SOLVE_MAX_TOL = 1e-16
 
 
-def create_classification_problem(
+def create_classification_problem(  # noqa: PLR0917
     cost_cls: type[LogisticRegressionCost | PyTorchCost] = LogisticRegressionCost,
     device: SupportedDevices = SupportedDevices.CPU,
     n_agents: int = 100,
     batch_size: EmpiricalRiskBatchSize = "all",
+    compute_x_optimal: bool = True,
     show_progress: bool = True,
 ) -> tuple[Sequence[Cost], Array | None, Dataset]:
     """
@@ -33,6 +34,8 @@ def create_classification_problem(
         device: device to create the problem on (only relevant for PyTorchCost)
         n_agents: number of agents
         batch_size: size of mini-batches for stochastic methods, or "all" for full-batch
+        compute_x_optimal: if the optimal solution should be computed
+            (using :func:`~decent_bench.centralized_algorithms.solve`). It is ignored when PyTorchCost is selected.
         show_progress: whether to display a progress bar while computing ``x_optimal``. Defaults to ``True``.
 
     Note:
@@ -69,6 +72,7 @@ def create_classification_problem(
         squeeze_targets=cost_cls is PyTorchCost,
     )
 
+    x_optimal = None
     if cost_cls is PyTorchCost:
         try:
             import torch  # noqa: PLC0415
@@ -99,7 +103,6 @@ def create_classification_problem(
         ]
         LOGGER.info("... done!")
         costs: Sequence[Cost] = pytorch_costs
-        x_optimal = None
     elif cost_cls is LogisticRegressionCost:
         classification_costs: list[LogisticRegressionCost] = [
             LogisticRegressionCost(dataset=p, batch_size=batch_size) for p in dataset.get_partitions()
@@ -108,13 +111,14 @@ def create_classification_problem(
         sum_cost = reduce(add, classification_costs)
         if sum_cost.batch_size < sum_cost.n_samples:
             sum_cost._batch_size = sum_cost.n_samples  # noqa: SLF001
-        x_optimal = ca.solve(
-            sum_cost,
-            max_iter=SOLVE_MAX_ITER,
-            stop_tol=SOLVE_STOP_TOL,
-            max_tol=SOLVE_MAX_TOL,
-            show_progress=show_progress,
-        )
+        if compute_x_optimal:
+            x_optimal = ca.solve(
+                sum_cost,
+                max_iter=SOLVE_MAX_ITER,
+                stop_tol=SOLVE_STOP_TOL,
+                max_tol=SOLVE_MAX_TOL,
+                show_progress=show_progress,
+            )
         costs = classification_costs
     else:
         raise ValueError(f"Unsupported cost class: {cost_cls}")
@@ -122,11 +126,12 @@ def create_classification_problem(
     return costs, x_optimal, test_data.get_datapoints()
 
 
-def create_regression_problem(
+def create_regression_problem(  # noqa: PLR0917
     cost_cls: type[LinearRegressionCost | PyTorchCost] = LinearRegressionCost,
     device: SupportedDevices = SupportedDevices.CPU,
     n_agents: int = 100,
     batch_size: EmpiricalRiskBatchSize = "all",
+    compute_x_optimal: bool = True,
     show_progress: bool = True,
 ) -> tuple[Sequence[Cost], Array | None, Dataset]:
     """
@@ -137,6 +142,8 @@ def create_regression_problem(
         device: device to create the problem on (only relevant for PyTorchCost)
         n_agents: number of agents
         batch_size: size of mini-batches for stochastic methods, or "all" for full-batch
+        compute_x_optimal: if the optimal solution should be computed
+            (using :func:`~decent_bench.centralized_algorithms.solve`). It is ignored when PyTorchCost is selected.
         show_progress: whether to display a progress bar while computing ``x_optimal``. Defaults to ``True``.
 
     Note:
@@ -172,6 +179,8 @@ def create_regression_problem(
         feature_dtype=np.float32 if cost_cls is PyTorchCost else np.float64,
         target_dtype=np.float32 if cost_cls is PyTorchCost else np.float64,
     )
+
+    x_optimal = None
     if cost_cls is PyTorchCost:
         try:
             import torch  # noqa: PLC0415
@@ -194,7 +203,6 @@ def create_regression_problem(
         ]
         LOGGER.info("... done!")
         costs: Sequence[Cost] = pytorch_costs
-        x_optimal = None
     elif cost_cls is LinearRegressionCost:
         regression_costs: list[LinearRegressionCost] = [
             LinearRegressionCost(dataset=p, batch_size=batch_size) for p in dataset.get_partitions()
@@ -203,13 +211,14 @@ def create_regression_problem(
         sum_cost = reduce(add, regression_costs)
         if sum_cost.batch_size < sum_cost.n_samples:
             sum_cost._batch_size = sum_cost.n_samples  # noqa: SLF001
-        x_optimal = ca.solve(
-            sum_cost,
-            max_iter=SOLVE_MAX_ITER,
-            stop_tol=SOLVE_STOP_TOL,
-            max_tol=SOLVE_MAX_TOL,
-            show_progress=show_progress,
-        )
+        if compute_x_optimal:
+            x_optimal = ca.solve(
+                sum_cost,
+                max_iter=SOLVE_MAX_ITER,
+                stop_tol=SOLVE_STOP_TOL,
+                max_tol=SOLVE_MAX_TOL,
+                show_progress=show_progress,
+            )
         costs = regression_costs
     else:
         raise ValueError(f"Unsupported cost class: {cost_cls}")
@@ -220,7 +229,6 @@ def create_regression_problem(
 def create_quadratic_problem(
     size: int = 10,
     n_agents: int = 100,
-    show_progress: bool = True,
 ) -> tuple[Sequence[Cost], Array]:
     """
     Create out-of-the-box quadratic problems.
@@ -228,7 +236,6 @@ def create_quadratic_problem(
     Args:
         size: number of dimensions
         n_agents: number of agents
-        show_progress: whether to display a progress bar while computing ``x_optimal``. Defaults to ``True``.
 
     """
     if not LOGGER.handlers:
@@ -249,7 +256,7 @@ def create_quadratic_problem(
         max_iter=SOLVE_MAX_ITER,
         stop_tol=SOLVE_STOP_TOL,
         max_tol=SOLVE_MAX_TOL,
-        show_progress=show_progress,
+        show_progress=False,
     )
 
     return costs, x_optimal

--- a/decent_bench/centralized_algorithms.py
+++ b/decent_bench/centralized_algorithms.py
@@ -54,10 +54,20 @@ def solve(
         stop_criteria += f" Will raise if ||x_new - x_old||^2 > {max_tol} at the end."
 
     # quadratic
-    from decent_bench.costs import QuadraticCost  # noqa: PLC0415
+    from decent_bench.costs import LinearRegressionCost, QuadraticCost, SumCost  # noqa: PLC0415
 
     if isinstance(cost, QuadraticCost):
         x_optimal = Array(np.linalg.solve(cost.A, -cost.b))
+    # linear regression
+    elif isinstance(cost, SumCost) and all(isinstance(c, LinearRegressionCost) for c in cost.costs):
+        z = iop.zeros(framework=cost.costs[0].framework, device=cost.costs[0].device, shape=cost.costs[0].shape)
+        Q = np.asarray(sum(c.hessian(z, indices="all") for c in cost.costs))  # noqa: N806
+        r = np.asarray(sum(c.gradient(z, indices="all") for c in cost.costs))
+        try:
+            x_optimal_np = np.linalg.solve(Q, -r)
+        except np.linalg.LinAlgError:
+            x_optimal_np = np.linalg.lstsq(Q, -r, rcond=None)[0]
+        x_optimal = Array(x_optimal_np)
     # exclude costs with m_smooth = 0
     elif np.isfinite(cost.m_smooth) and np.isfinite(cost.m_cvx) and cost.m_smooth == 0:
         raise ValueError("Costs with m_smooth = 0 are not supported.")

--- a/decent_bench/costs/_base/_cost.py
+++ b/decent_bench/costs/_base/_cost.py
@@ -10,7 +10,7 @@ from decent_bench.utils.array import Array
 from decent_bench.utils.types import SupportedDevices, SupportedFrameworks
 
 
-class Cost(ABC):  # noqa: PLR0904
+class Cost(ABC):
     """Used by agents to evaluate the cost and its derivatives at a certain x."""
 
     def _validate_cost_operation(

--- a/decent_bench/costs/_base/_cost.py
+++ b/decent_bench/costs/_base/_cost.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import cached_property
+from math import prod
 from numbers import Real
 from typing import Any
 
@@ -44,6 +46,11 @@ class Cost(ABC):  # noqa: PLR0904
     def domain_shape(self) -> tuple[int, ...]:
         """Alias for :attr:`shape`."""
         return self.shape
+
+    @cached_property
+    def size(self) -> int:
+        """Number of elements in x."""
+        return prod(self.shape)
 
     @property
     @abstractmethod

--- a/decent_bench/costs/_empirical_risk/_linear_regression_cost.py
+++ b/decent_bench/costs/_empirical_risk/_linear_regression_cost.py
@@ -7,7 +7,6 @@ from numpy import float64
 from numpy.typing import NDArray
 
 import decent_bench.utils.interoperability as iop
-from decent_bench.costs._base._cost import Cost
 from decent_bench.costs._empirical_risk._empirical_risk_cost import EmpiricalRiskCost
 from decent_bench.utils._tags import tags
 from decent_bench.utils.types import (
@@ -314,30 +313,9 @@ class LinearRegressionCost(EmpiricalRiskCost):
                 self.ATA = self.A.T @ self.A
             return self.A, self.ATA, self.b
 
-        A_list, b_list = [], []  # noqa: N806
-        for idx in indices:
+        A, b = np.empty((len(indices), *self.shape)), np.empty(len(indices))  # noqa: N806
+        for i, idx in enumerate(indices):
             x_i, y_i = self._dataset[idx]
-            A_list.append(iop.to_numpy(x_i))
-            b_list.append(iop.to_numpy(y_i))
-        A = np.stack(A_list)  # noqa: N806
-        b = np.stack(b_list).squeeze()
+            A[i, :] = iop.to_numpy(x_i)
+            b[i] = iop.to_numpy(y_i).item()
         return A, A.T @ A, b
-
-    def __add__(self, other: Cost) -> Cost:
-        """Add another cost function."""
-        self._validate_cost_operation(other)
-        if isinstance(other, LinearRegressionCost):
-            if self.batch_size == self.n_samples and other.batch_size == other.n_samples:
-                combined_batch_size = self.n_samples + other.n_samples
-            elif self.batch_size == self.n_samples:
-                combined_batch_size = other.batch_size
-            elif other.batch_size == other.n_samples:
-                combined_batch_size = self.batch_size
-            else:
-                combined_batch_size = max(self.batch_size, other.batch_size)
-
-            return LinearRegressionCost(
-                dataset=self.dataset + other.dataset,
-                batch_size=combined_batch_size,
-            )
-        return super().__add__(other)

--- a/decent_bench/costs/_empirical_risk/_logistic_regression_cost.py
+++ b/decent_bench/costs/_empirical_risk/_logistic_regression_cost.py
@@ -10,7 +10,6 @@ from scipy import special
 
 import decent_bench.centralized_algorithms as ca
 import decent_bench.utils.interoperability as iop
-from decent_bench.costs._base._cost import Cost
 from decent_bench.utils._tags import tags
 from decent_bench.utils.array import Array
 from decent_bench.utils.types import (
@@ -329,32 +328,11 @@ class LogisticRegressionCost(EmpiricalRiskCost):
                     self.b[np.where(self.b == self._label_mapping[k])] = k
             return self.A, self.b
 
-        A_list, b_list = [], []  # noqa: N806
-        for idx in indices:
+        A, b = np.empty((len(indices), *self.shape)), np.empty(len(indices))  # noqa: N806
+        for i, idx in enumerate(indices):
             x_i, y_i = self._dataset[idx]
-            A_list.append(iop.to_numpy(x_i))
-            b_list.append(iop.to_numpy(y_i))
-        A = np.stack(A_list)  # noqa: N806
-        b = np.stack(b_list).squeeze()
+            A[i, :] = iop.to_numpy(x_i)
+            b[i] = iop.to_numpy(y_i).item()
         for k in self._label_mapping:
             b[np.where(b == self._label_mapping[k])] = k
         return A, b
-
-    def __add__(self, other: Cost) -> Cost:
-        """Add another cost function."""
-        self._validate_cost_operation(other)
-        if isinstance(other, LogisticRegressionCost):
-            if self.batch_size == self.n_samples and other.batch_size == other.n_samples:
-                combined_batch_size = self.n_samples + other.n_samples
-            elif self.batch_size == self.n_samples:
-                combined_batch_size = other.batch_size
-            elif other.batch_size == other.n_samples:
-                combined_batch_size = self.batch_size
-            else:
-                combined_batch_size = max(self.batch_size, other.batch_size)
-
-            return LogisticRegressionCost(
-                dataset=self._dataset + other._dataset,
-                batch_size=combined_batch_size,
-            )
-        return super().__add__(other)

--- a/decent_bench/metrics/_metric.py
+++ b/decent_bench/metrics/_metric.py
@@ -25,7 +25,7 @@ class Metric(ABC):
     Abstract base class for metrics.
 
     In order to create a new metric, subclass this class and implement the abstract methods
-    :func:`table_description`, :func:`plot_description`, and :func:`get_data_from_trial`.
+    :func:`description` and :func:`get_data_from_trial`.
     If you don't want the table to indicate whether the metric has diverged then override :func:`can_diverge`
     to return False. If you don't want to use the default behavior for :func:`get_table_data` or :func:`get_plot_data`
     you can also override those methods but this is not common. See the documentation for each method for more details
@@ -64,13 +64,8 @@ class Metric(ABC):
 
     @property
     @abstractmethod
-    def table_description(self) -> str:
-        """Metric description to display in the table."""
-
-    @property
-    @abstractmethod
-    def plot_description(self) -> str:
-        """Label for the y-axis in plots."""
+    def description(self) -> str:
+        """Metric description used as the table row label and y-axis label in plots."""
 
     @property
     def can_diverge(self) -> bool:

--- a/decent_bench/metrics/_metric.py
+++ b/decent_bench/metrics/_metric.py
@@ -33,8 +33,9 @@ class Metric(ABC):
 
     Args:
         statistics: sequence of statistics such as :func:`min`, :func:`sum`, and :func:`~numpy.average` used for
-            aggregating the data retrieved with :func:`get_data_from_trial` into a single value, each statistic gets its
-            own row in the table.
+            aggregating across agents the data retrieved with :func:`get_data_from_trial` into a single value;
+            each statistic gets its own row in the table. If it is None (the default) or an empty list,
+            :func:`~numpy.average` is used as statistic.
         fmt: format string used to format the values in the table, defaults to ".2e". Common formats include:
 
             - ".2e": scientific notation with 2 decimal places
@@ -51,13 +52,12 @@ class Metric(ABC):
 
     def __init__(
         self,
-        statistics: Sequence[Statistic],
-        *,
+        statistics: Sequence[Statistic] | None = None,
         fmt: str = ".2e",
         x_log: bool = False,
         y_log: bool = True,
     ) -> None:
-        self.statistics = statistics
+        self.statistics = statistics or [utils.default_statistic]
         self.x_log = x_log
         self.y_log = y_log
         self.fmt = fmt

--- a/decent_bench/metrics/_plots.py
+++ b/decent_bench/metrics/_plots.py
@@ -17,7 +17,6 @@ from decent_bench.algorithms import Algorithm
 from decent_bench.metrics._computational_cost import ComputationalCost
 from decent_bench.metrics._metric import Metric, X, Y
 from decent_bench.networks import Network
-from decent_bench.utils._metric_helpers import _flatten_plot_metrics
 from decent_bench.utils.logger import LOGGER
 
 if TYPE_CHECKING:
@@ -71,8 +70,8 @@ def display_plots(
     Display plots for the metric results.
 
     Each algorithm's curve is its mean across the trials. The surrounding envelope is the min and max across the trials.
-    If metrics is a list of lists, each inner list will be plotted in a separate figure. Otherwise groups of 3 metrics
-    will be plotted together in subplots of the same figure.
+    Metrics are grouped into figures with up to 3 subplots each, unless ``individual_plots`` is True, in which case
+    each metric is plotted in its own figure.
 
     Args:
         metrics_result: result of metrics computation containing the metrics to plot and the data to plot them with.
@@ -138,10 +137,10 @@ def display_plots(
     _save_and_show_figures(all_figures, plot_path=plot_path, plot_format=plot_format, show_plots=show_plots)
 
 
-def compute_plots(  # noqa: PLR0914
+def compute_plots(
     resulting_agent_states: dict[Algorithm[Network], list[list[AgentMetricsView]]],
     problem: "BenchmarkProblem",
-    metrics: list[Metric] | list[list[Metric]],
+    metrics: list[Metric],
 ) -> Mapping[
     Algorithm[Network], Mapping[Metric, tuple[Sequence[float], Sequence[float], Sequence[float], Sequence[float]]]
 ]:
@@ -153,8 +152,7 @@ def compute_plots(  # noqa: PLR0914
     Args:
         resulting_agent_states: resulting agent states from the trial executions, grouped by algorithm
         problem: benchmark problem whose properties are used for metric calculations
-        metrics: metrics to calculate and plot. If a list of lists is provided, each inner list will be plotted in a
-            separate figure. Otherwise groups of 3 metrics will be plotted together in subplots of the same figure
+        metrics: metrics to calculate and plot. A maximum of 3 metrics are plotted as subplots in the same figure
 
     Returns:
         A nested dictionary containing plot data for each algorithm and metric, structured as
@@ -174,8 +172,6 @@ def compute_plots(  # noqa: PLR0914
     if not metrics:
         return {}
 
-    flat_metrics = _flatten_plot_metrics(metrics)
-
     algs = list(resulting_agent_states)
     results: dict[
         Algorithm[Network],
@@ -183,15 +179,15 @@ def compute_plots(  # noqa: PLR0914
     ] = {alg: {} for alg in algs}
 
     with utils.MetricProgressBar() as progress:
-        total_plots = len(flat_metrics) * len(resulting_agent_states)
+        total_plots = len(metrics) * len(resulting_agent_states)
         plot_task = progress.add_task(
             "Computing plot metrics",
             total=total_plots,
             status="",
         )
 
-        for metric in flat_metrics:
-            progress.update(plot_task, status=f"Task: {metric.plot_description}")
+        for metric in metrics:
+            progress.update(plot_task, status=f"Task: {metric.description}")
 
             for alg, agent_states in resulting_agent_states.items():
                 data_per_trial: list[Sequence[tuple[X, Y]]] = _plot_data_per_trial(
@@ -205,12 +201,12 @@ def compute_plots(  # noqa: PLR0914
                 if not truncated_data_per_trial:
                     if had_non_finite:
                         LOGGER.warning(
-                            f"Skipping plot computation for {metric.plot_description} and {alg.name}: "
+                            f"Skipping plot computation for {metric.description} and {alg.name}: "
                             "all trials diverged before the first plottable datapoint."
                         )
                     else:
                         LOGGER.warning(
-                            f"Skipping plot computation for {metric.plot_description} and {alg.name}: "
+                            f"Skipping plot computation for {metric.description} and {alg.name}: "
                             "metric produced no datapoints."
                         )
                     progress.advance(plot_task)
@@ -221,7 +217,7 @@ def compute_plots(  # noqa: PLR0914
                     total_trials = len(data_per_trial)
                     retained_points = len(truncated_data_per_trial[0])
                     LOGGER.info(
-                        f"Truncating plot computation for {metric.plot_description} and {alg.name} "
+                        f"Truncating plot computation for {metric.description} and {alg.name} "
                         "at the first non-finite or over-threshold datapoint; retained "
                         f"{retained_points} point(s) from {retained_trials}/{total_trials} trial(s)."
                     )
@@ -283,14 +279,14 @@ def _create_and_plot_figures(  # noqa: PLR0912
                     offset = 1 - min(x)
                     x = [val + offset for val in x]  # avoid log(a), a<=0 issues
                     LOGGER.warning(
-                        f"Metric '{metric.plot_description}' has x_log=True but contains non-positive x values. "
+                        f"Metric '{metric.description}' has x_log=True but contains non-positive x values. "
                         f"Added {offset} to all x values for plotting purposes."
                     )
                 if metric.y_log and any(val <= 0 for val in y_mean):
                     non_positive_replacement = min(*(val for val in y_mean if val > 0), 1e-8)
                     y_mean = [val if val > 0 else non_positive_replacement for val in y_mean]
                     LOGGER.warning(
-                        f"Metric '{metric.plot_description}' has y_log=True but contains non-positive y values for"
+                        f"Metric '{metric.description}' has y_log=True but contains non-positive y values for"
                         f"algorithm {alg.name}. These values have been replaced with {non_positive_replacement} for "
                         f"plotting purposes."
                     )
@@ -362,44 +358,24 @@ def _save_and_show_figures(
 
 
 def _organize_metrics_into_groups(
-    metrics: list[Metric] | list[list[Metric]],
+    metrics: list[Metric],
     individual_plots: bool,
 ) -> list[list[Metric]]:
     """
     Organize metrics into groups where each group will be plotted in one figure.
 
     Args:
-        metrics: Either a flat list of metrics or a list of lists of metrics
+        metrics: list of metrics
         individual_plots: If True, each metric gets its own figure
 
     Returns:
         List of metric groups, where each group will be plotted in one figure
 
-    Raises:
-        ValueError: If metrics is a list of lists but not all elements are lists
-
     """
-    # Check if metrics is list[list[Metric]]
-    if any(isinstance(m, list) for m in metrics):
-        if not all(isinstance(m, list) for m in metrics):
-            raise ValueError("If metrics is a list of lists, all elements must be lists.")
-        if individual_plots:
-            # Flatten and make each metric its own group
-            flat_metrics: list[Metric] = [m for group in metrics for m in group]  # type: ignore[union-attr]
-            return [[metric] for metric in flat_metrics]
-
-        # Use the provided grouping
-        return metrics  # type: ignore[return-value]
-
-    # Flat list[Metric]
-    flat_metrics_list: list[Metric] = metrics  # type: ignore[assignment]
     if individual_plots:
-        # Each metric in its own figure
-        return [[metric] for metric in flat_metrics_list]
+        return [[metric] for metric in metrics]
 
-    # Group into chunks of up to 3 metrics per figure
-    groups: list[list[Metric]] = [flat_metrics_list[i : i + 3] for i in range(0, len(flat_metrics_list), 3)]
-    return groups
+    return [metrics[i : i + 3] for i in range(0, len(metrics), 3)]
 
 
 def _create_metric_subplots(
@@ -445,7 +421,7 @@ def _create_metric_subplots(
 
         # Only set y label for left column subplots
         if i % n_cols == 0:
-            sp.set_ylabel(metric.plot_description)
+            sp.set_ylabel(metric.description)
 
         if metric.x_log:
             sp.set_xscale("log")

--- a/decent_bench/metrics/_plots.py
+++ b/decent_bench/metrics/_plots.py
@@ -565,7 +565,7 @@ def _truncate_to_common_finite_prefix(
     return [trial_data[:common_prefix_length] for trial_data in truncated_trials], had_non_finite
 
 
-def _plot_subplot(  # noqa: PLR0917
+def _plot_subplot(
     subplot: SubPlot,
     x: Sequence[float],
     y_mean: Sequence[float],

--- a/decent_bench/metrics/_plots.py
+++ b/decent_bench/metrics/_plots.py
@@ -52,6 +52,8 @@ LEGEND_MAX_COLS = 3
 SEPARATE_LEGEND_MIN_LABELS = 9
 SEPARATE_LEGEND_MIN_ROWS = 4
 SEPARATE_LEGEND_MAX_LABEL_LENGTH = 24
+# max number of subplots in a figure
+MAX_NUM_SUBPLOTS = 3
 
 
 def display_plots(
@@ -375,7 +377,7 @@ def _organize_metrics_into_groups(
     if individual_plots:
         return [[metric] for metric in metrics]
 
-    return [metrics[i : i + 3] for i in range(0, len(metrics), 3)]
+    return [metrics[i : i + MAX_NUM_SUBPLOTS] for i in range(0, len(metrics), MAX_NUM_SUBPLOTS)]
 
 
 def _create_metric_subplots(

--- a/decent_bench/metrics/_runtime_metric_plotter.py
+++ b/decent_bench/metrics/_runtime_metric_plotter.py
@@ -62,7 +62,7 @@ class RuntimeMetricPlotter:
         # Set matplotlib to use a backend that works in a separate process
         plt.ion()
 
-        try:  # noqa: PLR1702
+        try:
             while True:
                 processed = 0
                 try:

--- a/decent_bench/metrics/_tables.py
+++ b/decent_bench/metrics/_tables.py
@@ -71,12 +71,12 @@ def display_tables(
 
     table_results = metrics_result.table_results
     algs = list(table_results.keys())
-    headers = ["Metric (statistic)"] + [alg.name for alg in algs]
+    headers = ["Metric (statistic across agents)"] + [alg.name for alg in algs]
     rows: list[list[str]] = []
 
     for metric in metrics_result.table_metrics:
         for statistic_name in table_results[algs[0]][metric]:
-            row = [f"{metric.description} ({statistic_name})"]
+            row = [f"{metric.description} ({statistic_name})"] if statistic_name else [f"{metric.description}"]
             for alg in algs:
                 mean, margin_of_error = table_results[alg][metric][statistic_name]
 
@@ -148,6 +148,8 @@ def compute_tables(
 
             for statistic in metric.statistics:
                 statistic_name = STATISTICS_ABBR.get(statistic.__name__) or statistic.__name__
+                if statistic_name == "default_statistic":
+                    statistic_name = ""
                 for i, alg in enumerate(algs):
                     agg_data_per_trial = [statistic(trial) for trial in data_per_trial[i]]
                     mean, margin_of_error = _calculate_mean_and_margin_of_error(agg_data_per_trial, confidence_level)

--- a/decent_bench/metrics/_tables.py
+++ b/decent_bench/metrics/_tables.py
@@ -60,7 +60,7 @@ def display_tables(
     ):
         metric_views = next(iter(metrics_result.agent_metrics.values()))[0]
         scale_metrics_in_use = [
-            metric.table_description for metric in metrics_result.table_metrics if isinstance(metric, SCALE_METRICS)
+            metric.description for metric in metrics_result.table_metrics if isinstance(metric, SCALE_METRICS)
         ]
         if any(isinstance(a.cost, EmpiricalRiskCost) for a in metric_views):
             LOGGER.info(
@@ -76,7 +76,7 @@ def display_tables(
 
     for metric in metrics_result.table_metrics:
         for statistic_name in table_results[algs[0]][metric]:
-            row = [f"{metric.table_description} ({statistic_name})"]
+            row = [f"{metric.description} ({statistic_name})"]
             for alg in algs:
                 mean, margin_of_error = table_results[alg][metric][statistic_name]
 
@@ -142,7 +142,7 @@ def compute_tables(
             status="",
         )
         for metric in metrics:
-            progress.update(table_task, status=f"Task: {metric.table_description}")
+            progress.update(table_task, status=f"Task: {metric.description}")
 
             data_per_trial = [_table_data_per_trial(resulting_agent_states[a], problem, metric) for a in algs]
 

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -35,8 +35,7 @@ class Regret(Metric):
 
     """
 
-    table_description: str = "regret"
-    plot_description: str = "regret"
+    description: str = "regret"
 
     def is_available(  # noqa: D102
         self,
@@ -71,8 +70,7 @@ class GradientNorm(Metric):
 
     """
 
-    table_description: str = "gradient norm"
-    plot_description: str = "gradient norm"
+    description: str = "gradient norm"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -107,8 +105,7 @@ class XError(Metric):
 
     """
 
-    table_description: str = "x error"
-    plot_description: str = "x error"
+    description: str = "x error"
 
     def is_available(  # noqa: D102
         self,
@@ -150,8 +147,7 @@ class ConsensusError(Metric):
 
     """
 
-    table_description: str = "consensus error"
-    plot_description: str = "consensus error"
+    description: str = "consensus error"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -178,8 +174,7 @@ class XUpdates(Metric):
 
     """
 
-    table_description: str = "nr x updates"
-    plot_description: str = "nr x updates"
+    description: str = "nr x updates"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -208,8 +203,7 @@ class FunctionCalls(Metric):
 
     """
 
-    table_description: str = "nr function calls"
-    plot_description: str = "nr function calls"
+    description: str = "nr function calls"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -238,8 +232,7 @@ class GradientCalls(Metric):
 
     """
 
-    table_description: str = "nr gradient calls"
-    plot_description: str = "nr gradient calls"
+    description: str = "nr gradient calls"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -268,8 +261,7 @@ class HessianCalls(Metric):
 
     """
 
-    table_description: str = "nr Hessian calls"
-    plot_description: str = "nr Hessian calls"
+    description: str = "nr Hessian calls"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -294,8 +286,7 @@ class ProximalCalls(Metric):
 
     """
 
-    table_description: str = "nr proximal calls"
-    plot_description: str = "nr proximal calls"
+    description: str = "nr proximal calls"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -320,8 +311,7 @@ class SentMessages(Metric):
 
     """
 
-    table_description: str = "nr sent messages"
-    plot_description: str = "nr sent messages"
+    description: str = "nr sent messages"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -346,8 +336,7 @@ class ReceivedMessages(Metric):
 
     """
 
-    table_description: str = "nr received messages"
-    plot_description: str = "nr received messages"
+    description: str = "nr received messages"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -372,8 +361,7 @@ class SentMessagesDropped(Metric):
 
     """
 
-    table_description: str = "nr sent messages dropped"
-    plot_description: str = "nr sent messages dropped"
+    description: str = "nr sent messages dropped"
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -416,8 +404,7 @@ class Accuracy(Metric):
 
     """
 
-    table_description: str = "accuracy"
-    plot_description: str = "accuracy"
+    description: str = "accuracy"
     can_diverge: bool = False
 
     def is_available(  # noqa: D102
@@ -472,8 +459,7 @@ class MSE(Metric):
 
     """
 
-    table_description: str = "mse"
-    plot_description: str = "mse"
+    description: str = "mse"
     can_diverge: bool = False
 
     def is_available(  # noqa: D102
@@ -527,8 +513,7 @@ class Precision(Metric):
 
     """
 
-    table_description: str = "precision"
-    plot_description: str = "precision"
+    description: str = "precision"
     can_diverge: bool = False
 
     def is_available(  # noqa: D102
@@ -585,8 +570,7 @@ class Recall(Metric):
 
     """
 
-    table_description: str = "recall"
-    plot_description: str = "recall"
+    description: str = "recall"
     can_diverge: bool = False
 
     def is_available(  # noqa: D102
@@ -626,8 +610,7 @@ class Loss(Metric):
 
     """
 
-    table_description: str = "loss"
-    plot_description: str = "loss"
+    description: str = "loss"
     can_diverge: bool = False
 
     def get_data_from_trial(  # noqa: D102

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -86,19 +86,18 @@ class XError(Metric):
     Distance to optimal solution.
 
     Table:
-        Distance to optimal solution using the agents' final x.
+        Distance to optimal solution using the mean of the agents' final x.
 
     Plot:
         Distance to optimal solution (y-axis) per iteration (x-axis).
 
-    X error per agent is defined as:
+    X error is defined as:
 
     .. math::
-        \{ \|\mathbf{x}_i - \mathbf{x}^\star\|, \|\mathbf{x}_j - \mathbf{x}^\star\|, ... \}
+        \|\mathbf{\bar{x}} - \mathbf{x}^\star\|
 
-    where :math:`\mathbf{x}_i` is agent i's final x,
-    :math:`\mathbf{x}_j` is agent j's final x,
-    and :math:`\mathbf{x}^\star` is the optimal x defined in the *problem*.
+    where  :math:`\mathbf{\bar{x}}` is the mean x across all *agents*, and
+    :math:`\mathbf{x}^\star` is the optimal x defined in the *problem*.
 
     Note:
         Available only when ``problem.x_optimal`` is provided.
@@ -120,8 +119,8 @@ class XError(Metric):
         agents: Sequence[AgentMetricsView],
         problem: "BenchmarkProblem",
         iteration: int,
-    ) -> list[float]:
-        return [utils._x_error(a, problem, iteration) for a in agents]  # noqa: SLF001
+    ) -> tuple[float]:
+        return (utils._x_error(agents, problem, iteration),)  # noqa: SLF001
 
 
 class ConsensusError(Metric):
@@ -630,7 +629,7 @@ class Loss(Metric):
 DEFAULT_TABLE_METRICS: list[Metric] = [
     Regret(),
     GradientNorm(),
-    XError([min, np.average, max]),
+    XError(),
     ConsensusError([min, np.average, max]),
     Loss([min, np.average, max]),
     XUpdates([np.average, sum]),
@@ -645,7 +644,7 @@ DEFAULT_TABLE_METRICS: list[Metric] = [
 """
 - :class:`Regret` (no statistics)
 - :class:`GradientNorm` (no statistics)
-- :class:`XError` - :func:`min`, :func:`~numpy.average`, :func:`max`
+- :class:`XError` (no statistics)
 - :class:`ConsensusError` - :func:`min`, :func:`~numpy.average`, :func:`max`
 - :class:`Loss` - :func:`min`, :func:`~numpy.average`, :func:`max`
 - :class:`XUpdates` - :func:`~numpy.average`, :func:`sum`

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -715,7 +715,7 @@ class FractionSelectedClients(Metric):
         self,
         problem: "BenchmarkProblem",
     ) -> tuple[bool, str | None]:
-        return _requires_fednetwork(problem, self.table_description)
+        return _requires_fednetwork(problem, self.description)
 
     def get_data_from_trial(  # noqa: D102
         self,
@@ -929,7 +929,7 @@ _CLASSIFICATION_PLOT_METRICS: list[Metric] = _CLASSIFICATION_TABLE_METRICS
 
 _FEDERATED_TABLE_METRICS: list[Metric] = [
     ClientDriftFromServer([min, np.average, max]),
-    FractionSelectedClients([utils.single], fmt=".2%", x_log=False, y_log=False),
+    FractionSelectedClients(fmt=".2%", x_log=False, y_log=False),
 ]
 """
 - :class:`ClientDriftFromServer` - min, average, max
@@ -948,7 +948,7 @@ _FEDERATED_PLOT_METRICS: list[Metric] = [
 """
 
 _FEDERATED_REGRESSION_TABLE_METRICS: list[Metric] = [
-    ServerMSE([utils.single], x_log=False, y_log=True),
+    ServerMSE(x_log=False, y_log=True),
 ]
 """
 - :class:`ServerMSE` - single value
@@ -966,7 +966,7 @@ _FEDERATED_REGRESSION_PLOT_METRICS: list[Metric] = [
 """
 
 _FEDERATED_CLASSIFICATION_TABLE_METRICS: list[Metric] = [
-    ServerAccuracy([utils.single], fmt=".2%", x_log=False, y_log=False),
+    ServerAccuracy(fmt=".2%", x_log=False, y_log=False),
 ]
 """
 - :class:`ServerAccuracy` - single value with percentage format

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -321,7 +321,7 @@ class SentMessages(Metric):
         agents: Sequence[AgentMetricsView],
         _: "BenchmarkProblem",
         __: int,
-    ) -> list[int]:
+    ) -> list[float]:
         return [a.n_sent_messages for a in agents]
 
 
@@ -346,7 +346,7 @@ class ReceivedMessages(Metric):
         agents: Sequence[AgentMetricsView],
         _: "BenchmarkProblem",
         __: int,
-    ) -> list[int]:
+    ) -> list[float]:
         return [a.n_received_messages for a in agents]
 
 
@@ -371,7 +371,7 @@ class SentMessagesDropped(Metric):
         agents: Sequence[AgentMetricsView],
         _: "BenchmarkProblem",
         __: int,
-    ) -> list[int]:
+    ) -> list[float]:
         return [a.n_sent_messages_dropped for a in agents]
 
 

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -628,8 +628,8 @@ class Loss(Metric):
 
 
 DEFAULT_TABLE_METRICS: list[Metric] = [
-    Regret([utils.single]),
-    GradientNorm([utils.single]),
+    Regret(),
+    GradientNorm(),
     XError([min, np.average, max]),
     ConsensusError([min, np.average, max]),
     Loss([min, np.average, max]),
@@ -643,8 +643,8 @@ DEFAULT_TABLE_METRICS: list[Metric] = [
     SentMessagesDropped([np.average, sum]),
 ]
 """
-- :class:`Regret` - :func:`~.metric_utils.single`
-- :class:`GradientNorm` - :func:`~.metric_utils.single`
+- :class:`Regret` (no statistics)
+- :class:`GradientNorm` (no statistics)
 - :class:`XError` - :func:`min`, :func:`~numpy.average`, :func:`max`
 - :class:`ConsensusError` - :func:`min`, :func:`~numpy.average`, :func:`max`
 - :class:`Loss` - :func:`min`, :func:`~numpy.average`, :func:`max`

--- a/decent_bench/metrics/metric_utils.py
+++ b/decent_bench/metrics/metric_utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from functools import cache
+from functools import lru_cache
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -19,6 +19,9 @@ from decent_bench.utils.types import Dataset
 
 if TYPE_CHECKING:
     from decent_bench.benchmark import BenchmarkProblem
+
+
+CACHE_MAX_SIZE = 50
 
 
 class MetricProgressBar(Progress):
@@ -50,13 +53,13 @@ def _clear_caches() -> None:
     _server_view.cache_clear()
 
 
-@cache
+@lru_cache(maxsize=CACHE_MAX_SIZE)
 def _non_server_views(agents: tuple[AgentMetricsView, ...]) -> tuple[AgentMetricsView, ...]:
     """Return all non-server agent views."""
     return tuple(agent for agent in agents if not agent.is_server)
 
 
-@cache
+@lru_cache(maxsize=CACHE_MAX_SIZE)
 def _server_view(agents: tuple[AgentMetricsView, ...]) -> AgentMetricsView:
     """Return the federated server view."""
     return next(agent for agent in agents if agent.is_server)
@@ -75,7 +78,7 @@ def default_statistic(values: Sequence[float]) -> float:
     return np.average(values)
 
 
-@cache
+@lru_cache(maxsize=CACHE_MAX_SIZE)
 def x_mean(agents: tuple[AgentMetricsView, ...], iteration: int = -1) -> Array:
     """
     Calculate the mean x at *iteration* (or using the agents' final x if *iteration* is -1).
@@ -142,7 +145,7 @@ def _x_error(agents: Sequence[AgentMetricsView], problem: "BenchmarkProblem", it
 
     """
     mean_x = x_mean(tuple(agents), iteration)
-    return float(la.norm(iop.to_numpy(mean_x - problem.x_optimal)))  # type: ignore[operator]
+    return float(iop.norm(mean_x - problem.x_optimal))  # type: ignore[operator]
 
 
 def _observed_rounds(agents: Sequence[AgentMetricsView]) -> int:
@@ -332,7 +335,7 @@ def _split_dataset(data: Dataset) -> tuple[tuple[Array, ...], NDArray[float64]]:
     return test_x, test_y
 
 
-@cache
+@lru_cache(maxsize=CACHE_MAX_SIZE)
 def _predict_agent(agent: AgentMetricsView, iteration: int, problem: "BenchmarkProblem") -> NDArray[float64]:
     """Get the predictions of *agent* at *iteration*. Cached since predictions may be expensive."""
     test_x, _ = _split_dataset(problem.test_data)  # type: ignore[arg-type]

--- a/decent_bench/metrics/metric_utils.py
+++ b/decent_bench/metrics/metric_utils.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from decent_bench.benchmark import BenchmarkProblem
 
 
-CACHE_MAX_SIZE = 50
+CACHE_MAX_SIZE = 50_000
 
 
 class MetricProgressBar(Progress):

--- a/decent_bench/metrics/metric_utils.py
+++ b/decent_bench/metrics/metric_utils.py
@@ -12,6 +12,7 @@ from sklearn import metrics as sk_metrics
 
 import decent_bench.utils.interoperability as iop
 from decent_bench.agents import AgentMetricsView
+from decent_bench.costs import EmpiricalRiskCost
 from decent_bench.utils.array import Array
 from decent_bench.utils.logger import LOGGER
 from decent_bench.utils.types import Dataset
@@ -44,7 +45,6 @@ class MetricProgressBar(Progress):
 def _clear_caches() -> None:
     """Clear module-level functools caches used by metric utilities."""
     x_mean.cache_clear()
-    _x_error.cache_clear()
     _predict_agent.cache_clear()
 
 
@@ -85,9 +85,12 @@ def _regret(agents: Sequence[AgentMetricsView], problem: "BenchmarkProblem", ite
     """
     x_opt = problem.x_optimal
     mean_x = x_mean(tuple(agents), iteration)
-    optimal_cost = sum(a.cost.function(x_opt) for a in agents)  # type: ignore[arg-type, misc]
-    actual_cost = sum(a.cost.function(mean_x) for a in agents)
-    return actual_cost - optimal_cost
+    optimal_cost, actual_cost = 0.0, 0.0
+    for a in agents:
+        kwargs = {"indices": "all"} if isinstance(a.cost, EmpiricalRiskCost) else {}
+        optimal_cost += a.cost.function(x_opt, **kwargs)  # type: ignore[arg-type]
+        actual_cost += a.cost.function(mean_x, **kwargs)
+    return (actual_cost - optimal_cost) / len(agents)
 
 
 def _gradient_norm(agents: Sequence[AgentMetricsView], iteration: int = -1) -> float:
@@ -99,26 +102,27 @@ def _gradient_norm(agents: Sequence[AgentMetricsView], iteration: int = -1) -> f
     .. include:: snippets/global_gradient_optimality.rst
     """
     mean_x = x_mean(tuple(agents), iteration)
-    grad_avg = sum(iop.to_numpy(a.cost.gradient(mean_x)) for a in agents) / len(agents)
-    return float(la.norm(grad_avg)) ** 2
+    gradients = []
+    for a in agents:
+        kwargs = {"indices": "all"} if isinstance(a.cost, EmpiricalRiskCost) else {}
+        gradients.append(iop.to_numpy(a.cost.gradient(mean_x, **kwargs)))
+    grad_avg = sum(gradients) / len(agents)
+    return float(la.norm(grad_avg))
 
 
-@cache
-def _x_error(agent: AgentMetricsView, problem: "BenchmarkProblem", iteration: int = -1) -> float:
+def _x_error(agents: Sequence[AgentMetricsView], problem: "BenchmarkProblem", iteration: int = -1) -> float:
     r"""
-    Calculate x error at *iteration* (or at the agent's final x if *iteration* is -1).
+    Calculate x error at *iteration* (or at the final x if *iteration* is -1).
 
     .. math::
-        \|\mathbf{x}_k - \mathbf{x}^\star\|
+        \|\mathbf{\bar{x}}_k - \mathbf{x}^\star\|
 
-    where :math:`\mathbf{x}_k` is the agent's local x at iteration k,
+    where :math:`\mathbf{\bar{x}}_k` is the mean of the agents' local x at iteration k,
     and :math:`\mathbf{x}^\star` is the optimal x defined in the *problem*.
 
     """
-    agent_iteration = agent.x_history.max() if iteration == -1 else iteration
-    x_at_iteration = iop.to_numpy(agent.x_history[agent_iteration])
-    opt_x = iop.to_numpy(problem.x_optimal)  # type: ignore[arg-type]
-    return float(la.norm(x_at_iteration - opt_x))
+    mean_x = x_mean(tuple(agents), iteration)
+    return float(la.norm(iop.to_numpy(mean_x - problem.x_optimal)))  # type: ignore[operator]
 
 
 def _accuracy(agents: Sequence[AgentMetricsView], problem: "BenchmarkProblem", iteration: int) -> list[float]:

--- a/decent_bench/metrics/metric_utils.py
+++ b/decent_bench/metrics/metric_utils.py
@@ -48,17 +48,11 @@ def _clear_caches() -> None:
     _predict_agent.cache_clear()
 
 
-def single(values: Sequence[float]) -> float:
-    """
-    Assert that *values* contain exactly one element and return it.
-
-    Raises:
-        ValueError: if there isn't exactly one element in *values*
-
-    """
-    if len(values) != 1:
-        raise ValueError("Argument `values` must have exactly 1 element")
-    return values[0]
+def default_statistic(values: Sequence[float]) -> float:
+    """Return *values[0]* if it contains exactly one element, *mean(values)* otherwise."""
+    if len(values) == 1:
+        return values[0]
+    return np.average(values)
 
 
 @cache

--- a/decent_bench/networks.py
+++ b/decent_bench/networks.py
@@ -265,13 +265,14 @@ class Network(ABC):  # noqa: B024
 
         The message will be immediately available to the receiver if it is active in the current iteration.
         """
-        sender._n_sent_messages += 1  # noqa: SLF001
+        counter_increment = int(np.prod(iop.shape(msg)) / sender.cost.size)  # replace with msg.size
+        sender._n_sent_messages += counter_increment  # noqa: SLF001
         if self._message_drop[sender].should_drop():
-            sender._n_sent_messages_dropped += 1  # noqa: SLF001
+            sender._n_sent_messages_dropped += counter_increment  # noqa: SLF001
             return
         msg = iop.copy(msg)
         msg = self._message_noise[sender].make_noise(msg)
-        receiver._n_received_messages += 1  # noqa: SLF001
+        receiver._n_received_messages += counter_increment  # noqa: SLF001
         receiver._received_messages[sender] = msg  # noqa: SLF001
 
     def _allowed_receivers(self, sender: Agent) -> set[Agent]:

--- a/decent_bench/networks.py
+++ b/decent_bench/networks.py
@@ -254,27 +254,6 @@ class Network(ABC):  # noqa: B024
             self._active_connected_agents_cache[agent] = [a for a in self.connected_agents(agent) if a in active_agents]
         return self._active_connected_agents_cache[agent]
 
-    def _send_one(self, sender: Agent, receiver: Agent, msg: Array) -> None:
-        """
-        Send message to an agent.
-
-        The message may be compressed, distorted by noise, and/or dropped depending on the network's
-        :class:`~decent_bench.schemes.CompressionScheme`,
-        :class:`~decent_bench.schemes.NoiseScheme`,
-        and :class:`~decent_bench.schemes.DropScheme`.
-
-        The message will be immediately available to the receiver if it is active in the current iteration.
-        """
-        counter_increment = int(np.prod(iop.shape(msg)) / sender.cost.size)  # replace with msg.size
-        sender._n_sent_messages += counter_increment  # noqa: SLF001
-        if self._message_drop[sender].should_drop():
-            sender._n_sent_messages_dropped += counter_increment  # noqa: SLF001
-            return
-        msg = iop.copy(msg)
-        msg = self._message_noise[sender].make_noise(msg)
-        receiver._n_received_messages += counter_increment  # noqa: SLF001
-        receiver._received_messages[sender] = msg  # noqa: SLF001
-
     def _allowed_receivers(self, sender: Agent) -> set[Agent]:
         """Get the set of agents that the sender is allowed to send messages to (i.e. connected and active)."""
         return set(self.active_connected_agents(sender))
@@ -287,6 +266,12 @@ class Network(ABC):  # noqa: B024
     ) -> None:
         """
         Send message to one or more agents.
+
+        The message may be compressed, distorted by noise, and/or dropped depending on the network's
+        :class:`~decent_bench.schemes.CompressionScheme`,
+        :class:`~decent_bench.schemes.NoiseScheme`,
+        and :class:`~decent_bench.schemes.DropScheme`. The potentially compressed and noisy message (if not dropped)
+        is then instantaneously available to each receiver.
 
         Args:
             sender: sender agent
@@ -311,14 +296,29 @@ class Network(ABC):  # noqa: B024
                 raise ValueError("Sender and receiver must be connected in the network")
             receiver = [receiver]
 
-        currently_active_connected_agents = self._allowed_receivers(sender)
+        # raise for unconnected/inactive
+        unavailable_missing_receivers = set(receiver) - self._allowed_receivers(sender)
+        if unavailable_missing_receivers:
+            raise ValueError(
+                f"Receivers {unavailable_missing_receivers} are not active or not connected to {sender} "
+                f"in iteration {self._iteration}"
+            )
+
+        counter_increment = int(np.prod(iop.shape(msg)) / sender.cost.size)  # replace with msg.size once available
+        sender._n_sent_messages += counter_increment * len(receiver)  # noqa: SLF001
+        framework, device = iop.framework_device_of_array(msg)  # remove after iop refactor
+
+        # select confirmed receivers (message is not dropped)
+        confirmed_receivers = [r for r in receiver if not self._message_drop[sender].should_drop()]
+        sender._n_sent_messages_dropped += counter_increment * (len(receiver) - len(confirmed_receivers))  # noqa: SLF001
+        # compress the message
         msg = self._message_compression[sender].compress(iop.copy(msg))
-        for r in receiver:
-            if r not in currently_active_connected_agents:
-                raise ValueError(
-                    f"Receiver {r} is not active or not connected to {sender} in iteration {self._iteration}"
-                )
-            self._send_one(sender=sender, receiver=r, msg=msg)
+        # generate noise
+        noise = self._message_noise[sender].make_noise((len(confirmed_receivers), *iop.shape(msg)), framework, device)
+        # transmit messages
+        for i, r in enumerate(confirmed_receivers):
+            r._received_messages[sender] = msg if noise is None else msg + noise[i]  # noqa: SLF001
+            r._n_received_messages += counter_increment  # noqa: SLF001
 
     def _step(self, iteration: int) -> None:
         """Set the iteration counter for the network and clear all received messages from agents."""

--- a/decent_bench/networks.py
+++ b/decent_bench/networks.py
@@ -48,16 +48,6 @@ class Network(ABC):  # noqa: B024
             not of type :class:`~decent_bench.agents.Agent`, if any two agents have incompatible costs, or if
             any agent is already assigned to another network (i.e. it has index != -1).
 
-    Raises:
-        ValueError: if the graph is not connected, if it is directed, if it is a multi-graph, if its nodes are
-            not of type :class:`~decent_bench.agents.Agent`, if any two agents have incompatible costs, or if
-            any agent is already assigned to another network (i.e. it has index != -1).
-
-    Raises:
-        ValueError: if the graph is not connected, if it is directed, if it is a multi-graph, if its nodes are
-            not of type :class:`~decent_bench.agents.Agent`, if any two agents have incompatible costs, or if
-            any agent is already assigned to another network (i.e. it has index != -1).
-
     """
 
     def __init__(
@@ -79,7 +69,7 @@ class Network(ABC):  # noqa: B024
         self._validate_agent_cost_compatibility(graph)
         for idx, agent in enumerate(graph.nodes()):  # assign agent index within the network
             if agent.index != -1:
-                raise ValueError("Agents can only be asigned to one network at a time")
+                raise ValueError("Agents can only be assigned to one network at a time")
             agent.index = idx
 
         self._graph = graph

--- a/decent_bench/networks.py
+++ b/decent_bench/networks.py
@@ -68,8 +68,6 @@ class Network(ABC):  # noqa: B024
             raise ValueError("The graph nodes must be `Agent` objects")
         self._validate_agent_cost_compatibility(graph)
         for idx, agent in enumerate(graph.nodes()):  # assign agent index within the network
-            if agent.index != -1:
-                raise ValueError("Agents can only be assigned to one network at a time")
             agent.index = idx
 
         self._graph = graph
@@ -116,20 +114,26 @@ class Network(ABC):  # noqa: B024
     @staticmethod
     def _validate_agent_ids(agents: Sequence[Agent]) -> None:
         """
-        Validate that all agents have distinct ids.
+        Validate that all agents have distinct ids and were not assigned to a network.
 
         This util checks that all agents have distinct ``Agent.id``. Distinct ids are mandatory since agents are
         hashed by their id (necessary during un/pickling operations). The util is meant to be used in subclasses
         on raw Agent lists passed by users. NetworkX collapses two agents with the same id, so it is necessary to
         run this validation before Graph[Agent] is constructed.
 
+        Additionally, it checks that no agent was previously assigned to another network, by checking that its
+        index is -1.
+
         Raises:
-            ValueError: If any two agents have the same id.
+            ValueError: If any two agents have the same id or were already assigned to a network.
 
         """
         agent_ids = [agent.id for agent in agents]
         if len(agent_ids) != len(set(agent_ids)):
             raise ValueError("Agent IDs must be unique")
+
+        if any(agent.index != -1 for agent in agents):
+            raise ValueError("Agents can only be assigned to one network at a time")
 
     def _initialize_message_schemes(
         self,
@@ -305,7 +309,7 @@ class Network(ABC):  # noqa: B024
                 f"in iteration {self._iteration}"
             )
 
-        counter_increment = int(np.prod(iop.shape(msg)) / sender.cost.size)  # replace with msg.size once available
+        counter_increment = self._message_compression[sender].compressed_msg_size(msg) / sender.cost.size
         sender._n_sent_messages += counter_increment * len(receiver)  # noqa: SLF001
         framework, device = iop.framework_device_of_array(msg)  # remove after iop refactor
 

--- a/decent_bench/networks.py
+++ b/decent_bench/networks.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Callable, Collection, Sequence
+from collections.abc import Callable, Sequence
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 
 import networkx as nx
 import numpy as np
@@ -22,21 +22,13 @@ from decent_bench.schemes import (
 )
 from decent_bench.utils.array import Array
 
-if TYPE_CHECKING:
-    AnyGraph = nx.Graph[Any]
-    AgentGraph = nx.Graph[Agent]
-else:
-    AnyGraph = nx.Graph
-    AgentGraph = nx.Graph
-
 
 class Network(ABC):  # noqa: B024
     """
     Base network object defining communication logic shared by all network types.
 
     Args:
-        graph: underlying NetworkX graph defining the network topology.
-            Nodes must be of type :class:`~decent_bench.agents.Agent`.
+        graph: NetworkX graph defining the network topology, with :class:`~decent_bench.agents.Agent` nodes.
         buffer_messages: whether to keep stored messages at the end of each iteration. If ``True``, messages
             persist on the receiver until they are overwritten by a newer message from the same sender to the same
             receiver. If ``False``, messages delivered to a receiver during iteration *k* are dropped when
@@ -52,11 +44,16 @@ class Network(ABC):  # noqa: B024
             :class:`~decent_bench.schemes.DropScheme` instance to apply the same scheme to all agents, a dictionary
             mapping each agent to its scheme, or ``None`` to apply no message drop to any agent.
 
+    Raises:
+        ValueError: if the graph is not connected, if it is directed, if it is a multi-graph, if its nodes are
+            not of type :class:`~decent_bench.agents.Agent`, if any two agents have incompatible costs, or if
+            any agent is already assigned to another network (i.e. it has index != -1).
+
     """
 
     def __init__(
         self,
-        graph: AgentGraph,
+        graph: nx.Graph[Agent],
         buffer_messages: bool = False,
         message_noise: NoiseScheme | dict[Agent, NoiseScheme] | None = None,
         message_compression: CompressionScheme | dict[Agent, CompressionScheme] | None = None,
@@ -69,10 +66,13 @@ class Network(ABC):  # noqa: B024
             raise ValueError("Directed graphs are not supported; please provide an undirected graph")
         if not nx.is_connected(graph):
             raise ValueError("The graph needs to be connected")
-        agent_ids = [agent.id for agent in graph.nodes()]
-        if len(agent_ids) != len(set(agent_ids)):
-            raise ValueError("Agent IDs must be unique")
+        if any(not isinstance(node, Agent) for node in graph):
+            raise ValueError("The graph nodes must be `Agent` objects")
         self._validate_agent_cost_compatibility(graph)
+        for idx, agent in enumerate(graph.nodes()):  # assign agent index within the network
+            if agent.index != -1:
+                raise ValueError("Agents can only be asigned to one network at a time")
+            agent.index = idx
 
         self._graph = graph
         self._message_noise = self._initialize_message_schemes(message_noise, "noise", NoiseScheme, NoNoise)
@@ -86,7 +86,7 @@ class Network(ABC):  # noqa: B024
         self._iteration = 0  # Current iteration, updated by the algorithm
 
     @staticmethod
-    def _validate_agent_cost_compatibility(graph: AgentGraph) -> None:
+    def _validate_agent_cost_compatibility(graph: nx.Graph[Agent]) -> None:
         """
         Validate that all agents' costs share the same shape, framework, and device.
 
@@ -115,6 +115,24 @@ class Network(ABC):  # noqa: B024
                 f"Expected shape={first_cost.shape}, framework={first_cost.framework}, "
                 f"device={first_cost.device}; mismatches: {'; '.join(mismatches)}"
             )
+
+    @staticmethod
+    def _validate_agent_ids(agents: Sequence[Agent]) -> None:
+        """
+        Validate that all agents have distinct ids.
+
+        This util checks that all agents have distinct ``Agent.id``. Distinct ids are mandatory since agents are
+        hashed by their id (necessary during un/pickling operations). The util is meant to be used in subclasses
+        on raw Agent lists passed by users. NetworkX collapses two agents with the same id, so it is necessary to
+        run this validation before Graph[Agent] is constructed.
+
+        Raises:
+            ValueError: If any two agents have the same id.
+
+        """
+        agent_ids = [agent.id for agent in agents]
+        if len(agent_ids) != len(set(agent_ids)):
+            raise ValueError("Agent IDs must be unique")
 
     def _initialize_message_schemes(
         self,
@@ -161,12 +179,12 @@ class Network(ABC):  # noqa: B024
         )
 
     @property
-    def graph(self) -> AgentGraph:
+    def graph(self) -> nx.Graph[Agent]:
         """Underlying NetworkX graph; mutating it will change the network."""
         return self._graph
 
     @property
-    def G(self) -> AgentGraph:  # noqa: N802
+    def G(self) -> nx.Graph[Agent]:  # noqa: N802
         """Alias for the underlying graph."""
         return self.graph
 
@@ -322,13 +340,9 @@ class P2PNetwork(Network):
     Peer-to-peer network architecture where agents communicate directly with each other.
 
     Args:
-        graph: NetworkX graph defining the network topology. Can be a graph with arbitrary node types as long as a list
-            of agents is provided via the `agents` argument; or it can be a graph with
-            :class:`~decent_bench.agents.Agent` nodes, in which case the `agents` argument is optional and will be
-            ignored if provided.
-        agents: list of agents corresponding to the nodes in `graph` if `graph` is not a graph with
-            :class:`~decent_bench.agents.Agent` nodes. The agents in the list are assigned in order to each node of the
-            graph. This argument is ignored if `graph` is a graph with :class:`~decent_bench.agents.Agent` nodes.
+        graph: NetworkX graph defining the network topology.
+        agents: list of agents corresponding to the nodes in ``graph``. The agents in the list are assigned
+            in order to each node of the graph. Agents must have unique ids.
         buffer_messages: whether to keep stored messages at the end of each iteration. If ``True``, messages
             persist on the receiver until they are overwritten by a newer message from the same sender to the same
             receiver. If ``False``, messages delivered to a receiver during iteration *k* are dropped when
@@ -344,40 +358,35 @@ class P2PNetwork(Network):
             :class:`~decent_bench.schemes.DropScheme` instance to apply the same scheme to all agents, a dictionary
             mapping each agent to its scheme, or ``None`` to apply no message drop to any agent.
 
+    Raises:
+        ValueError: if length of ``agents`` doesn't match the number of nodes in ``graph``, or if any two agents
+            have the same ids.
+
     """
 
     def __init__(
         self,
-        graph: AnyGraph,
-        agents: Sequence[Agent] | None = None,
+        graph: nx.Graph[Any],
+        agents: Sequence[Agent],
         *,
         buffer_messages: bool = False,
         message_noise: NoiseScheme | dict[Agent, NoiseScheme] | None = None,
         message_compression: CompressionScheme | dict[Agent, CompressionScheme] | None = None,
         message_drop: DropScheme | dict[Agent, DropScheme] | None = None,
     ) -> None:
-        if all(isinstance(node, Agent) for node in graph.nodes()):  # pass directly to super().__init__
-            super().__init__(
-                graph=graph,
-                buffer_messages=buffer_messages,
-                message_noise=message_noise,
-                message_compression=message_compression,
-                message_drop=message_drop,
-            )
-        else:  # create AgentGraph from graph (which defines the topology) and list of agents
-            if agents is None:
-                raise ValueError("Provide `agents` if `graph` is not a Graph with Agent nodes")
-            if len(agents) != len(graph):
-                raise ValueError(f"Expected {len(graph)} agents but got {len(agents)}")
-            agent_node_map = {node: agents[i] for i, node in enumerate(graph.nodes())}
-            graph = nx.relabel_nodes(graph, agent_node_map)
-            super().__init__(
-                graph=graph,
-                buffer_messages=buffer_messages,
-                message_noise=message_noise,
-                message_compression=message_compression,
-                message_drop=message_drop,
-            )
+        if len(agents) != len(graph):
+            raise ValueError(f"Expected {len(graph)} agents but got {len(agents)}")
+        self._validate_agent_ids(agents)
+
+        agent_node_map = {node: agents[i] for i, node in enumerate(graph.nodes())}
+        graph = nx.relabel_nodes(graph, agent_node_map)
+        super().__init__(
+            graph=graph,
+            buffer_messages=buffer_messages,
+            message_noise=message_noise,
+            message_compression=message_compression,
+            message_drop=message_drop,
+        )
         self.W: Array | None = None
 
     @property
@@ -385,7 +394,7 @@ class P2PNetwork(Network):
         """
         Symmetric, doubly stochastic matrix for consensus weights. Initialized using the Metropolis-Hastings method.
 
-        Use ``weights[i, j]`` or ``weights[i.id, j.id]`` to get the weight between agent i and j.
+        Use ``weights[i, j]`` or ``weights[i.index, j.index]`` to get the weight between agent i and j.
         """
         agents = self.agents()
 
@@ -444,14 +453,14 @@ class P2PNetwork(Network):
         """
         Adjacency matrix of the network.
 
-        Use ``adjacency[i, j]`` or ``adjacency[i.id, j.id]`` to get the adjacency between agent i and j.
+        Use ``adjacency[i, j]`` or ``adjacency[i.index, j.index]`` to get the adjacency between agent i and j.
         """
         agents = self.agents()
         adjacency_matrix = nx.to_numpy_array(
             self.graph,
-            nodelist=cast("Collection[Any]", agents),
-            dtype=float,
-        )  # type: ignore[call-overload]
+            nodelist=agents,
+            dtype=np.dtype(float),
+        )
         return iop.to_array(
             adjacency_matrix,
             agents[0].cost.framework,
@@ -516,14 +525,15 @@ class FedNetwork(Network):
             # get cost info from one of the clients
             shape, framework, device = clients[0].cost.shape, clients[0].cost.framework, clients[0].cost.device
             server = Agent(
-                max(c.id for c in clients) + 1,
                 ZeroCost(shape, framework, device),
                 AlwaysActive(),
                 min(c.state_snapshot_period for c in clients),
             )
         elif not isinstance(server._activation, AlwaysActive):  # noqa: SLF001
             raise ValueError("FedNetwork server must use AlwaysActive activation")
-        graph = nx.star_graph([server, *list(clients)])  # create AgentGraph
+        nodes = [server, *list(clients)]
+        self._validate_agent_ids(nodes)
+        graph = nx.star_graph(nodes)  # create Graph of Agents
 
         # specify the server's message schemes if not provided
         if isinstance(message_noise, dict) and server not in message_noise:

--- a/decent_bench/schemes.py
+++ b/decent_bench/schemes.py
@@ -475,6 +475,10 @@ class CompressionScheme(ABC):
     def compress(self, msg: Array) -> Array:
         """Apply compression and return a new, compressed message."""
 
+    def compressed_msg_size(self, msg: Array) -> int:
+        """Compute the size of the compressed version of *msg*."""
+        return int(np.prod(iop.shape(msg)))  # replace with msg.size once available
+
 
 class NoCompression(CompressionScheme):
     """Scheme that leaves messages uncompressed."""
@@ -615,6 +619,10 @@ class TopK(CompressionScheme):
 
         return iop.to_array_like(compressed_flat.reshape(msg_np.shape), msg)
 
+    def compressed_msg_size(self, msg: Array) -> int:
+        """Compute the size of the compressed version of *msg*."""
+        return int(self.k if self.is_integer_k else np.ceil(self.k * np.prod(iop.shape(msg))))  # replace with msg.size
+
 
 class RandK(CompressionScheme):
     """
@@ -656,6 +664,10 @@ class RandK(CompressionScheme):
         compressed_flat[idx] = flat_msg[idx]
 
         return iop.to_array_like(compressed_flat.reshape(msg_np.shape), msg)
+
+    def compressed_msg_size(self, msg: Array) -> int:
+        """Compute the size of the compressed version of *msg*."""
+        return int(self.k if self.is_integer_k else np.ceil(self.k * np.prod(iop.shape(msg))))  # replace with msg.size
 
 
 class DropScheme(ABC):

--- a/decent_bench/schemes.py
+++ b/decent_bench/schemes.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import decent_bench.utils.interoperability as iop
 from decent_bench.utils.array import Array
+from decent_bench.utils.types import SupportedDevices, SupportedFrameworks
 
 if TYPE_CHECKING:
     from decent_bench.agents import Agent
@@ -343,23 +344,31 @@ class GilbertElliott(DropScheme):
         return iop.rng_numpy().random() < self.drop_rate if self._current_state else False
 
 
+# later remove framework and device when iop refactored
 class NoiseScheme(ABC):
-    """Scheme defining how noise impacts messages."""
+    """Scheme defining the noise impacting messages."""
 
     @abstractmethod
-    def make_noise(self, msg: Array) -> Array:
-        """Apply noise scheme without mutating the *msg* passed in."""
+    def make_noise(
+        self, shape: tuple[int, ...], framework: SupportedFrameworks, device: SupportedDevices
+    ) -> Array | None:
+        """Generate noise array of given shape (None if no noise)."""
 
 
 class NoNoise(NoiseScheme):
-    """Scheme that leaves messages untouched."""
+    """Scheme representing transmission without noise."""
 
-    def make_noise(self, msg: Array) -> Array:  # noqa: D102
-        return msg
+    def make_noise(  # noqa: D102
+        self,
+        _: tuple[int, ...],
+        _framework: SupportedFrameworks,
+        _device: SupportedDevices,
+    ) -> Array | None:
+        return None
 
 
 class GaussianNoise(NoiseScheme):
-    """Scheme that applies Gaussian noise - that is, noise following a normal distribution."""
+    """Scheme generating normal noise."""
 
     def __init__(self, mean: float, std: float):
         if std < 0:
@@ -367,5 +376,5 @@ class GaussianNoise(NoiseScheme):
         self.mean = mean
         self.std = std
 
-    def make_noise(self, msg: Array) -> Array:  # noqa: D102
-        return msg + iop.normal_like(msg, mean=self.mean, std=self.std)
+    def make_noise(self, shape: tuple[int, ...], framework: SupportedFrameworks, device: SupportedDevices) -> Array:  # noqa: D102
+        return iop.normal(framework=framework, device=device, shape=shape, mean=self.mean, std=self.std)

--- a/decent_bench/schemes.py
+++ b/decent_bench/schemes.py
@@ -173,24 +173,24 @@ class NoCompression(CompressionScheme):
 
 
 class Quantization(CompressionScheme):
-    """Scheme that rounds each element in a message to *significant_digits*."""
+    r"""
+    Scheme applying uniform quantization to the message.
 
-    def __init__(self, n_significant_digits: int):
-        if n_significant_digits <= 0:
-            raise ValueError("`n_significant_digits` must be a positive integer")
-        self.n_significant_digits = n_significant_digits
+    Given a message :math:`x` and quantization step :math:`\Delta`, the scheme returns
+
+        .. math:: q(x) = \Delta \operatorname{round}(x / \Delta)
+
+    where :math:`\operatorname{round}(\cdot)` represents rounding to the nearest integer.
+    """
+
+    def __init__(self, quantization_step: float):
+        if quantization_step <= 0:
+            raise ValueError("`quantization_step` must be a positive float")
+        self.quantization_step = quantization_step
 
     def compress(self, msg: Array) -> Array:  # noqa: D102
         msg_np = iop.to_numpy(msg, dtype=np.float64)
-
-        # Round finite non-zero entries to the requested number of significant digits.
-        mask = np.isfinite(msg_np) & (msg_np != 0)
-        if np.any(mask):
-            magnitudes = np.floor(np.log10(np.abs(msg_np[mask])))
-            scale = np.power(10.0, self.n_significant_digits - 1 - magnitudes)
-            msg_np[mask] = np.round(msg_np[mask] * scale) / scale
-
-        return iop.to_array_like(msg_np, msg)
+        return iop.to_array_like(self.quantization_step * np.rint(msg_np / self.quantization_step), msg)
 
 
 class TopK(CompressionScheme):

--- a/decent_bench/schemes.py
+++ b/decent_bench/schemes.py
@@ -493,6 +493,7 @@ class Quantization(CompressionScheme):
 
     Raises:
         ValueError: if ``quantization_step`` is not positive.
+
     """
 
     def __init__(self, quantization_step: float):
@@ -503,72 +504,6 @@ class Quantization(CompressionScheme):
     def compress(self, msg: Array) -> Array:  # noqa: D102
         msg_np = iop.to_numpy(msg, dtype=np.float64)
         return iop.to_array_like(self.quantization_step * np.rint(msg_np / self.quantization_step), msg)
-
-
-class StochasticQuantization(CompressionScheme):
-    r"""
-    Stochastic quantization used in QSGD :footcite:p:`Scheme_QSGD`.
-
-    The scheme quantizes each coordinate using ``n_levels`` stochastic levels scaled by the message norm. This keeps the
-    compressed message unbiased in expectation while preserving the original message shape. Given a message
-    :math:`x` and :math:`s=\texttt{n\_levels}`, the quantizer computes
-
-    .. math::
-
-        a_i = \frac{s |x_i|}{\lVert x \rVert_2}, \qquad
-        \ell_i = \lfloor a_i \rfloor, \qquad
-        p_i = a_i - \ell_i.
-
-    The quantization level is sampled as
-
-    .. math::
-
-        \xi_i =
-        \begin{cases}
-            \ell_i + 1, & \text{with probability } p_i, \\
-            \ell_i, & \text{with probability } 1 - p_i,
-        \end{cases}
-
-    and the compressed coordinate is
-
-    .. math::
-
-        Q_s(x_i) = \lVert x \rVert_2 \operatorname{sign}(x_i) \frac{\xi_i}{s}.
-
-    Args:
-        n_levels: number of stochastic quantization levels. Larger values give a finer quantization grid and usually
-            lower quantization error. Smaller values give coarser quantization and stronger compression noise.
-
-    Raises:
-        ValueError: if ``n_levels`` is not positive.
-
-    Warning:
-        This scheme computes the :math:`\ell_2` norm of each message. This can be computationally expensive for large
-        messages or when messages live on accelerator devices.
-
-    .. footbibliography::
-
-    """
-
-    def __init__(self, n_levels: int):
-        if n_levels <= 0:
-            raise ValueError("`n_levels` must be a positive integer")
-        self.n_levels = n_levels
-
-    def compress(self, msg: Array) -> Array:  # noqa: D102
-        msg_norm = float(iop.norm(msg))
-        if msg_norm == 0:
-            return iop.zeros_like(msg)
-
-        msg_np = iop.to_numpy(msg, dtype=np.float64)
-        magnitudes = np.abs(msg_np)
-        signs = np.sign(msg_np)
-        scaled_magnitudes = self.n_levels * magnitudes / msg_norm
-        lower_levels = np.floor(scaled_magnitudes)
-        probabilities = scaled_magnitudes - lower_levels
-        quantized_levels = lower_levels + (iop.rng_numpy().random(size=magnitudes.shape) < probabilities)
-        compressed_msg = msg_norm * signs * quantized_levels / self.n_levels
-        return iop.to_array_like(compressed_msg, msg)
 
 
 class StochasticQuantization(CompressionScheme):

--- a/decent_bench/utils/_metric_helpers.py
+++ b/decent_bench/utils/_metric_helpers.py
@@ -1,18 +1,3 @@
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from decent_bench.metrics import Metric
-
-
-def _flatten_plot_metrics(plot_metrics: list["Metric"] | list[list["Metric"]]) -> list["Metric"]:
-    if any(isinstance(metric, list) for metric in plot_metrics):
-        if not all(isinstance(metric, list) for metric in plot_metrics):
-            raise ValueError("If passing lists in ``plot_metrics``, all items must be lists.")
-        return [metric for group in plot_metrics for metric in group]  # type: ignore[union-attr]
-
-    return plot_metrics  # type: ignore[return-value]
-
-
 def _find_duplicates(items: list[str]) -> list[str]:
     seen: set[str] = set()
     duplicates: set[str] = set()

--- a/decent_bench/utils/array.py
+++ b/decent_bench/utils/array.py
@@ -7,7 +7,7 @@ import decent_bench.utils.interoperability as iop
 from decent_bench.utils.types import ArrayKey, SupportedArrayTypes
 
 
-class Array:  # noqa: PLR0904
+class Array:
     """
     A wrapper class for :data:`~decent_bench.utils.types.SupportedArrayTypes` objects to enable operator overloading.
 
@@ -326,7 +326,7 @@ class Array:  # noqa: PLR0904
             raise TypeError("Scalar values are not iterable.")
         return iter(self.value)
 
-    def __array__(self) -> SupportedArrayTypes:  # noqa: PLW3201
+    def __array__(self) -> SupportedArrayTypes:
         """
         Return the underlying array-like object.
 

--- a/decent_bench/utils/checkpoint_manager.py
+++ b/decent_bench/utils/checkpoint_manager.py
@@ -11,7 +11,7 @@ from rich.progress import track
 from rich.status import Status
 
 import decent_bench.utils.interoperability as iop
-from decent_bench.agents import AgentMetricsView
+from decent_bench.agents import Agent, AgentMetricsView
 from decent_bench.algorithms import Algorithm
 from decent_bench.benchmark import BenchmarkProblem, BenchmarkResult, MetricResult
 from decent_bench.networks import Network
@@ -22,6 +22,7 @@ from decent_bench.utils.logger import LOGGER
 # `int.to_bytes(..., signed=False)` then raises: OverflowError: can't convert negative int to unsigned
 _ZSTD_MAGIC = (int(zstd.MAGIC_NUMBER) & 0xFFFFFFFF).to_bytes(4, "little")
 _CHECKPOINT_NAME_RE = re.compile(r"^checkpoint_(\d+)\.pkl(?:\.zst)?$")
+_AGENT_HASH_DICT_MARKER = "__agent_hash_keyed__"
 
 
 class _CheckpointData(TypedDict):
@@ -260,16 +261,24 @@ class CheckpointManager:  # noqa: PLR0904
         self._save_metadata(metadata)
         return metadata
 
-    def load_initial_algorithms(self) -> list[Algorithm[Network]]:
+    def load_initial_algorithms(self, network: Network | None = None) -> list[Algorithm[Network]]:
         """
         Load initial algorithm states from checkpoint.
+
+        Args:
+            network: If provided, restore any agent-hash-keyed dicts back to Agent-keyed dicts
+                using the agents from this network.
 
         Returns:
             List of Algorithm objects representing the initial algorithm states.
 
         """
         initial_path = self._resolve_data_file("initial_algorithms.pkl.zst", "initial_algorithms.pkl")
-        return cast("list[Algorithm[Network]]", self._load_pickle(initial_path))
+        algorithms = cast("list[Algorithm[Network]]", self._load_pickle(initial_path))
+        if network is not None:
+            for alg in algorithms:
+                _restore_algorithm_agent_dicts_inplace(alg, network)
+        return algorithms
 
     def load_benchmark_problem(self) -> BenchmarkProblem:
         """
@@ -781,8 +790,15 @@ class CheckpointManager:  # noqa: PLR0904
     def _save_initial_algorithms(self, algorithms: list[Algorithm[Network]]) -> None:
         """Save initial algorithm states before any trials run."""
         initial_path = self.checkpoint_dir / "initial_algorithms.pkl.zst"
-        with Status(f"Saving initial algorithms to {initial_path}..."):
-            self._save_pickle(initial_path, algorithms)
+        original_values_list = [_compact_algorithm_agent_dicts_inplace(alg) for alg in algorithms]
+        try:
+            with Status(f"Saving initial algorithms to {initial_path}..."):
+                self._save_pickle(initial_path, algorithms)
+        finally:
+            for alg, original_values in zip(algorithms, original_values_list, strict=True):
+                if original_values:
+                    for attr_name, value in original_values.items():
+                        setattr(alg, attr_name, value)
         LOGGER.debug(f"Saved initial algorithms to {initial_path}")
 
     def _save_benchmark_problem(self, problem: BenchmarkProblem) -> None:
@@ -876,3 +892,62 @@ class CheckpointManager:  # noqa: PLR0904
                     LOGGER.debug(f"Removed old checkpoint: {file_to_remove}")
                 except FileNotFoundError:
                     LOGGER.debug(f"Checkpoint file already removed by another process: {file_to_remove}")
+
+
+def _compact_algorithm_agent_dicts_inplace(algorithm: Algorithm[Network]) -> dict[str, dict[Any, Any]]:
+    """Temporarily replace algorithm dict attributes keyed by Agent with hash(Agent)."""
+    original_values: dict[str, dict[Any, Any]] = {}
+    for attr_name, value in algorithm.__dict__.items():
+        if not isinstance(value, dict) or len(value) == 0:
+            continue
+        if not all(isinstance(k, Agent) for k in value):
+            continue
+
+        original_values[attr_name] = value
+        compact: dict[int, Any] = {hash(agent): item for agent, item in value.items()}
+        setattr(
+            algorithm,
+            attr_name,
+            {
+                _AGENT_HASH_DICT_MARKER: True,
+                "data": compact,
+            },
+        )
+    return original_values
+
+
+def _restore_algorithm_agent_dicts_inplace(
+    algorithm: Algorithm[Network],
+    network: Network,
+    original_values: dict[str, dict[Any, Any]] | None = None,
+) -> None:
+    """
+    Restore algorithm dict attributes keyed by hash(Agent) with Agent.
+
+    Raises:
+        ValueError: If a compacted hash key cannot be matched to an agent in the provided network.
+
+    """
+    if original_values is not None:
+        for attr_name, value in original_values.items():
+            setattr(algorithm, attr_name, value)
+        return
+
+    hash_to_agent = {hash(agent): agent for agent in network.graph}
+    for attr_name, value in list(algorithm.__dict__.items()):
+        if not (
+            isinstance(value, dict)
+            and value.get(_AGENT_HASH_DICT_MARKER) is True
+            and "data" in value
+            and isinstance(value["data"], dict)
+        ):
+            continue
+
+        compact = value["data"]
+        decoded: dict[Any, Any] = {}
+        for key_hash, item in compact.items():
+            agent = hash_to_agent.get(key_hash)
+            if agent is None:
+                raise ValueError(f"Cannot restore {attr_name!r}: no agent in network matches hash {key_hash}.")
+            decoded[agent] = item
+        setattr(algorithm, attr_name, decoded)

--- a/decent_bench/utils/checkpoint_manager.py
+++ b/decent_bench/utils/checkpoint_manager.py
@@ -1,5 +1,5 @@
 import json
-import pickle  # noqa: S403
+import pickle
 import re
 import shutil
 from datetime import datetime
@@ -34,7 +34,7 @@ class _CheckpointData(TypedDict):
     rng_state: dict[str, Any]
 
 
-class CheckpointManager:  # noqa: PLR0904
+class CheckpointManager:
     """
     Manages checkpoint directory structure and file operations for benchmark execution.
 

--- a/decent_bench/utils/network_utils.py
+++ b/decent_bench/utils/network_utils.py
@@ -4,8 +4,9 @@ from collections.abc import Mapping
 from typing import Any, Literal
 
 import matplotlib.axes
-import networkx
 import networkx as nx
+
+from decent_bench.networks import Network
 
 _LAYOUT_FUNCS: dict[Literal["spring", "kamada_kawai", "circular", "random", "shell"], Any] = {
     "spring": nx.drawing.layout.spring_layout,
@@ -17,17 +18,17 @@ _LAYOUT_FUNCS: dict[Literal["spring", "kamada_kawai", "circular", "random", "she
 
 
 def plot_network(
-    graph: networkx.Graph[Any],
+    network: Network,
     *,
     ax: matplotlib.axes.Axes | None = None,
     layout: Literal["spring", "kamada_kawai", "circular", "random", "shell"] = "spring",
     **draw_kwargs: Mapping[str, object],
 ) -> matplotlib.axes.Axes:
     """
-    Plot a NetworkX graph using the built-in NetworkX drawing utilities.
+    Plot a Network using NetworkX drawing utilities.
 
     Args:
-        graph: NetworkX graph to plot.
+        network: Network to be plotted.
         ax: optional :class:`matplotlib.axes.Axes` to draw on. If ``None`` a new figure is created.
         layout: layout algorithm to position nodes (e.g. :func:`networkx.drawing.layout.spring_layout`,
             :func:`networkx.drawing.layout.kamada_kawai_layout`,
@@ -54,17 +55,17 @@ def plot_network(
         supported = ", ".join(sorted(_LAYOUT_FUNCS))
         raise ValueError(f"Unsupported layout '{layout}'. Supported layouts: {supported}")
 
-    pos = layout_func(graph)
+    pos = layout_func(network.graph)
     if ax is None:
         _, ax = plt.subplots()
 
     draw_kwargs_dict: dict[str, Any] = dict(draw_kwargs)
-    # use agents' ids as labels if custom labels are not specified by the user
+    # use agents' indices within the network as labels (if custom labels are not specified by the user)
     if "labels" not in draw_kwargs_dict:
-        draw_kwargs_dict["labels"] = {a: getattr(a, "id", a) for a in graph}
+        draw_kwargs_dict["labels"] = {a: a.index for a in network.graph}
 
     nx.drawing.nx_pylab.draw_networkx(
-        graph,
+        network.graph,
         pos=pos,
         ax=ax,
         **draw_kwargs_dict,

--- a/decent_bench/utils/progress_bar.py
+++ b/decent_bench/utils/progress_bar.py
@@ -180,7 +180,7 @@ class ProgressBarController:
 
     """
 
-    def __init__(  # noqa: PLR0917
+    def __init__(
         self,
         manager: SyncManager | None,
         algorithms: Sequence[Algorithm[Any]],

--- a/decent_bench/utils/types.py
+++ b/decent_bench/utils/types.py
@@ -35,13 +35,13 @@ else:
 Type variable for algorithms operating on a :class:`~decent_bench.networks.Network`.
 """
 
-type InitialStates = Union["Array", "dict[Agent, Array]", None]  # noqa: TC008, UP007
+type InitialStates = Union["Array", "dict[Agent, Array]", None]  # noqa: UP007
 """
 Type alias for what can be passed to
 :func:`~decent_bench.algorithms.utils.initial_states`.
 """
 
-type LocalSteps = int | dict["Agent", int]  # noqa: TC008
+type LocalSteps = int | dict["Agent", int]
 """
 Type alias for specifying local step counts in federated algorithms.
 
@@ -75,7 +75,7 @@ Type alias for specifying batch size in empirical risk initialization.
 Can be an integer for mini-batch size or the string "all" for full dataset.
 """
 
-type Datapoint = tuple["Array", "Array"]  # noqa: TC008
+type Datapoint = tuple["Array", "Array"]
 """Tuple of (x, y) representing one datapoint where x are features and y is the target."""
 
 type Dataset = list[Datapoint]

--- a/docs/source/api/snippets/global_cost_error.rst
+++ b/docs/source/api/snippets/global_cost_error.rst
@@ -1,6 +1,6 @@
 .. math::
-    \sum_i (f_i(\mathbf{\bar{x}}) - f_i(\mathbf{x}^\star))
+    \frac{1}{N} \sum_i (f_i(\mathbf{\bar{x}}) - f_i(\mathbf{x}^\star))
 
 where :math:`f_i` is agent i's local cost function,
-:math:`\mathbf{\bar{x}}` is the mean x across all *agents*,
+:math:`\mathbf{\bar{x}}` is the mean x across all :math:`N` *agents*,
 and :math:`\mathbf{x}^\star` is the optimal x defined in the *problem*.

--- a/docs/source/api/snippets/global_gradient_optimality.rst
+++ b/docs/source/api/snippets/global_gradient_optimality.rst
@@ -1,5 +1,5 @@
 .. math::
-    \| \frac{1}{N} \sum_i \nabla f_i(\mathbf{\bar{x}}) \|^2
+    \| \frac{1}{N} \sum_i \nabla f_i(\mathbf{\bar{x}}) \|
 
 where N is the number of *agents*,
 :math:`f_i` is agent i's local cost function,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,6 +70,7 @@ intersphinx_mapping = {
     "rich": ("https://rich.readthedocs.io/en/latest/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
     "zstandard": ("https://python-zstandard.readthedocs.io/en/latest/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
 }
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -135,6 +135,12 @@ def _fix_missing_ref(app, env, node, contnode):
                 "TensorflowTensor",
                 refuri="https://www.tensorflow.org/api_docs/python/tf/Tensor",
             )
+        if target in {"nx.Graph", "networkx.Graph"}:
+            return nodes.reference(
+                "",
+                "networkx.Graph",
+                refuri="https://networkx.org/documentation/stable/reference/classes/graph.html#networkx.Graph",
+            )
     return None
 
 

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -249,7 +249,7 @@ Configure settings for metrics, trials, statistical confidence level, logging, a
     from decent_bench.metrics.runtime_library import RuntimeLoss, RuntimeRegret
 
     if __name__ == "__main__":
-        regret = Regret([utils.single], x_log=False, y_log=True)
+        regret = Regret(x_log=False, y_log=True)
         gradient_calls = GradientCalls([min, np.average, max, sum])
 
         benchmark_result = benchmark.benchmark(

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -48,7 +48,7 @@ Note:
 
         costs, x_optimal = create_quadratic_problem(10, n_agents)
 
-        agents = [Agent(i, cost) for i, cost in enumerate(costs)]
+        agents = [Agent(cost) for i, cost in enumerate(costs)]
         graph = nx.complete_graph(n_agents)
         
         net = P2PNetwork(
@@ -359,8 +359,6 @@ If you set ``individual_plots = True`` then each plot metric will be displayed i
 otherwise groups of up to 3 plot metrics will be displayed together in the same figure as subplots.
 If you set ``compare_iterations_and_computational_cost = True``, then an additional column of subplots will be added to each figure comparing iterations and computational cost, 
 which can be useful to understand the trade-off between faster convergence and higher computational cost for different algorithms.
-If you set ``plot_metrics`` to a list of lists of :class:`~decent_bench.metrics.Metric` objects (`list[list[Metric]]`), then each inner list will be plotted together in the same figure as subplots,
-allowing you to control which metrics are plotted together.
 
 
 Interpreting Metric Warnings
@@ -525,7 +523,7 @@ Create a custom benchmark problem using existing resources.
         costs=costs,
         x_optimal=x_optimal,
         agent_activations=[UniformActivationRate(0.5)] * n_agents,
-        message_compression=Quantization(n_significant_digits=4),
+        message_compression=Quantization(quantization_step=0.01),
         message_noise=GaussianNoise(mean=0, std=0.001),
         message_drop=UniformDropRate(drop_rate=0.5),
     )
@@ -1057,8 +1055,7 @@ Create your own metrics to tabulate and/or plot.
 
     class XError(Metric):
 
-        table_description: str = "x error"
-        plot_description: str = "x error"
+        description: str = "x error"
 
         def get_data_from_trial(  # noqa: D102
             self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "matplotlib",
   "networkx",
   "numpy",
+  "pandas",
   "rich",
   "scipy",
   "scikit-learn",
@@ -39,7 +40,6 @@ dev = [
   "torch",
   "torchvision",
   "types-tensorflow",
-  "pandas",
   "pandas-stubs",
   "kagglehub",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,6 @@ lint.ignore = [
   "PLR0913",  # too-many-arguments, complains when there are more than 5 arguments
   "PLR2004",  # magic-value-comparison, complains about dimension checks in cost functions
   "PLR6301",  # no-self-use, complains when self is unused even when implementing an abstract method
-  "RUF100",   # unused-noqa, noisy when preview-only rules are disabled
   "S311",     # suspicious-non-cryptographic-random-usage, complains about `random.random()`
   "TC001",    # typing-only-first-party-import, reduced rt overhead but slower development and messy imports
   "TC002",    # typing-only-third-party-import, reduced rt overhead but slower development and messy imports

--- a/test/test_agents.py
+++ b/test/test_agents.py
@@ -81,9 +81,8 @@ except RuntimeError:
 def test_in_place_operations_history(framework: SupportedFrameworks, device: SupportedDevices):
     """Test that in-place operations on agent.x properly update the history."""
     agent = Agent(
-        0,
         LinearRegressionCost([(np.array([1.0, 1.0, 1.0]), np.array([1.0]))]),
-        None,
+        activation=None,
         state_snapshot_period=1,
     )
 
@@ -228,9 +227,8 @@ def test_agent_state_snapshot_period(
 ):
     """Test that agent history is recorded according to the specified history period."""
     agent = Agent(
-        0,
         LinearRegressionCost([(np.array([1.0, 1.0, 1.0]), np.array([1.0]))]),
-        None,
+        activation=None,
         state_snapshot_period=state_snapshot_period,
     )
 
@@ -288,13 +286,13 @@ def _make_quadratic_agent() -> Agent:
     """Return an agent with a simple 2-D quadratic cost f(x) = x^T x."""
     A = np.eye(2) * 2.0
     b = np.zeros(2)
-    return Agent(0, QuadraticCost(A, b, 0.0), None, state_snapshot_period=1)
+    return Agent(QuadraticCost(A, b, 0.0), activation=None, state_snapshot_period=1)
 
 
 def _make_empirical_agent(batch_size="all") -> Agent:
     """Return an agent backed by a 4-sample LinearRegressionCost."""
     dataset = [(np.array([float(i)]), np.array([float(i)])) for i in range(1, 5)]
-    return Agent(0, LinearRegressionCost(dataset, batch_size=batch_size), None, state_snapshot_period=1)
+    return Agent(LinearRegressionCost(dataset, batch_size=batch_size), activation=None, state_snapshot_period=1)
 
 
 def _initialized_quadratic_agent() -> Agent:
@@ -361,7 +359,7 @@ class TestCallCounting:
         """
         base_cost = QuadraticCost(np.eye(2) * 2.0, np.zeros(2), 0.0)
         wrapper = make_wrapper(base_cost)
-        agent = Agent(0, base_cost, None, state_snapshot_period=1)
+        agent = Agent(base_cost, activation=None, state_snapshot_period=1)
         agent.initialize(x=np.zeros(2))
 
         agent.cost.function(agent.x)
@@ -380,7 +378,7 @@ class TestCallCounting:
         """Deep-copying a wrapper breaks the shared reference to the patched base cost."""
         base_cost = QuadraticCost(np.eye(2) * 2.0, np.zeros(2), 0.0)
         wrapper = copy.deepcopy(make_wrapper(base_cost))
-        agent = Agent(0, base_cost, None, state_snapshot_period=1)
+        agent = Agent(base_cost, activation=None, state_snapshot_period=1)
         agent.initialize(x=np.zeros(2))
 
         wrapper.function(agent.x)
@@ -403,8 +401,8 @@ class TestCallCounting:
         """
         base_cost = QuadraticCost(np.eye(2) * 2.0, np.zeros(2), 0.0)
         wrapped_cost = make_wrapper(base_cost)
-        base_agent = Agent(0, base_cost, None, state_snapshot_period=1)
-        wrapped_agent = Agent(1, wrapped_cost, None, state_snapshot_period=1)
+        base_agent = Agent(base_cost, activation=None, state_snapshot_period=1)
+        wrapped_agent = Agent(wrapped_cost, activation=None, state_snapshot_period=1)
         base_agent.initialize(x=np.zeros(2))
         wrapped_agent.initialize(x=np.zeros(2))
 

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -44,7 +44,7 @@ def _build_p2p_problem_and_algorithms(
     network = P2PNetwork(
         graph=nx.complete_graph(len(agents)),
         agents=agents,
-        message_compression=Quantization(8),
+        message_compression=Quantization(quantization_step=1e-2),
         message_noise=GaussianNoise(0.0, 0.01),
         message_drop=UniformDropRate(0.1),
     )
@@ -75,7 +75,7 @@ def _build_fed_problem_and_algorithms(
     agents = [Agent(cost, activation=UniformActivationRate(0.8)) for cost in costs]
     network = FedNetwork(
         clients=agents,
-        message_compression=Quantization(8),
+        message_compression=Quantization(quantization_step=1e-2),
         message_noise=GaussianNoise(0.0, 0.01),
         message_drop=UniformDropRate(0.1),
     )

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -40,7 +40,7 @@ def _build_p2p_problem_and_algorithms(
         cost_cls=cost_cls,
         n_agents=4,
     )
-    agents = [Agent(i, cost, activation=UniformActivationRate(0.8)) for i, cost in enumerate(costs)]
+    agents = [Agent(cost, activation=UniformActivationRate(0.8)) for cost in costs]
     network = P2PNetwork(
         graph=nx.complete_graph(len(agents)),
         agents=agents,
@@ -72,7 +72,7 @@ def _build_fed_problem_and_algorithms(
         cost_cls=cost_cls,
         n_agents=4,
     )
-    agents = [Agent(i, cost, activation=UniformActivationRate(0.8)) for i, cost in enumerate(costs)]
+    agents = [Agent(cost, activation=UniformActivationRate(0.8)) for cost in costs]
     network = FedNetwork(
         clients=agents,
         message_compression=Quantization(8),

--- a/test/test_cost_type_preservation.py
+++ b/test/test_cost_type_preservation.py
@@ -427,37 +427,21 @@ def test_empirical_risk_plus_scaled_regularizer_matches_lambda_expression() -> N
     np.testing.assert_allclose(actual_per_sample.mean(axis=0), iop.to_numpy(objective.gradient(x, indices="all")))
 
 
-def test_same_type_empirical_addition_preserves_concrete_type_and_metadata() -> None:
+def test_same_type_empirical_addition_falls_back_to_sumcost_with_correct_numerics() -> None:
     risk_a = _simple_linear_regression_cost()
     risk_b = _second_linear_regression_cost()
     x = np.array([0.25, -0.75])
-    prediction_data = [np.array([1.0, 0.0]), np.array([0.0, 1.0])]
 
     combined = risk_a + risk_b
-    total_samples = risk_a.n_samples + risk_b.n_samples
 
-    assert isinstance(combined, LinearRegressionCost)
-    assert combined.n_samples == total_samples
-    assert combined.batch_size == combined.n_samples
-    np.testing.assert_allclose(iop.to_numpy(combined.predict(x, prediction_data)), iop.to_numpy(risk_a.predict(x, prediction_data)))
+    assert isinstance(combined, SumCost)
     _assert_cost_matches_expression(
         actual_function=combined.function(x, indices="all"),
-        expected_function=(
-            risk_a.n_samples * risk_a.function(x, indices="all") + risk_b.n_samples * risk_b.function(x, indices="all")
-        )
-        / total_samples,
+        expected_function=risk_a.function(x, indices="all") + risk_b.function(x, indices="all"),
         actual_gradient=iop.to_numpy(combined.gradient(x, indices="all")),
-        expected_gradient=(
-            risk_a.n_samples * iop.to_numpy(risk_a.gradient(x, indices="all"))
-            + risk_b.n_samples * iop.to_numpy(risk_b.gradient(x, indices="all"))
-        )
-        / total_samples,
+        expected_gradient=iop.to_numpy(risk_a.gradient(x, indices="all")) + iop.to_numpy(risk_b.gradient(x, indices="all")),
         actual_hessian=iop.to_numpy(combined.hessian(x, indices="all")),
-        expected_hessian=(
-            risk_a.n_samples * iop.to_numpy(risk_a.hessian(x, indices="all"))
-            + risk_b.n_samples * iop.to_numpy(risk_b.hessian(x, indices="all"))
-        )
-        / total_samples,
+        expected_hessian=iop.to_numpy(risk_a.hessian(x, indices="all")) + iop.to_numpy(risk_b.hessian(x, indices="all")),
     )
 
 

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -38,20 +38,14 @@ class _AlgorithmStub:
 class _MetricStub(Metric):
     def __init__(
         self,
-        table_description: str,
-        plot_description: str,
+        description: str,
     ) -> None:
         super().__init__([np.average], fmt=".2e", y_log=False)
-        self._table_description = table_description
-        self._plot_description = plot_description
+        self._description = description
 
     @property
-    def table_description(self) -> str:
-        return self._table_description
-
-    @property
-    def plot_description(self) -> str:
-        return self._plot_description
+    def description(self) -> str:
+        return self._description
 
     def get_data_from_trial(self, agents, problem, iteration):  # noqa: D102
         return [0.0]
@@ -144,7 +138,7 @@ def _build_minimal_benchmark_result() -> BenchmarkResult:
 def _build_display_metric_result(
     algorithms: list[_AlgorithmStub],
     table_metrics: list[_MetricStub],
-    plot_metrics: list[_MetricStub] | list[list[_MetricStub]],
+    plot_metrics: list[_MetricStub],
     *,
     agent_x_values: list[float] | None = None,
     table_results: dict[_AlgorithmStub, dict[_MetricStub, dict[str, tuple[float, float]]]] | None = None,
@@ -153,12 +147,6 @@ def _build_display_metric_result(
 ) -> MetricResult:
     if agent_x_values is None:
         agent_x_values = [1.0] * len(algorithms)
-
-    flat_plot_metrics = (
-        plot_metrics
-        if isinstance(plot_metrics[0], _MetricStub)
-        else [metric for group in plot_metrics for metric in group]
-    )
 
     default_table_results: dict[_AlgorithmStub, dict[_MetricStub, dict[str, tuple[float, float]]]] = {}
     default_plot_results: dict[
@@ -171,7 +159,7 @@ def _build_display_metric_result(
         for metric_idx, metric in enumerate(table_metrics):
             value = float(alg_idx + metric_idx + 1)
             default_table_results[alg][metric] = {"avg": (value, 0.0)}
-        for metric_idx, metric in enumerate(flat_plot_metrics):
+        for metric_idx, metric in enumerate(plot_metrics):
             value = float(alg_idx + metric_idx + 1)
             default_plot_results[alg][metric] = ([0.0], [value], [value], [value])
 
@@ -199,9 +187,9 @@ def _build_display_metric_result(
 def test_display_metrics_filters_algorithms(monkeypatch, algorithm_filter: str, expected_algorithms: list[str]) -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
     alg_b = _AlgorithmStub("B")
-    metric = _MetricStub("table one", "plot one")
+    metric = _MetricStub("one")
 
-    metrics_result = _build_display_metric_result([alg_a, alg_b], [metric], [[metric]])
+    metrics_result = _build_display_metric_result([alg_a, alg_b], [metric], [metric])
     algorithms = [alg_b] if algorithm_filter == "object" else ["A"]
     captured = _run_display_with_capture(monkeypatch, metrics_result, algorithms=algorithms)
 
@@ -216,8 +204,8 @@ def test_display_metrics_filters_algorithms(monkeypatch, algorithm_filter: str, 
 def test_display_metrics_keeps_nan_table_metrics(monkeypatch) -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
     alg_b = _AlgorithmStub("B")
-    valid_metric = _MetricStub("valid table", "valid plot")
-    nan_metric = _MetricStub("nan table", "nan plot")
+    valid_metric = _MetricStub("valid")
+    nan_metric = _MetricStub("nan")
 
     metrics_result = _build_display_metric_result(
         [alg_a, alg_b],
@@ -244,77 +232,57 @@ def test_display_metrics_keeps_nan_table_metrics(monkeypatch) -> None:  # noqa: 
 
     assert "table" in captured
     assert "plot" in captured
-    assert [metric.table_description for metric in captured["table"].table_metrics] == ["valid table", "nan table"]
-    assert [metric.plot_description for metric in captured["table"].plot_metrics] == ["valid plot", "nan plot"]
+    assert [metric.description for metric in captured["table"].table_metrics] == ["valid", "nan"]
+    assert [metric.description for metric in captured["table"].plot_metrics] == ["valid", "nan"]
     for algorithm_results in captured["table"].table_results.values():
-        assert [metric.table_description for metric in algorithm_results] == ["valid table", "nan table"]
+        assert [metric.description for metric in algorithm_results] == ["valid", "nan"]
 
 
 def test_display_metrics_filters_metrics_by_name(monkeypatch) -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
-    metric_1 = _MetricStub("table one", "plot one")
-    metric_2 = _MetricStub("table two", "plot two")
+    metric_1 = _MetricStub("one")
+    metric_2 = _MetricStub("two")
 
-    metrics_result = _build_display_metric_result([alg_a], [metric_1, metric_2], [[metric_1], [metric_2]])
+    metrics_result = _build_display_metric_result([alg_a], [metric_1, metric_2], [metric_1, metric_2])
 
     captured = _run_display_with_capture(
         monkeypatch,
         metrics_result,
-        table_metrics=["table two"],
-        plot_metrics=[["plot one"]],
+        table_metrics=["two"],
+        plot_metrics=["one"],
     )
 
     assert "table" in captured
-    assert [metric.table_description for metric in captured["table"].table_metrics] == ["table two"]
-    assert isinstance(captured["table"].plot_metrics, list)
-    grouped_plot_metrics = captured["table"].plot_metrics
-    assert isinstance(grouped_plot_metrics[0], list)
-    assert [metric.plot_description for metric in grouped_plot_metrics[0]] == ["plot one"]
+    assert [metric.description for metric in captured["table"].table_metrics] == ["two"]
+    assert [metric.description for metric in captured["table"].plot_metrics] == ["one"]
 
 
 def test_display_metrics_filters_metrics_with_mixed_objects_and_names(monkeypatch) -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
-    metric_1 = _MetricStub("table one", "plot one")
-    metric_2 = _MetricStub("table two", "plot two")
+    metric_1 = _MetricStub("one")
+    metric_2 = _MetricStub("two")
 
-    metrics_result = _build_display_metric_result([alg_a], [metric_1, metric_2], [[metric_1], [metric_2]])
+    metrics_result = _build_display_metric_result([alg_a], [metric_1, metric_2], [metric_1, metric_2])
 
     captured = _run_display_with_capture(
         monkeypatch,
         metrics_result,
-        table_metrics=[metric_1, "table two"],
-        plot_metrics=[[metric_1, "plot two"]],
+        table_metrics=[metric_1, "two"],
+        plot_metrics=[metric_1, "two"],
     )
 
     assert "table" in captured
-    assert [metric.table_description for metric in captured["table"].table_metrics] == ["table one", "table two"]
-    assert isinstance(captured["table"].plot_metrics, list)
-    grouped_plot_metrics = captured["table"].plot_metrics
-    assert isinstance(grouped_plot_metrics[0], list)
-    assert [metric.plot_description for metric in grouped_plot_metrics[0]] == ["plot one", "plot two"]
-
-
-def test_display_metrics_rejects_mixed_shape_plot_metrics() -> None:  # noqa: D103
-    alg_a = _AlgorithmStub("A")
-    metric_1 = _MetricStub("table one", "plot one")
-    metric_2 = _MetricStub("table two", "plot two")
-
-    metrics_result = _build_display_metric_result([alg_a], [metric_1, metric_2], [[metric_1], [metric_2]])
-
-    with pytest.raises(ValueError, match="all items must be lists"):
-        display_metrics(
-            metrics_result=metrics_result,
-            plot_metrics=[metric_1, [metric_2]],
-        )
+    assert [metric.description for metric in captured["table"].table_metrics] == ["one", "two"]
+    assert [metric.description for metric in captured["table"].plot_metrics] == ["one", "two"]
 
 
 def test_display_metrics_filters_algorithms_with_mixed_objects_and_names(monkeypatch) -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
     alg_b = _AlgorithmStub("B")
     alg_c = _AlgorithmStub("C")
-    metric = _MetricStub("table one", "plot one")
+    metric = _MetricStub("one")
 
-    metrics_result = _build_display_metric_result([alg_a, alg_b, alg_c], [metric], [[metric]])
+    metrics_result = _build_display_metric_result([alg_a, alg_b, alg_c], [metric], [metric])
 
     captured = _run_display_with_capture(monkeypatch, metrics_result, algorithms=[alg_a, "C"])
 
@@ -327,12 +295,12 @@ def test_display_metrics_filters_algorithms_with_mixed_objects_and_names(monkeyp
 
 def test_display_metrics_raises_when_all_algorithms_filtered_out(monkeypatch) -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
-    metric = _MetricStub("table one", "plot one")
+    metric = _MetricStub("one")
 
     metrics_result = MetricResult(
         agent_metrics={alg_a: [[_agent_metrics_view(1.0)]]},
         table_metrics=[metric],
-        plot_metrics=[[metric]],
+        plot_metrics=[metric],
         table_results={alg_a: {metric: {"avg": (1.0, 0.0)}}},
         plot_results={alg_a: {metric: ([0.0], [1.0], [1.0], [1.0])}},
     )
@@ -343,13 +311,13 @@ def test_display_metrics_raises_when_all_algorithms_filtered_out(monkeypatch) ->
 
 def test_display_metrics_raises_when_all_table_and_plot_metrics_filtered_out(monkeypatch) -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
-    metric_1 = _MetricStub("table one", "plot one")
-    metric_2 = _MetricStub("table two", "plot two")
+    metric_1 = _MetricStub("one")
+    metric_2 = _MetricStub("two")
 
     metrics_result = MetricResult(
         agent_metrics={alg_a: [[_agent_metrics_view(1.0)]]},
         table_metrics=[metric_1, metric_2],
-        plot_metrics=[[metric_1], [metric_2]],
+        plot_metrics=[metric_1, metric_2],
         table_results={
             alg_a: {
                 metric_1: {"avg": (1.0, 0.0)},
@@ -374,10 +342,10 @@ def test_display_metrics_raises_when_all_table_and_plot_metrics_filtered_out(mon
 
 def test_display_metrics_shows_only_tables_when_plot_metrics_empty(monkeypatch) -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
-    metric_1 = _MetricStub("table one", "plot one")
-    metric_2 = _MetricStub("table two", "plot two")
+    metric_1 = _MetricStub("one")
+    metric_2 = _MetricStub("two")
 
-    metrics_result = _build_display_metric_result([alg_a], [metric_1, metric_2], [[metric_1], [metric_2]])
+    metrics_result = _build_display_metric_result([alg_a], [metric_1, metric_2], [metric_1, metric_2])
 
     captured = _run_display_with_capture(
         monkeypatch,
@@ -392,10 +360,10 @@ def test_display_metrics_shows_only_tables_when_plot_metrics_empty(monkeypatch) 
 
 def test_display_metrics_shows_only_plots_when_table_metrics_empty(monkeypatch) -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
-    metric_1 = _MetricStub("table one", "plot one")
-    metric_2 = _MetricStub("table two", "plot two")
+    metric_1 = _MetricStub("one")
+    metric_2 = _MetricStub("two")
 
-    metrics_result = _build_display_metric_result([alg_a], [metric_1, metric_2], [[metric_1], [metric_2]])
+    metrics_result = _build_display_metric_result([alg_a], [metric_1, metric_2], [metric_1, metric_2])
 
     captured = _run_display_with_capture(
         monkeypatch,
@@ -411,44 +379,42 @@ def test_display_metrics_shows_only_plots_when_table_metrics_empty(monkeypatch) 
 def test_metric_result_available_discovery_properties() -> None:  # noqa: D103
     alg_a = _AlgorithmStub("A")
     alg_b = _AlgorithmStub("B")
-    metric_1 = _MetricStub("table one", "plot one")
-    metric_2 = _MetricStub("table two", "plot two")
+    metric_1 = _MetricStub("one")
+    metric_2 = _MetricStub("two")
 
     metrics_result = MetricResult(
         agent_metrics={alg_a: [[[]]], alg_b: [[[]]]},
         table_metrics=[metric_1, metric_1, metric_2],
-        plot_metrics=[[metric_1], [metric_1, metric_2]],
+        plot_metrics=[metric_1, metric_1, metric_2],
         table_results={alg_a: {metric_1: {"avg": (1.0, 0.1)}}},
         plot_results={alg_b: {metric_2: ([0.0], [2.0], [2.0], [2.0])}},
     )
 
     assert metrics_result.available_algorithms == ["A", "B"]
-    assert metrics_result.available_table_metrics == ["table one", "table two"]
-    assert metrics_result.available_plot_metrics == ["plot one", "plot two"]
+    assert metrics_result.available_table_metrics == ["one", "two"]
+    assert metrics_result.available_plot_metrics == ["one", "two"]
 
 
-def test_compute_metrics_rejects_duplicate_table_metric_descriptions(monkeypatch) -> None:  # noqa: D103
+@pytest.mark.parametrize(
+    ("table_metrics", "plot_metrics", "expected_error"),
+    [
+        ([_MetricStub("same"), _MetricStub("same")], [], "Table metric descriptions must be unique"),
+        ([], [_MetricStub("same"), _MetricStub("same")], "Plot metric descriptions must be unique"),
+    ],
+)
+def test_compute_metrics_rejects_duplicate_metric_descriptions(
+    monkeypatch,
+    table_metrics: list[_MetricStub],
+    plot_metrics: list[_MetricStub],
+    expected_error: str,
+) -> None:  # noqa: D103
     benchmark_result = _build_minimal_benchmark_result()
-    metric_1 = _MetricStub("same table", "plot one")
-    metric_2 = _MetricStub("same table", "plot two")
 
     monkeypatch.setattr("decent_bench.benchmark._compute.compute_tables", lambda *args, **kwargs: {})
     monkeypatch.setattr("decent_bench.benchmark._compute.compute_plots", lambda *args, **kwargs: {})
 
-    with pytest.raises(ValueError, match="Table metric descriptions must be unique"):
-        compute_metrics(benchmark_result=benchmark_result, table_metrics=[metric_1, metric_2], plot_metrics=[])
-
-
-def test_compute_metrics_rejects_duplicate_plot_metric_descriptions(monkeypatch) -> None:  # noqa: D103
-    benchmark_result = _build_minimal_benchmark_result()
-    metric_1 = _MetricStub("table one", "same plot")
-    metric_2 = _MetricStub("table two", "same plot")
-
-    monkeypatch.setattr("decent_bench.benchmark._compute.compute_tables", lambda *args, **kwargs: {})
-    monkeypatch.setattr("decent_bench.benchmark._compute.compute_plots", lambda *args, **kwargs: {})
-
-    with pytest.raises(ValueError, match="Plot metric descriptions must be unique"):
-        compute_metrics(benchmark_result=benchmark_result, table_metrics=[], plot_metrics=[[metric_1], [metric_2]])
+    with pytest.raises(ValueError, match=expected_error):
+        compute_metrics(benchmark_result=benchmark_result, table_metrics=table_metrics, plot_metrics=plot_metrics)
 
 
 # -----------------------------------------------------------------------------
@@ -726,7 +692,7 @@ def test_classification_metrics_unavailable_with_float_targets() -> None:  # noq
 
 def test_is_available_default_returns_true() -> None:  # noqa: D103
     """Base Metric.is_available default: always available."""
-    metric = _MetricStub("t", "p")
+    metric = _MetricStub("t")
     available, reason = metric.is_available(SimpleNamespace())
     assert available
     assert reason is None
@@ -738,18 +704,14 @@ def test_is_available_default_returns_true() -> None:  # noqa: D103
 
 
 class _PlotMetricStub(Metric):
-    def __init__(self, plot_description: str, plot_data_by_x_value: dict[float, list[tuple[float, float]]]) -> None:
+    def __init__(self, description: str, plot_data_by_x_value: dict[float, list[tuple[float, float]]]) -> None:
         super().__init__([np.average], fmt=".2e", y_log=False)
-        self._plot_description = plot_description
+        self._description = description
         self._plot_data_by_x_value = plot_data_by_x_value
 
     @property
-    def table_description(self) -> str:
-        return self._plot_description
-
-    @property
-    def plot_description(self) -> str:
-        return self._plot_description
+    def description(self) -> str:
+        return self._description
 
     def get_data_from_trial(self, agents, problem, iteration):  # noqa: D102
         return [0.0]

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -7,6 +7,7 @@ from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 from pathlib import Path
 from types import SimpleNamespace
+from uuid import uuid4
 
 from decent_bench.agents import Agent, AgentHistory, AgentMetricsView
 from decent_bench.algorithms.federated import FedAvg
@@ -58,6 +59,7 @@ def _agent_metrics_view(x_value: float) -> AgentMetricsView:
     history = AgentHistory()
     history[0] = np.array([x_value])
     return AgentMetricsView(
+        id=uuid4(),
         cost=object(),
         x_history=history,
         n_x_updates=0,
@@ -792,6 +794,7 @@ def test_server_mse_availability_and_values() -> None:  # noqa: D103
     server_history[0] = np.array([0.0])
     server_history[1] = np.array([1.0])
     server_view = AgentMetricsView(
+        id=uuid4(),
         cost=cost,
         x_history=server_history,
         n_x_updates=0,
@@ -839,6 +842,7 @@ def test_server_accuracy_availability_and_values() -> None:  # noqa: D103
     server_history[0] = np.array([0.0])
     server_history[1] = np.array([10.0])
     server_view = AgentMetricsView(
+        id=uuid4(),
         cost=cost,
         x_history=server_history,
         n_x_updates=0,

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -143,8 +143,8 @@ def _build_minimal_benchmark_result() -> BenchmarkResult:
 
 def _build_federated_benchmark_result(iterations: int = 2) -> tuple[BenchmarkResult, FedAvg]:
     clients = [
-        Agent(0, QuadraticCost(np.eye(1), np.array([0.0]))),
-        Agent(1, QuadraticCost(np.eye(1), np.array([0.0]))),
+        Agent(QuadraticCost(np.eye(1), np.array([0.0]))),
+        Agent(QuadraticCost(np.eye(1), np.array([0.0]))),
     ]
     network = FedNetwork(clients=clients)
     algorithm = FedAvg(iterations=iterations, step_size=0.1)
@@ -457,13 +457,13 @@ def test_compute_metrics_uses_federated_defaults_and_server_view() -> None:  # n
     )
 
     assert metrics_result.table_results is not None
-    assert metrics_result.table_results[algorithm][selected_metric]["single"] == (1.0, 0.0)
+    assert metrics_result.table_results[algorithm][selected_metric][""] == (1.0, 0.0)
     assert metrics_result.table_results[algorithm][sent_messages_metric]["sum"] == (8.0, 0.0)
 
 
 def test_compute_metrics_custom_metrics_do_not_append_federated_defaults(monkeypatch) -> None:  # noqa: D103
     benchmark_result, _ = _build_federated_benchmark_result(iterations=1)
-    metric = _MetricStub("custom table", "custom plot")
+    metric = _MetricStub("custom table")
     captured: dict[str, object] = {}
 
     def _capture_tables(*args, **kwargs):
@@ -479,7 +479,7 @@ def test_compute_metrics_custom_metrics_do_not_append_federated_defaults(monkeyp
 
     compute_metrics(benchmark_result=benchmark_result, table_metrics=[metric], plot_metrics=[])
 
-    assert [m.table_description for m in captured["table_metrics"]] == [metric.table_description]
+    assert [m.description for m in captured["table_metrics"]] == [metric.description]
     assert captured["plot_metrics"] == []
 
 
@@ -759,7 +759,7 @@ def test_classification_metrics_unavailable_with_float_targets() -> None:  # noq
 def test_server_mse_availability_and_values() -> None:  # noqa: D103
     test_data = [(np.array([1.0]), np.array([1.0]))]
     cost = LinearRegressionCost(test_data)
-    client = Agent(0, cost)
+    client = Agent(cost)
     client.initialize(x=np.array([0.0]))
 
     unavailable_problem = SimpleNamespace(
@@ -770,10 +770,16 @@ def test_server_mse_availability_and_values() -> None:  # noqa: D103
     assert not available
     assert "FedNetwork" in reason
 
+    client = Agent(cost)
+    client.initialize(x=np.array([0.0]))
+
     fed_problem_without_test_data = BenchmarkProblem(network=FedNetwork([client]))
     available, reason = ml.ServerMSE([np.average]).is_available(fed_problem_without_test_data)
     assert not available
     assert reason == "requires problem.test_data"
+
+    client = Agent(cost)
+    client.initialize(x=np.array([0.0]))
 
     problem = BenchmarkProblem(network=FedNetwork([client]), test_data=test_data)
     metric = ml.ServerMSE([np.average])
@@ -808,12 +814,15 @@ def test_server_accuracy_availability_and_values() -> None:  # noqa: D103
     train_data = [(np.array([1.0]), np.array([1])), (np.array([-1.0]), np.array([0]))]
     test_data = [(np.array([1.0]), 1), (np.array([-1.0]), 0)]
     cost = LogisticRegressionCost(train_data)
-    client = Agent(0, cost)
+    client = Agent(cost)
     client.initialize(x=np.array([0.0]))
     problem = BenchmarkProblem(network=FedNetwork([client]), test_data=test_data)
 
+    client_for_float_targets = Agent(cost)
+    client_for_float_targets.initialize(x=np.array([0.0]))
+
     float_target_problem = BenchmarkProblem(
-        network=FedNetwork([client]),
+        network=FedNetwork([client_for_float_targets]),
         test_data=[(np.array([1.0]), 1.0), (np.array([-1.0]), 0.0)],
     )
     metric = ml.ServerAccuracy([np.average])

--- a/test/test_distributed_algorithms.py
+++ b/test/test_distributed_algorithms.py
@@ -102,7 +102,7 @@ def _create_p2p_network(impairments: bool, cost_cls: type) -> P2PNetwork:
     return P2PNetwork(
         graph=nx.complete_graph(len(agents)),
         agents=agents,
-        message_compression=Quantization(8) if impairments else None,
+        message_compression=Quantization(quantization_step=1e-2) if impairments else None,
         message_noise=GaussianNoise(0.0, 0.01) if impairments else None,
         message_drop=UniformDropRate(0.1) if impairments else None,
     )
@@ -134,7 +134,7 @@ def _create_fed_network(impairments: bool, cost_cls: type) -> FedNetwork:
     ]
     return FedNetwork(
         clients=agents,
-        message_compression=Quantization(8) if impairments else None,
+        message_compression=Quantization(quantization_step=1e-2) if impairments else None,
         message_noise=GaussianNoise(0.0, 0.01) if impairments else None,
         message_drop=UniformDropRate(0.1) if impairments else None,
     )

--- a/test/test_distributed_algorithms.py
+++ b/test/test_distributed_algorithms.py
@@ -94,7 +94,6 @@ def _create_p2p_network(impairments: bool, cost_cls: type) -> P2PNetwork:
         )
     agents = [
         Agent(
-            i,
             cost,
             activation=UniformActivationRate(0.8) if impairments else None,
         )
@@ -128,7 +127,6 @@ def _create_fed_network(impairments: bool, cost_cls: type) -> FedNetwork:
         )
     agents = [
         Agent(
-            i,
             cost,
             activation=UniformActivationRate(0.8) if impairments else None,
         )

--- a/test/test_feddyn.py
+++ b/test/test_feddyn.py
@@ -72,7 +72,7 @@ class FirstClientSelection(ClientSelectionScheme):
 
 
 def test_feddyn_initializes_server_and_client_dynamic_states() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedDyn(iterations=1, x0=np.array([2.0]))
 
@@ -86,7 +86,7 @@ def test_feddyn_initializes_server_and_client_dynamic_states() -> None:
 
 
 def test_feddyn_one_round_update_follows_dynamic_regularization_formula() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedDyn(iterations=1, step_size=1.0, alpha=1.0)
     algorithm.initialize(network)
@@ -103,7 +103,7 @@ def test_feddyn_one_round_update_follows_dynamic_regularization_formula() -> Non
 
 
 def test_feddyn_uses_dynamic_state_in_later_local_updates() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedDyn(iterations=2, step_size=1.0, alpha=1.0)
     algorithm.initialize(network)
@@ -122,7 +122,7 @@ def test_feddyn_uses_dynamic_state_in_later_local_updates() -> None:
 
 
 def test_feddyn_partial_participation_leaves_unselected_client_state_unchanged() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedDyn(iterations=1, step_size=1.0, alpha=1.0, selection_scheme=FirstClientSelection())
     algorithm.initialize(network)
@@ -139,7 +139,7 @@ def test_feddyn_partial_participation_leaves_unselected_client_state_unchanged()
 
 
 def test_feddyn_aggregate_uses_only_received_client_models() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedDyn(iterations=1, alpha=1.0)
     algorithm.initialize(network)
@@ -153,7 +153,7 @@ def test_feddyn_aggregate_uses_only_received_client_models() -> None:
 
 
 def test_feddyn_aggregate_keeps_server_state_when_no_models_are_received() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedDyn(iterations=1, alpha=1.0)
     algorithm.initialize(network)
@@ -167,8 +167,8 @@ def test_feddyn_aggregate_keeps_server_state_when_no_models_are_received() -> No
 
 
 def test_feddyn_clients_without_server_broadcast_do_not_participate() -> None:
-    client = Agent(0, TrackingCost(1.0))
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(TrackingCost(1.0))
+    server = Agent(ZeroCost((1,)))
     network = FedNetwork(clients=[client], server=server, message_drop={server: DropOnCalls({1}), client: NoDrops()})
     algorithm = FedDyn(iterations=1, step_size=1.0, alpha=1.0)
     algorithm.initialize(network)

--- a/test/test_federated_aggregation.py
+++ b/test/test_federated_aggregation.py
@@ -164,35 +164,6 @@ def test_clients_without_server_broadcast_do_not_participate(
 @pytest.mark.parametrize(
     ("algorithm_cls", "kwargs"),
     [
-        pytest.param(FedAvg, {"iterations": 2, "step_size": 1.0}, id="fedavg"),
-        pytest.param(FedProx, {"iterations": 2, "step_size": 1.0}, id="fedprox"),
-    ],
-)
-def test_buffered_stale_client_messages_are_not_aggregated(algorithm_cls: type, kwargs: dict[str, float | int]) -> None:
-    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
-    server = Agent(TrackingCost(0.0))
-    network = FedNetwork(
-        clients=clients,
-        server=server,
-        buffer_messages=True,
-        message_drop={server: NoDrops(), clients[0]: DropOnCalls({2}), clients[1]: NoDrops()},
-    )
-    algorithm = algorithm_cls(**kwargs)
-    algorithm.initialize(network)
-
-    network._step(0)  # noqa: SLF001
-    algorithm.step(network, 0)
-    np.testing.assert_allclose(network.server().x, np.array([-2.0]))
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([-5.0]))
-
-
-@pytest.mark.parametrize(
-    ("algorithm_cls", "kwargs"),
-    [
         pytest.param(
             FedAdagrad,
             {"iterations": 1, "step_size": 1.0, "server_step_size": 1.0, "beta_1": 0.0, "tau": 1.0},
@@ -474,66 +445,6 @@ def test_fedopt_clients_without_server_broadcast_do_not_participate(
     np.testing.assert_allclose(network.server().x, first_round_x)
     np.testing.assert_allclose(network.server().aux_vars["m"], first_round_m)
     np.testing.assert_allclose(network.server().aux_vars["v"], first_round_v)
-
-
-@pytest.mark.parametrize(
-    ("algorithm_cls", "kwargs", "expected_x"),
-    [
-        pytest.param(
-            FedAdagrad,
-            {"iterations": 2, "step_size": 1.0, "server_step_size": 1.0, "beta_1": 0.0, "tau": 1.0},
-            -0.6666666666666666 + (-3.0 / (np.sqrt(13.0) + 1.0)),
-            id="fedadagrad",
-        ),
-        pytest.param(
-            FedYogi,
-            {
-                "iterations": 2,
-                "step_size": 1.0,
-                "server_step_size": 1.0,
-                "beta_1": 0.0,
-                "beta_2": 0.25,
-                "tau": 1.0,
-            },
-            (-2.0 / (np.sqrt(3.0) + 1.0)) + (-3.0 / (np.sqrt(9.75) + 1.0)),
-            id="fedyogi",
-        ),
-        pytest.param(
-            FedAdam,
-            {
-                "iterations": 2,
-                "step_size": 1.0,
-                "server_step_size": 1.0,
-                "beta_1": 0.0,
-                "beta_2": 0.25,
-                "tau": 1.0,
-            },
-            (-2.0 / (np.sqrt(3.0) + 1.0)) + (-3.0 / (np.sqrt(7.5) + 1.0)),
-            id="fedadam",
-        ),
-    ],
-)
-def test_fedopt_buffered_stale_client_messages_are_not_aggregated(
-    algorithm_cls: type, kwargs: dict[str, float | int], expected_x: float
-) -> None:
-    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
-    server = Agent(TrackingCost(0.0))
-    network = FedNetwork(
-        clients=clients,
-        server=server,
-        buffer_messages=True,
-        message_drop={server: NoDrops(), clients[0]: DropOnCalls({2}), clients[1]: NoDrops()},
-    )
-    algorithm = algorithm_cls(**kwargs)
-    algorithm.initialize(network)
-
-    network._step(0)  # noqa: SLF001
-    algorithm.step(network, 0)
-
-    network._step(1)  # noqa: SLF001
-    algorithm.step(network, 1)
-
-    np.testing.assert_allclose(network.server().x, np.array([expected_x]))
 
 
 @pytest.mark.parametrize(

--- a/test/test_federated_aggregation.py
+++ b/test/test_federated_aggregation.py
@@ -64,7 +64,7 @@ class DropOnCalls(DropScheme):
 
 
 def _make_fed_network(*costs: Cost) -> tuple[FedNetwork, list[Agent]]:
-    clients = [Agent(i, cost) for i, cost in enumerate(costs)]
+    clients = [Agent(cost) for cost in costs]
     network = FedNetwork(clients=clients)
     for client in clients:
         client.initialize(x=np.zeros(client.cost.shape, dtype=float))
@@ -141,8 +141,8 @@ def test_aggregation_keeps_server_state_when_no_updates_are_received(
 def test_clients_without_server_broadcast_do_not_participate(
     algorithm_cls: type, kwargs: dict[str, float | int]
 ) -> None:
-    client = Agent(0, TrackingCost(1.0))
-    server = Agent(1, TrackingCost(0.0))
+    client = Agent(TrackingCost(1.0))
+    server = Agent(TrackingCost(0.0))
     network = FedNetwork(
         clients=[client],
         server=server,
@@ -169,8 +169,8 @@ def test_clients_without_server_broadcast_do_not_participate(
     ],
 )
 def test_buffered_stale_client_messages_are_not_aggregated(algorithm_cls: type, kwargs: dict[str, float | int]) -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, TrackingCost(0.0))
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
+    server = Agent(TrackingCost(0.0))
     network = FedNetwork(
         clients=clients,
         server=server,
@@ -452,8 +452,8 @@ def test_fedopt_server_state_updates_follow_variant_formula(
 def test_fedopt_clients_without_server_broadcast_do_not_participate(
     algorithm_cls: type, kwargs: dict[str, float | int]
 ) -> None:
-    client = Agent(0, TrackingCost(1.0))
-    server = Agent(1, TrackingCost(0.0))
+    client = Agent(TrackingCost(1.0))
+    server = Agent(TrackingCost(0.0))
     network = FedNetwork(
         clients=[client],
         server=server,
@@ -516,8 +516,8 @@ def test_fedopt_clients_without_server_broadcast_do_not_participate(
 def test_fedopt_buffered_stale_client_messages_are_not_aggregated(
     algorithm_cls: type, kwargs: dict[str, float | int], expected_x: float
 ) -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, TrackingCost(0.0))
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
+    server = Agent(TrackingCost(0.0))
     network = FedNetwork(
         clients=clients,
         server=server,

--- a/test/test_federated_cost_routing.py
+++ b/test/test_federated_cost_routing.py
@@ -180,8 +180,8 @@ def _run_federated_local_update(
     num_local_epochs: int = 1,
     mu: float = 0.5,
 ) -> np.ndarray:
-    client = Agent(0, cost)
-    server = Agent(1, ZeroCost(cost.shape))
+    client = Agent(cost)
+    server = Agent(ZeroCost(cost.shape))
 
     if algorithm_name == "fedavg":
         algorithm = FedAvg(iterations=1, step_size=step_size, num_local_epochs=num_local_epochs)

--- a/test/test_fedlt.py
+++ b/test/test_fedlt.py
@@ -160,7 +160,7 @@ class FirstClientSelection(ClientSelectionScheme):
 
 
 def _make_network(*costs: Cost) -> FedNetwork:
-    return FedNetwork(clients=[Agent(i, cost) for i, cost in enumerate(costs)])
+    return FedNetwork(clients=[Agent(cost) for cost in costs])
 
 
 @pytest.mark.parametrize("use_acceleration", [False, True])
@@ -213,8 +213,8 @@ def test_fedlt_accelerated_solver_requires_valid_client_constants() -> None:
 
 
 def test_fedlt_local_gradient_step_uses_penalty_term() -> None:
-    client = Agent(0, ConstantGradientCost(gradient_value=1.0))
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(ConstantGradientCost(gradient_value=1.0))
+    server = Agent(ZeroCost((1,)))
     algorithm = FedLT(iterations=1, step_size=1.0, num_local_epochs=2, rho=1.0)
     client.initialize(x=np.array([0.0]), aux_vars={"z": np.array([0.0])})
     server.initialize(x=np.array([0.0]))
@@ -228,8 +228,8 @@ def test_fedlt_local_gradient_step_uses_penalty_term() -> None:
 
 def test_fedlt_server_step_uses_server_cost_proximal_for_optional_global_regularizer() -> None:
     server_cost = ShiftProxCost(shift=0.5)
-    clients = [Agent(0, ConstantGradientCost(0.0)), Agent(1, ConstantGradientCost(0.0))]
-    server = Agent(2, server_cost)
+    clients = [Agent(ConstantGradientCost(0.0)), Agent(ConstantGradientCost(0.0))]
+    server = Agent(server_cost)
     network = FedNetwork(clients=clients, server=server)
     algorithm = FedLT(iterations=1, step_size=0.1, num_local_epochs=1, rho=2.0)
     algorithm.initialize(network)
@@ -243,8 +243,8 @@ def test_fedlt_server_step_uses_server_cost_proximal_for_optional_global_regular
 
 
 def test_fedlt_server_step_supports_regularizer_server_cost() -> None:
-    clients = [Agent(0, ConstantGradientCost(0.0)), Agent(1, ConstantGradientCost(0.0))]
-    server = Agent(2, L1RegularizerCost(shape=(1,)))
+    clients = [Agent(ConstantGradientCost(0.0)), Agent(ConstantGradientCost(0.0))]
+    server = Agent(L1RegularizerCost(shape=(1,)))
     network = FedNetwork(clients=clients, server=server)
     algorithm = FedLT(iterations=1, step_size=0.1, num_local_epochs=1, rho=2.0)
     algorithm.initialize(network)
@@ -258,8 +258,8 @@ def test_fedlt_server_step_supports_regularizer_server_cost() -> None:
 
 def test_fedlt_empirical_cost_uses_existing_minibatch_gradient_default() -> None:
     cost = TrackingEmpiricalCost(n_samples=5, batch_size=2)
-    client = Agent(0, cost)
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(cost)
+    server = Agent(ZeroCost((1,)))
     algorithm = FedLT(iterations=1, step_size=1.0, num_local_epochs=3, rho=1.0)
     client.initialize(x=np.array([0.0]), aux_vars={"z": np.array([0.0])})
     server.initialize(x=np.array([0.0]))
@@ -274,8 +274,8 @@ def test_fedlt_empirical_cost_uses_existing_minibatch_gradient_default() -> None
 
 def test_fedlt_generic_cost_uses_full_gradient_call_default() -> None:
     cost = ConstantGradientCost(gradient_value=1.0)
-    client = Agent(0, cost)
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(cost)
+    server = Agent(ZeroCost((1,)))
     algorithm = FedLT(iterations=1, step_size=1.0, num_local_epochs=2, rho=1.0)
     client.initialize(x=np.array([0.0]), aux_vars={"z": np.array([0.0])})
     server.initialize(x=np.array([0.0]))
@@ -307,7 +307,7 @@ def test_fedlt_supports_partial_participation_and_keeps_stale_server_z() -> None
 
 def test_fedlt_smoke_with_network_noise_and_compression() -> None:
     network = FedNetwork(
-        clients=[Agent(0, ConstantGradientCost(1.0)), Agent(1, ConstantGradientCost(2.0))],
+        clients=[Agent(ConstantGradientCost(1.0)), Agent(ConstantGradientCost(2.0))],
         message_noise=GaussianNoise(0.0, 0.0),
         message_compression=Quantization(6),
     )

--- a/test/test_fedlt.py
+++ b/test/test_fedlt.py
@@ -309,7 +309,7 @@ def test_fedlt_smoke_with_network_noise_and_compression() -> None:
     network = FedNetwork(
         clients=[Agent(ConstantGradientCost(1.0)), Agent(ConstantGradientCost(2.0))],
         message_noise=GaussianNoise(0.0, 0.0),
-        message_compression=Quantization(6),
+        message_compression=Quantization(quantization_step=1e-2),
     )
     algorithm = FedLT(iterations=2, step_size=0.1, num_local_epochs=1, rho=1.0)
 

--- a/test/test_fedlt.py
+++ b/test/test_fedlt.py
@@ -268,8 +268,8 @@ def test_fedlt_initializes_auxiliary_variables_from_z0() -> None:
 
 
 def test_fedlt_nesterov_update_uses_step_size_and_momentum() -> None:
-    client = Agent(0, ConstantGradientCost(gradient_value=2.0))
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(ConstantGradientCost(gradient_value=2.0))
+    server = Agent(ZeroCost((1,)))
     algorithm = FedLT(
         iterations=1,
         step_size=0.25,
@@ -289,8 +289,8 @@ def test_fedlt_nesterov_update_uses_step_size_and_momentum() -> None:
 
 
 def test_fedlt_nesterov_default_momentum_is_used() -> None:
-    client = Agent(0, ConstantGradientCost(gradient_value=2.0))
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(ConstantGradientCost(gradient_value=2.0))
+    server = Agent(ZeroCost((1,)))
     algorithm = FedLT(
         iterations=1,
         step_size=0.25,
@@ -323,8 +323,8 @@ def test_fedlt_local_gradient_step_uses_penalty_term() -> None:
 
 
 def test_fedlt_adam_one_step_matches_formula() -> None:
-    client = Agent(0, ConstantGradientCost(gradient_value=2.0))
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(ConstantGradientCost(gradient_value=2.0))
+    server = Agent(ZeroCost((1,)))
     algorithm = FedLT(iterations=1, step_size=0.5, num_local_epochs=1, rho=1.0, local_solver="adam")
     client.initialize(x=np.array([0.0]), aux_vars={"z": np.array([0.0])})
     server.initialize(x=np.array([0.0]))
@@ -360,8 +360,8 @@ def _manual_adam_steps(
 
 
 def test_fedlt_adam_multi_step_matches_formula_on_quadratic() -> None:
-    client = Agent(0, QuadraticCost(A=np.array([[1.0]]), b=np.array([0.0])))
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(QuadraticCost(A=np.array([[1.0]]), b=np.array([0.0])))
+    server = Agent(ZeroCost((1,)))
     algorithm = FedLT(
         iterations=1,
         step_size=0.1,
@@ -389,8 +389,8 @@ def test_fedlt_adam_multi_step_matches_formula_on_quadratic() -> None:
 
 
 def test_fedlt_adam_moments_reset_each_local_solve() -> None:
-    client = Agent(0, QuadraticCost(A=np.array([[1.0]]), b=np.array([0.0])))
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(QuadraticCost(A=np.array([[1.0]]), b=np.array([0.0])))
+    server = Agent(ZeroCost((1,)))
     algorithm = FedLT(iterations=1, step_size=0.1, num_local_epochs=2, rho=1.0, local_solver="adam")
     server.initialize(x=np.array([0.0]))
 
@@ -487,7 +487,7 @@ def test_fedlt_supports_partial_participation_and_keeps_stale_server_z() -> None
 
 
 def test_fedlt_keeps_stale_server_z_when_client_upload_is_dropped() -> None:
-    clients = [Agent(0, ConstantGradientCost(1.0)), Agent(1, ConstantGradientCost(3.0))]
+    clients = [Agent(ConstantGradientCost(1.0)), Agent(ConstantGradientCost(3.0))]
     network = FedNetwork(
         clients=clients,
         message_drop={clients[0]: DropOnCalls({1}), clients[1]: NoDrops()},

--- a/test/test_fednova.py
+++ b/test/test_fednova.py
@@ -70,7 +70,7 @@ def _make_fed_network(*client_specs: float | tuple[float, int]) -> FedNetwork:
             gradient_value, n_samples = client_spec
         else:
             gradient_value, n_samples = client_spec, 1
-        clients.append(Agent(i, TrackingCost(gradient_value, n_samples=n_samples)))
+        clients.append(Agent(TrackingCost(gradient_value, n_samples=n_samples)))
     return FedNetwork(clients=clients)
 
 
@@ -391,8 +391,8 @@ def test_fednova_aggregate_rejects_non_positive_normalizer() -> None:
 
 
 def test_fednova_collect_received_normalizers_stores_empty_dict_when_all_are_dropped() -> None:
-    clients = [Agent(0, TrackingCost(1.0, n_samples=1)), Agent(1, TrackingCost(10.0, n_samples=3))]
-    server = Agent(2, TrackingCost(0.0))
+    clients = [Agent(TrackingCost(1.0, n_samples=1)), Agent(TrackingCost(10.0, n_samples=3))]
+    server = Agent(TrackingCost(0.0))
     network = FedNetwork(
         clients=clients,
         server=server,
@@ -414,8 +414,8 @@ def test_fednova_collect_received_normalizers_stores_empty_dict_when_all_are_dro
 
 
 def test_fednova_skips_round_when_all_normalizer_uploads_are_dropped() -> None:
-    clients = [Agent(0, TrackingCost(1.0, n_samples=1)), Agent(1, TrackingCost(10.0, n_samples=3))]
-    server = Agent(2, TrackingCost(0.0))
+    clients = [Agent(TrackingCost(1.0, n_samples=1)), Agent(TrackingCost(10.0, n_samples=3))]
+    server = Agent(TrackingCost(0.0))
     network = FedNetwork(
         clients=clients,
         server=server,
@@ -435,8 +435,8 @@ def test_fednova_skips_round_when_all_normalizer_uploads_are_dropped() -> None:
 
 @pytest.mark.parametrize("dropped_calls", [{1}, {2}])
 def test_fednova_uses_only_clients_with_both_uploads(dropped_calls: set[int]) -> None:
-    clients = [Agent(0, TrackingCost(1.0, n_samples=1)), Agent(1, TrackingCost(10.0, n_samples=3))]
-    server = Agent(2, TrackingCost(0.0))
+    clients = [Agent(TrackingCost(1.0, n_samples=1)), Agent(TrackingCost(10.0, n_samples=3))]
+    server = Agent(TrackingCost(0.0))
     network = FedNetwork(
         clients=clients,
         server=server,
@@ -523,7 +523,7 @@ def test_fednova_rejects_local_step_mappings_missing_network_clients(num_local_s
 
 @pytest.mark.parametrize("step_value", [0, -1])
 def test_fednova_rejects_invalid_local_step_mapping_values(step_value: float) -> None:
-    client = Agent(0, TrackingCost())
+    client = Agent(TrackingCost())
     with pytest.raises(ValueError, match="`num_local_steps` must have positive values"):
         FedNova(iterations=1, step_size=1.0, num_local_steps={client: step_value})
 

--- a/test/test_fednova.py
+++ b/test/test_fednova.py
@@ -556,7 +556,7 @@ def test_fednova_rejects_invalid_local_step_mapping_values(step_value: float) ->
 
 @pytest.mark.parametrize("step_value", [2.0])
 def test_fednova_rejects_non_integer_local_step_mapping_values(step_value: object) -> None:
-    client = Agent(0, TrackingCost())
+    client = Agent(TrackingCost())
     with pytest.raises(TypeError, match="`num_local_steps` mapping values must be integers"):
         FedNova(iterations=1, step_size=1.0, num_local_steps={client: step_value})
 

--- a/test/test_fedpd.py
+++ b/test/test_fedpd.py
@@ -69,7 +69,7 @@ class DropOnCalls(DropScheme):
 
 
 def test_fedpd_initializes_primal_dual_and_center_states() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedPD(iterations=1, x0=np.array([2.0]))
 
@@ -83,7 +83,7 @@ def test_fedpd_initializes_primal_dual_and_center_states() -> None:
 
 
 def test_fedpd_p_zero_always_aggregates_and_synchronizes_centers() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedPD(iterations=1, step_size=1.0, eta=1.0, skip_probability=0.0)
     algorithm.initialize(network)
@@ -101,7 +101,7 @@ def test_fedpd_p_zero_always_aggregates_and_synchronizes_centers() -> None:
 
 
 def test_fedpd_supports_heterogeneous_local_steps() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedPD(
         iterations=1,
@@ -121,7 +121,7 @@ def test_fedpd_supports_heterogeneous_local_steps() -> None:
 
 
 def test_fedpd_always_selects_all_active_clients() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0)), Agent(2, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedPD(iterations=1, step_size=1.0, eta=1.0, skip_probability=1.0)
     algorithm.initialize(network)
@@ -140,7 +140,7 @@ def test_fedpd_rejects_selection_scheme_argument() -> None:
 
 
 def test_fedpd_p_one_always_skips_aggregation() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedPD(iterations=1, step_size=1.0, eta=1.0, skip_probability=1.0)
     algorithm.initialize(network)
@@ -156,7 +156,7 @@ def test_fedpd_p_one_always_skips_aggregation() -> None:
 
 def test_fedpd_dual_update_uses_previous_center() -> None:
     algorithm = FedPD(iterations=1, step_size=1.0, eta=2.0, skip_probability=1.0)
-    client = Agent(0, TrackingCost(gradient_value=0.0))
+    client = Agent(TrackingCost(gradient_value=0.0))
     network = FedNetwork(clients=[client])
     algorithm.initialize(network)
     client.x = np.array([1.0])
@@ -171,7 +171,7 @@ def test_fedpd_dual_update_uses_previous_center() -> None:
 
 
 def test_fedpd_aggregate_uses_only_received_center_candidates() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedPD(iterations=1)
     algorithm.initialize(network)
@@ -185,7 +185,7 @@ def test_fedpd_aggregate_uses_only_received_center_candidates() -> None:
 
 
 def test_fedpd_synchronizes_all_active_clients_after_aggregating_received_candidates() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(
         clients=clients,
         message_drop={clients[0]: DropOnCalls({1}), clients[1]: NoDrops()},
@@ -202,7 +202,7 @@ def test_fedpd_synchronizes_all_active_clients_after_aggregating_received_candid
 
 
 def test_fedpd_does_not_synchronize_when_no_center_candidates_are_received() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(
         clients=clients,
         message_drop={clients[0]: DropOnCalls({1}), clients[1]: DropOnCalls({1})},
@@ -221,8 +221,8 @@ def test_fedpd_does_not_synchronize_when_no_center_candidates_are_received() -> 
 
 
 def test_fedpd_keeps_local_center_when_server_sync_message_is_dropped() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, ZeroCost((1,)))
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
+    server = Agent(ZeroCost((1,)))
     network = FedNetwork(
         clients=clients,
         server=server,
@@ -242,7 +242,7 @@ def test_fedpd_keeps_local_center_when_server_sync_message_is_dropped() -> None:
 def test_fedpd_probabilistic_communication_is_reproducible_when_seeded() -> None:
     def run_once() -> tuple[np.ndarray, list[np.ndarray]]:
         iop.set_seed(123, frameworks=[])
-        clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+        clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
         network = FedNetwork(clients=clients)
         algorithm = FedPD(iterations=5, step_size=1.0, eta=1.0, skip_probability=0.5)
         algorithm.initialize(network)
@@ -289,7 +289,7 @@ def test_fedpd_rejects_non_integer_scalar_num_local_steps(num_local_steps: objec
 
 
 def test_fedpd_normalizes_scalar_local_steps_to_client_mapping_on_initialize() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0))]
     network = FedNetwork(clients=clients)
     algorithm = FedPD(iterations=1, num_local_steps=2)
 
@@ -300,7 +300,7 @@ def test_fedpd_normalizes_scalar_local_steps_to_client_mapping_on_initialize() -
 
 @pytest.mark.parametrize("num_local_steps", [{}, {"not-an-agent": 1}, {1: 1}])
 def test_fedpd_rejects_local_step_mappings_missing_network_clients(num_local_steps: object) -> None:
-    network = FedNetwork(clients=[Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))])
+    network = FedNetwork(clients=[Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0))])
     algorithm = FedPD(iterations=1, num_local_steps=num_local_steps)
 
     with pytest.raises(ValueError, match="`num_local_steps` mapping must provide a value for every network client"):
@@ -309,13 +309,13 @@ def test_fedpd_rejects_local_step_mappings_missing_network_clients(num_local_ste
 
 @pytest.mark.parametrize("step_value", [0, -1])
 def test_fedpd_rejects_invalid_local_step_mapping_values(step_value: float) -> None:
-    client = Agent(0, TrackingCost())
+    client = Agent(TrackingCost())
     with pytest.raises(ValueError, match="`num_local_steps` must have positive values"):
         FedPD(iterations=1, num_local_steps={client: step_value})
 
 
 @pytest.mark.parametrize("step_value", [2.0])
 def test_fedpd_rejects_non_integer_local_step_mapping_values(step_value: object) -> None:
-    client = Agent(0, TrackingCost())
+    client = Agent(TrackingCost())
     with pytest.raises(TypeError, match="`num_local_steps` mapping values must be integers"):
         FedPD(iterations=1, num_local_steps={client: step_value})

--- a/test/test_metric_result.py
+++ b/test/test_metric_result.py
@@ -1,0 +1,106 @@
+import numpy as np
+import pytest
+
+from decent_bench.benchmark import MetricResult
+from decent_bench.metrics._metric import Metric
+
+
+class _AlgorithmStub:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _MetricStub(Metric):
+    def __init__(self, description: str) -> None:
+        super().__init__([np.average], fmt=".2e", y_log=False)
+        self._description = description
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    def get_data_from_trial(self, agents, problem, iteration):  # noqa: D102
+        return [0.0]
+
+
+def test_metric_result_to_dataframe_converts_table_and_plot_results() -> None:
+    pd = pytest.importorskip("pandas")
+
+    algorithm_a = _AlgorithmStub("A")
+    algorithm_b = _AlgorithmStub("B")
+    metric_one = _MetricStub("one")
+    metric_two = _MetricStub("two")
+
+    metrics_result = MetricResult(
+        agent_metrics=None,
+        table_metrics=[metric_one, metric_two],
+        plot_metrics=[metric_one, metric_two],
+        table_results={
+            algorithm_a: {
+                metric_one: {"avg": (1.0, 0.1), "mdn": (1.5, 0.2)},
+            },
+            algorithm_b: {
+                metric_two: {"avg": (2.0, 0.3)},
+            },
+        },
+        plot_results={
+            algorithm_a: {
+                metric_one: ([0.0, 1.0], [1.0, 2.0], [0.5, 1.5], [1.5, 2.5]),
+            },
+            algorithm_b: {
+                metric_two: ([2.0], [3.0], [2.5], [3.5]),
+            },
+        },
+    )
+
+    table_df, plot_df = metrics_result.to_dataframe()
+
+    expected_table = pd.DataFrame(
+        [
+            {"algorithm": "A", "metric": "one", "statistic": "avg", "mean": 1.0, "margin_of_error": 0.1},
+            {"algorithm": "A", "metric": "one", "statistic": "mdn", "mean": 1.5, "margin_of_error": 0.2},
+            {"algorithm": "B", "metric": "two", "statistic": "avg", "mean": 2.0, "margin_of_error": 0.3},
+        ],
+        columns=["algorithm", "metric", "statistic", "mean", "margin_of_error"],
+    )
+    expected_plot = pd.DataFrame(
+        [
+            {"algorithm": "A", "metric": "one", "x": 0.0, "y_mean": 1.0, "y_min": 0.5, "y_max": 1.5},
+            {"algorithm": "A", "metric": "one", "x": 1.0, "y_mean": 2.0, "y_min": 1.5, "y_max": 2.5},
+            {"algorithm": "B", "metric": "two", "x": 2.0, "y_mean": 3.0, "y_min": 2.5, "y_max": 3.5},
+        ],
+        columns=["algorithm", "metric", "x", "y_mean", "y_min", "y_max"],
+    )
+
+    pd.testing.assert_frame_equal(table_df, expected_table)
+    pd.testing.assert_frame_equal(plot_df, expected_plot)
+
+
+def test_metric_result_to_dataframe_handles_missing_table_or_plot_results() -> None:
+    pytest.importorskip("pandas")
+
+    algorithm = _AlgorithmStub("A")
+    metric = _MetricStub("one")
+
+    table_only_result = MetricResult(
+        agent_metrics=None,
+        table_metrics=[metric],
+        plot_metrics=None,
+        table_results={algorithm: {metric: {"avg": (1.0, 0.0)}}},
+        plot_results=None,
+    )
+    plot_only_result = MetricResult(
+        agent_metrics=None,
+        table_metrics=None,
+        plot_metrics=[metric],
+        table_results=None,
+        plot_results={algorithm: {metric: ([0.0], [1.0], [0.5], [1.5])}},
+    )
+
+    table_only_df, table_only_plot_df = table_only_result.to_dataframe()
+    plot_only_table_df, plot_only_df = plot_only_result.to_dataframe()
+
+    assert table_only_plot_df is None
+    assert plot_only_table_df is None
+    assert list(table_only_df.columns) == ["algorithm", "metric", "statistic", "mean", "margin_of_error"]
+    assert list(plot_only_df.columns) == ["algorithm", "metric", "x", "y_mean", "y_min", "y_max"]

--- a/test/test_networks.py
+++ b/test/test_networks.py
@@ -9,6 +9,7 @@ from decent_bench.agents import Agent
 from decent_bench.networks import P2PNetwork, FedNetwork
 from decent_bench.costs import L2RegularizerCost
 from decent_bench.utils import interoperability as iop
+from decent_bench.utils.array import Array
 from decent_bench.utils.types import SupportedDevices, SupportedFrameworks
 from decent_bench.schemes import (
     AgentActivationScheme,
@@ -31,15 +32,23 @@ class MultiplyCompression(CompressionScheme):
     def __init__(self, factor: float):
         self.factor = factor
 
-    def compress(self, msg):  # noqa: ANN001, D102
+    def compress(self, msg: Array) -> Array:  # noqa: D102
         return msg * self.factor
+
+    def compressed_msg_size(self, msg: Array) -> int:  # noqa: D102
+        return int(np.prod(iop.shape(msg)))
 
 
 class AddNoise(NoiseScheme):
     def __init__(self, offset: float):
         self.offset = offset
 
-    def make_noise(self, shape, framework, device):  # noqa: ANN001, D102
+    def make_noise(
+        self,
+        shape: tuple[int, ...],
+        framework: SupportedFrameworks,
+        device: SupportedDevices,
+    ) -> Array:  # noqa: D102
         return iop.to_array(np.full(shape, self.offset), framework=framework, device=device)
 
 
@@ -247,6 +256,8 @@ def test_initialize_message_schemes_dict_used_in_send() -> None:
     mock_schemes = {agents[0]: MagicMock(spec=CompressionScheme), agents[1]: MagicMock(spec=CompressionScheme)}
     mock_schemes[agents[0]].compress = MagicMock(side_effect=lambda x: x)
     mock_schemes[agents[1]].compress = MagicMock(side_effect=lambda x: x)
+    mock_schemes[agents[0]].compressed_msg_size = MagicMock(return_value=agents[0].cost.size)
+    mock_schemes[agents[1]].compressed_msg_size = MagicMock(return_value=agents[1].cost.size)
 
     net._message_compression = mock_schemes
 
@@ -259,6 +270,9 @@ def test_initialize_message_schemes_dict_used_in_send() -> None:
 
     # verify agent 0's compression scheme was called
     mock_schemes[agents[0]].compress.assert_called_once()
+    mock_schemes[agents[0]].compressed_msg_size.assert_called_once()
+    assert agents[0]._n_sent_messages == pytest.approx(1.0)  # noqa: SLF001
+    assert agents[1]._n_received_messages == pytest.approx(1.0)  # noqa: SLF001
 
 
 def test_p2p_network_rejects_disconnected_graph() -> None:
@@ -354,6 +368,11 @@ def test_send_applies_drop_compression_and_noise_schemes() -> None:
     np_expected = np.array([5.0, 7.0])
     assert np_received.shape == np_expected.shape
     assert np_received.tolist() == pytest.approx(np_expected.tolist())
+    assert sender._n_sent_messages == pytest.approx(1.0)  # noqa: SLF001
+    assert sender._n_sent_messages_dropped == pytest.approx(0.0)  # noqa: SLF001
+    assert receiver._n_received_messages == pytest.approx(1.0)  # noqa: SLF001
 
     net.send(sender=dropped_sender, receiver=receiver, msg=msg)
     assert dropped_sender not in receiver.messages
+    assert dropped_sender._n_sent_messages == pytest.approx(1.0)  # noqa: SLF001
+    assert dropped_sender._n_sent_messages_dropped == pytest.approx(1.0)  # noqa: SLF001

--- a/test/test_networks.py
+++ b/test/test_networks.py
@@ -224,7 +224,7 @@ def test_initialize_message_schemes_with_dict_extra_keys() -> None:
 def test_initialize_message_schemes_copies_single_scheme_per_agent() -> None:
     """Test that a single scheme instance is copied independently for every agent."""
     n_agents = 3
-    agents = [Agent(i, L2RegularizerCost((10,))) for i in range(n_agents)]
+    agents = [Agent(L2RegularizerCost((10,))) for i in range(n_agents)]
     net = P2PNetwork(graph=nx.complete_graph(n_agents), agents=agents)
     scheme = AddNoise(offset=1.0)
 

--- a/test/test_networks.py
+++ b/test/test_networks.py
@@ -1,6 +1,9 @@
-import pytest
+from copy import deepcopy
+from unittest.mock import MagicMock
+
 import networkx as nx
 import numpy as np
+import pytest
 
 from decent_bench.agents import Agent
 from decent_bench.networks import P2PNetwork, FedNetwork
@@ -18,8 +21,6 @@ from decent_bench.schemes import (
     NoNoise,
     UniformActivationRate,
 )
-from unittest.mock import MagicMock
-
 
 class NeverActive(AgentActivationScheme):
     def is_active(self, iteration: int) -> bool:  # noqa: D102, ARG002
@@ -53,7 +54,7 @@ class FixedDrop(DropScheme):
 def test_p2p_network(n_agents: int = 10) -> None:
     net = P2PNetwork(
         graph=nx.complete_graph(n_agents),
-        agents=[Agent(i, L2RegularizerCost((10,))) for i in range(n_agents)],
+        agents=[Agent(L2RegularizerCost((10,))) for _ in range(n_agents)],
     )
 
     assert len(net.agents()) == n_agents
@@ -80,7 +81,7 @@ def test_p2p_network(n_agents: int = 10) -> None:
 
 def test_fed_network(n_agents: int = 10) -> None:
     net = FedNetwork(
-        clients=[Agent(i, L2RegularizerCost((10,))) for i in range(n_agents)],
+        clients=[Agent(L2RegularizerCost((10,))) for _ in range(n_agents)],
     )
 
     assert len(net.agents()) == n_agents
@@ -100,8 +101,8 @@ def test_fed_network(n_agents: int = 10) -> None:
 
 
 def test_fed_network_accepts_custom_always_active_server() -> None:
-    clients = [Agent(i, L2RegularizerCost((10,))) for i in range(3)]
-    server = Agent(99, L2RegularizerCost((10,)), activation=AlwaysActive())
+    clients = [Agent(L2RegularizerCost((10,))) for _ in range(3)]
+    server = Agent(L2RegularizerCost((10,)), activation=AlwaysActive())
 
     net = FedNetwork(clients=clients, server=server)
 
@@ -109,15 +110,15 @@ def test_fed_network_accepts_custom_always_active_server() -> None:
 
 
 def test_fed_network_rejects_custom_non_always_active_server() -> None:
-    clients = [Agent(i, L2RegularizerCost((10,))) for i in range(3)]
-    server = Agent(99, L2RegularizerCost((10,)), activation=UniformActivationRate(0.5))
+    clients = [Agent(L2RegularizerCost((10,))) for _ in range(3)]
+    server = Agent(L2RegularizerCost((10,)), activation=UniformActivationRate(0.5))
 
     with pytest.raises(ValueError, match="FedNetwork server must use AlwaysActive activation"):
         FedNetwork(clients=clients, server=server)
 
 
 def test_fed_network_default_server_is_always_active() -> None:
-    clients = [Agent(i, L2RegularizerCost((10,))) for i in range(3)]
+    clients = [Agent(L2RegularizerCost((10,))) for _ in range(3)]
 
     net = FedNetwork(clients=clients)
 
@@ -126,8 +127,8 @@ def test_fed_network_default_server_is_always_active() -> None:
 
 def test_p2p_network_rejects_mixed_framework_costs() -> None:
     agents = [
-        Agent(0, L2RegularizerCost((2,), framework=SupportedFrameworks.NUMPY)),
-        Agent(1, L2RegularizerCost((2,), framework=SupportedFrameworks.PYTORCH)),
+        Agent(L2RegularizerCost((2,), framework=SupportedFrameworks.NUMPY)),
+        Agent(L2RegularizerCost((2,), framework=SupportedFrameworks.PYTORCH)),
     ]
 
     with pytest.raises(ValueError, match="same shape, framework, and device"):
@@ -136,8 +137,8 @@ def test_p2p_network_rejects_mixed_framework_costs() -> None:
 
 def test_p2p_network_rejects_mixed_device_costs() -> None:
     agents = [
-        Agent(0, L2RegularizerCost((2,), device=SupportedDevices.CPU)),
-        Agent(1, L2RegularizerCost((2,), device=SupportedDevices.GPU)),
+        Agent(L2RegularizerCost((2,), device=SupportedDevices.CPU)),
+        Agent(L2RegularizerCost((2,), device=SupportedDevices.GPU)),
     ]
 
     with pytest.raises(ValueError, match="same shape, framework, and device"):
@@ -146,8 +147,8 @@ def test_p2p_network_rejects_mixed_device_costs() -> None:
 
 def test_p2p_network_rejects_mismatched_cost_shapes() -> None:
     agents = [
-        Agent(0, L2RegularizerCost((2,))),
-        Agent(1, L2RegularizerCost((3,))),
+        Agent(L2RegularizerCost((2,))),
+        Agent(L2RegularizerCost((3,))),
     ]
 
     with pytest.raises(ValueError, match="same shape, framework, and device"):
@@ -156,8 +157,8 @@ def test_p2p_network_rejects_mismatched_cost_shapes() -> None:
 
 def test_fed_network_rejects_mixed_framework_clients() -> None:
     clients = [
-        Agent(0, L2RegularizerCost((2,), framework=SupportedFrameworks.NUMPY)),
-        Agent(1, L2RegularizerCost((2,), framework=SupportedFrameworks.PYTORCH)),
+        Agent(L2RegularizerCost((2,), framework=SupportedFrameworks.NUMPY)),
+        Agent(L2RegularizerCost((2,), framework=SupportedFrameworks.PYTORCH)),
     ]
 
     with pytest.raises(ValueError, match="same shape, framework, and device"):
@@ -165,8 +166,8 @@ def test_fed_network_rejects_mixed_framework_clients() -> None:
 
 
 def test_fed_network_rejects_custom_server_with_mixed_framework() -> None:
-    clients = [Agent(i, L2RegularizerCost((2,), framework=SupportedFrameworks.NUMPY)) for i in range(2)]
-    server = Agent(99, L2RegularizerCost((2,), framework=SupportedFrameworks.PYTORCH), activation=AlwaysActive())
+    clients = [Agent(L2RegularizerCost((2,), framework=SupportedFrameworks.NUMPY)) for _ in range(2)]
+    server = Agent(L2RegularizerCost((2,), framework=SupportedFrameworks.PYTORCH), activation=AlwaysActive())
 
     with pytest.raises(ValueError, match="same shape, framework, and device"):
         FedNetwork(clients=clients, server=server)
@@ -175,7 +176,7 @@ def test_fed_network_rejects_custom_server_with_mixed_framework() -> None:
 def test_initialize_message_schemes_with_dict_all_agents() -> None:
     """Test that per-agent scheme dicts work when all agents are provided."""
     n_agents = 3
-    agents = [Agent(i, L2RegularizerCost((10,))) for i in range(n_agents)]
+    agents = [Agent(L2RegularizerCost((10,))) for _ in range(n_agents)]
     net = P2PNetwork(graph=nx.complete_graph(n_agents), agents=agents)
 
     # create per-agent noise schemes
@@ -191,7 +192,7 @@ def test_initialize_message_schemes_with_dict_all_agents() -> None:
 def test_initialize_message_schemes_with_dict_missing_agent() -> None:
     """Test that missing agent in scheme dict raises ValueError."""
     n_agents = 3
-    agents = [Agent(i, L2RegularizerCost((10,))) for i in range(n_agents)]
+    agents = [Agent(L2RegularizerCost((10,))) for _ in range(n_agents)]
     net = P2PNetwork(graph=nx.complete_graph(n_agents), agents=agents)
 
     # provide schemes for only 2 agents
@@ -204,11 +205,11 @@ def test_initialize_message_schemes_with_dict_missing_agent() -> None:
 def test_initialize_message_schemes_with_dict_extra_keys() -> None:
     """Test that extra keys in scheme dict are ignored."""
     n_agents = 3
-    agents = [Agent(i, L2RegularizerCost((10,))) for i in range(n_agents)]
+    agents = [Agent(L2RegularizerCost((10,))) for _ in range(n_agents)]
     net = P2PNetwork(graph=nx.complete_graph(n_agents), agents=agents)
 
     # Provide schemes with extra agent not in network
-    extra_agent = Agent(999, L2RegularizerCost((10,)))
+    extra_agent = Agent(L2RegularizerCost((10,)))
     schemes_with_extra = {agent: NoNoise() for agent in agents}
     schemes_with_extra[extra_agent] = NoNoise()
 
@@ -224,7 +225,7 @@ def test_initialize_message_schemes_dict_used_in_send() -> None:
     """Test that per-agent schemes in dict are actually used during send operations."""
 
     n_agents = 2
-    agents = [Agent(i, L2RegularizerCost((10,))) for i in range(n_agents)]
+    agents = [Agent(L2RegularizerCost((10,))) for _ in range(n_agents)]
     net = P2PNetwork(graph=nx.complete_graph(n_agents), agents=agents)
 
     # create mock compression schemes
@@ -246,7 +247,7 @@ def test_initialize_message_schemes_dict_used_in_send() -> None:
 
 
 def test_p2p_network_rejects_disconnected_graph() -> None:
-    agents = [Agent(i, L2RegularizerCost((2,))) for i in range(3)]
+    agents = [Agent(L2RegularizerCost((2,))) for _ in range(3)]
     graph = nx.Graph()
     graph.add_edges_from([(0, 1)])
     graph.add_node(2)
@@ -256,7 +257,7 @@ def test_p2p_network_rejects_disconnected_graph() -> None:
 
 
 def test_p2p_network_rejects_directed_graph() -> None:
-    agents = [Agent(i, L2RegularizerCost((2,))) for i in range(2)]
+    agents = [Agent(L2RegularizerCost((2,))) for _ in range(2)]
     graph = nx.DiGraph()
     graph.add_edge(0, 1)
 
@@ -265,7 +266,7 @@ def test_p2p_network_rejects_directed_graph() -> None:
 
 
 def test_p2p_network_rejects_multigraph() -> None:
-    agents = [Agent(i, L2RegularizerCost((2,))) for i in range(2)]
+    agents = [Agent(L2RegularizerCost((2,))) for _ in range(2)]
     graph = nx.MultiGraph()
     graph.add_edge(0, 1)
 
@@ -274,19 +275,17 @@ def test_p2p_network_rejects_multigraph() -> None:
 
 
 def test_p2p_network_rejects_duplicate_agent_ids() -> None:
-    agent_a = Agent(0, L2RegularizerCost((2,)))
-    agent_b = Agent(0, L2RegularizerCost((2,)))
-    graph = nx.Graph()
-    graph.add_edge(agent_a, agent_b)
+    agent_a = Agent(L2RegularizerCost((2,)))
+    agent_b = deepcopy(agent_a)
 
     with pytest.raises(ValueError, match="Agent IDs must be unique"):
-        P2PNetwork(graph=graph)
+        P2PNetwork(graph=nx.complete_graph(2), agents=[agent_a, agent_b])
 
 
 def test_send_rejects_inactive_receiver() -> None:
-    sender = Agent(0, L2RegularizerCost((2,)))
-    inactive_receiver = Agent(1, L2RegularizerCost((2,)), activation=NeverActive())
-    net = P2PNetwork(graph=nx.Graph([(sender, inactive_receiver)]))
+    sender = Agent(L2RegularizerCost((2,)))
+    inactive_receiver = Agent(L2RegularizerCost((2,)), activation=NeverActive())
+    net = P2PNetwork(graph=nx.Graph([(0, 1)]), agents=[sender, inactive_receiver])
     msg = iop.zeros(shape=(2,), framework=sender.cost.framework, device=sender.cost.device)
 
     with pytest.raises(ValueError, match="not active or not connected"):
@@ -303,10 +302,11 @@ def test_send_rejects_inactive_receiver() -> None:
 def test_step_clears_or_preserves_messages_based_on_buffer_setting(
     buffer_messages: bool, expect_message_after_step: bool
 ) -> None:
-    sender = Agent(0, L2RegularizerCost((2,)))
-    receiver = Agent(1, L2RegularizerCost((2,)))
+    sender = Agent(L2RegularizerCost((2,)))
+    receiver = Agent(L2RegularizerCost((2,)))
     net = P2PNetwork(
-        graph=nx.Graph([(sender, receiver)]),
+        graph=nx.Graph([(0, 1)]),
+        agents=[sender, receiver],
         buffer_messages=buffer_messages,
     )
     msg = iop.to_array([1.0, -1.0], framework=sender.cost.framework, device=sender.cost.device)
@@ -320,11 +320,12 @@ def test_step_clears_or_preserves_messages_based_on_buffer_setting(
 
 
 def test_send_applies_drop_compression_and_noise_schemes() -> None:
-    sender = Agent(0, L2RegularizerCost((2,)))
-    dropped_sender = Agent(1, L2RegularizerCost((2,)))
-    receiver = Agent(2, L2RegularizerCost((2,)))
+    sender = Agent(L2RegularizerCost((2,)))
+    dropped_sender = Agent(L2RegularizerCost((2,)))
+    receiver = Agent(L2RegularizerCost((2,)))
     net = P2PNetwork(
-        graph=nx.complete_graph([sender, dropped_sender, receiver]),
+        graph=nx.complete_graph(3),
+        agents=[sender, dropped_sender, receiver],
         message_compression={
             sender: MultiplyCompression(2.0),
             dropped_sender: NoCompression(),

--- a/test/test_networks.py
+++ b/test/test_networks.py
@@ -39,8 +39,8 @@ class AddNoise(NoiseScheme):
     def __init__(self, offset: float):
         self.offset = offset
 
-    def make_noise(self, msg):  # noqa: ANN001, D102
-        return msg + self.offset
+    def make_noise(self, shape, framework, device):  # noqa: ANN001, D102
+        return iop.to_array(np.full(shape, self.offset), framework=framework, device=device)
 
 
 class FixedDrop(DropScheme):

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -65,12 +65,12 @@ class DropOnCalls(DropScheme):
 
 
 class ScheduledSelection(ClientSelectionScheme):
-    def __init__(self, selected_ids_by_round: dict[int, list[int]]):
-        self._selected_ids_by_round = selected_ids_by_round
+    def __init__(self, selected_indices_by_round: dict[int, list[int]]):
+        self._selected_indices_by_round = selected_indices_by_round
 
     def select(self, clients: Sequence[Agent], iteration: int) -> list[Agent]:
-        selected_ids = set(self._selected_ids_by_round.get(iteration, []))
-        return [client for client in clients if client.id in selected_ids]
+        selected_indices = set(self._selected_indices_by_round.get(iteration, []))
+        return [client for client in clients if client.index in selected_indices]
 
 
 def _run_scaffold_local_update(
@@ -82,8 +82,8 @@ def _run_scaffold_local_update(
     server_control: float = 0.0,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     algorithm = Scaffold(iterations=1, step_size=step_size, num_local_epochs=num_local_epochs)
-    client = Agent(0, cost)
-    server = Agent(1, ZeroCost(cost.shape))
+    client = Agent(cost)
+    server = Agent(ZeroCost(cost.shape))
     client.initialize(
         x=np.zeros(cost.shape, dtype=float),
         aux_vars={"c_i": np.array([client_control], dtype=float)},
@@ -118,7 +118,7 @@ def test_scaffold_persists_control_variates_across_rounds() -> None:
         num_local_epochs=1,
         server_step_size=1.0,
     )
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm.initialize(network)
 
@@ -141,7 +141,7 @@ def test_scaffold_persists_control_variates_across_rounds() -> None:
 
 def test_scaffold_uses_uniform_aggregation() -> None:
     algorithm = Scaffold(iterations=1, step_size=1.0, num_local_epochs=1)
-    network = FedNetwork(clients=[Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))])
+    network = FedNetwork(clients=[Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))])
 
     algorithm.initialize(network)
     network._step(0)  # noqa: SLF001
@@ -164,8 +164,8 @@ def test_server_step_size_scales_only_the_server_model_update() -> None:
         num_local_epochs=1,
         server_step_size=0.25,
     )
-    full_step_network = FedNetwork(clients=[Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))])
-    damped_step_network = FedNetwork(clients=[Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))])
+    full_step_network = FedNetwork(clients=[Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))])
+    damped_step_network = FedNetwork(clients=[Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))])
 
     full_step_algorithm.initialize(full_step_network)
     damped_step_algorithm.initialize(damped_step_network)
@@ -183,7 +183,7 @@ def test_server_step_size_scales_only_the_server_model_update() -> None:
 
 def test_scaffold_aggregation_uses_only_received_updates_for_model_and_control_deltas() -> None:
     algorithm = Scaffold(iterations=1, step_size=1.0, num_local_epochs=1)
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0))]
     network = FedNetwork(clients=clients)
     algorithm.initialize(network)
     network.server().x = np.array([10.0])
@@ -206,9 +206,9 @@ def test_scaffold_partial_participation_persists_control_variates_across_rounds(
         step_size=1.0,
         num_local_epochs=1,
         server_step_size=1.0,
-        selection_scheme=ScheduledSelection({0: [0, 1], 1: [1], 2: [2]}),
+        selection_scheme=ScheduledSelection({0: [1, 2], 1: [2], 2: [3]}),
     )
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(2.0)), Agent(2, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(2.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm.initialize(network)
 
@@ -250,8 +250,8 @@ def test_scaffold_partial_participation_persists_control_variates_across_rounds(
 
 def test_scaffold_skips_participation_when_broadcast_is_dropped() -> None:
     algorithm = Scaffold(iterations=2, step_size=1.0, num_local_epochs=1)
-    client = Agent(0, TrackingCost(gradient_value=0.0))
-    server = Agent(1, ZeroCost((1,)))
+    client = Agent(TrackingCost(gradient_value=0.0))
+    server = Agent(ZeroCost((1,)))
     network = FedNetwork(
         clients=[client],
         server=server,
@@ -277,8 +277,8 @@ def test_scaffold_skips_participation_when_broadcast_is_dropped() -> None:
 
 def test_scaffold_ignores_buffered_stale_client_messages() -> None:
     algorithm = Scaffold(iterations=2, step_size=1.0, num_local_epochs=1)
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
-    server = Agent(2, ZeroCost((1,)))
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
+    server = Agent(ZeroCost((1,)))
     network = FedNetwork(
         clients=clients,
         server=server,

--- a/test/test_scaffold.py
+++ b/test/test_scaffold.py
@@ -97,7 +97,7 @@ def _run_scaffold_local_update(
 
 
 def test_scaffold_initializes_control_variates_from_c0() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm = Scaffold(
         iterations=1,
@@ -116,7 +116,7 @@ def test_scaffold_initializes_control_variates_from_c0() -> None:
 
 
 def test_scaffold_infers_server_control_from_client_c0() -> None:
-    clients = [Agent(0, TrackingCost(1.0)), Agent(1, TrackingCost(3.0))]
+    clients = [Agent(TrackingCost(1.0)), Agent(TrackingCost(3.0))]
     network = FedNetwork(clients=clients)
     algorithm = Scaffold(
         iterations=1,

--- a/test/test_schemes.py
+++ b/test/test_schemes.py
@@ -302,7 +302,9 @@ def test_no_noise(
     scheme: NoiseScheme,
 ) -> None:
     message = Array(np.ones(5))
-    noise_error = float(iop.norm(message - scheme.make_noise(message)))
+    framework, device = iop.framework_device_of_array(message)
+    noise = scheme.make_noise(iop.shape(message), framework, device)
+    noise_error = 0 if noise is None else float(iop.norm(noise))
 
     assert noise_error == pytest.approx(0)
 
@@ -318,7 +320,9 @@ def test_noise(
     scheme: NoiseScheme,
 ) -> None:
     message = Array(np.ones(5))
-    noise_error = float(iop.norm(message - scheme.make_noise(message)))
+    framework, device = iop.framework_device_of_array(message)
+    noise = scheme.make_noise(iop.shape(message), framework, device)
+    noise_error = 0 if noise is None else float(iop.norm(noise))
 
     assert noise_error > 0
 

--- a/test/test_schemes.py
+++ b/test/test_schemes.py
@@ -169,18 +169,19 @@ def test_client_selection(
 def test_data_size_client_selection_prefers_larger_clients() -> None:
     iop.set_seed(0)
     clients = [
-        _make_linear_regression_client(0, 1),
-        _make_linear_regression_client(1, 1000),
+        _make_linear_regression_client(1),
+        _make_linear_regression_client(1000),
     ]
     scheme = DataSizeSelection(num_selected_clients=1)
 
     selected_client_ids = [scheme.select(clients, iteration=i)[0].id for i in range(200)]
+    larger_client_id = clients[1].id
 
-    assert selected_client_ids.count(1) > 190
+    assert selected_client_ids.count(larger_client_id) > 190
 
 
 def test_data_size_client_selection_requires_empirical_risk_cost() -> None:
-    clients = [Agent(0, L2RegularizerCost((2,))), Agent(1, L2RegularizerCost((2,)))]
+    clients = [Agent(L2RegularizerCost((2,))), Agent(L2RegularizerCost((2,)))]
     scheme = DataSizeSelection(num_selected_clients=1)
 
     with pytest.raises(ValueError, match="EmpiricalRiskCost"):
@@ -205,9 +206,9 @@ def test_fair_selection_updates_counts_when_all_selected() -> None:
 
 def test_high_loss_client_selection_selects_largest_loss() -> None:
     clients = [
-        Agent(0, 1.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
-        Agent(1, 10.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
-        Agent(2, 2.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
+        Agent(1.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
+        Agent(10.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
+        Agent(2.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
     ]
     for client in clients:
         client.x = Array(np.ones(2))
@@ -220,11 +221,11 @@ def test_high_loss_client_selection_selects_largest_loss() -> None:
 
 def test_high_loss_client_selection_selects_fraction() -> None:
     clients = [
-        Agent(0, 1.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
-        Agent(1, 10.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
-        Agent(2, 2.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
-        Agent(3, 5.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
-        Agent(4, 3.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
+        Agent(1.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
+        Agent(10.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
+        Agent(2.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
+        Agent(5.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
+        Agent(3.0 * L2RegularizerCost((2,)), data={"n_samples": 1}),
     ]
     for client in clients:
         client.x = Array(np.ones(2))
@@ -252,8 +253,8 @@ def test_high_loss_client_selection_does_not_consume_empirical_risk_batch() -> N
     iop.set_seed(0)
     selected_cost = LinearRegressionCost(dataset, batch_size=2)
     clients = [
-        Agent(0, selected_cost),
-        Agent(1, LinearRegressionCost(dataset, batch_size=2)),
+        Agent(selected_cost),
+        Agent(LinearRegressionCost(dataset, batch_size=2)),
     ]
     for client in clients:
         client.x = x

--- a/test/test_schemes.py
+++ b/test/test_schemes.py
@@ -88,7 +88,7 @@ def test_randomly_active(
 
 # test client selection
 def make_clients(n_clients: int) -> list[Agent]:
-    return [Agent(agent_id, L2RegularizerCost((2,))) for agent_id in range(n_clients)]
+    return [Agent(L2RegularizerCost((2,))) for _ in range(n_clients)]
 
 
 @pytest.mark.parametrize(

--- a/test/test_schemes.py
+++ b/test/test_schemes.py
@@ -116,7 +116,7 @@ def test_client_selection(
     ("scheme", "message"),
     [
         (NoCompression(), Array(np.array([3.0, -4.0, 1.0]))),
-        (Quantization(n_significant_digits=5), Array(np.array([1.2345, -2.3456]))),
+        (Quantization(quantization_step=1e-6), Array(np.array([1.2345, -2.3456]))),
         (TopK(k=1.0), Array(np.array([3.0, -4.0, 1.0]))),
         (RandK(k=1.0), Array(np.array([3.0, -4.0, 1.0]))),
         (TopK(k=3), Array(np.array([3.0, -4.0, 1.0]))),
@@ -138,9 +138,9 @@ def test_no_compression(
     ("scheme", "message", "expected_norm"),
     [
         (
-            Quantization(n_significant_digits=3),
+            Quantization(quantization_step=1e-2),
             Array(np.array([1.2345, -2.3456])),
-            float(np.linalg.norm(np.array([0.0045, -0.0044]))),
+            float(np.linalg.norm(np.array([0.0045, 0.0044]))),
         ),
         (TopK(k=2 / 3), Array(np.array([3.0, -4.0, 1.0])), 1.0),
         (TopK(k=2), Array(np.array([3.0, -4.0, 1.0])), 1.0),
@@ -155,6 +155,12 @@ def test_compression(
     compression_error = float(iop.norm(original_message - scheme.compress(message)))
 
     assert compression_error == pytest.approx(expected_norm)
+
+
+@pytest.mark.parametrize("quantization_step", [0, -1.0])
+def test_quantization_invalid_step(quantization_step: float) -> None:
+    with pytest.raises(ValueError, match="quantization_step"):
+        Quantization(quantization_step)
 
 
 # test RandK

--- a/test/utils/test_algorithm_helpers.py
+++ b/test/utils/test_algorithm_helpers.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import networkx as nx
 import numpy as np
 import pytest
@@ -18,7 +20,7 @@ from decent_bench.utils.pytorch_utils import SimpleLinearModel
 
 
 def _make_p2p_network(n_agents: int = 3, shape: tuple[int, ...] = (2,)) -> P2PNetwork:
-    agents = [Agent(i, L2RegularizerCost(shape)) for i in range(n_agents)]
+    agents = [Agent(L2RegularizerCost(shape)) for _ in range(n_agents)]
     return P2PNetwork(graph=nx.complete_graph(n_agents), agents=agents)
 
 
@@ -46,14 +48,14 @@ def test_initial_states_dict_matches_by_agent_id() -> None:
     net = _make_p2p_network(n_agents=3, shape=(2,))
     x0_dict: dict[Agent, np.ndarray] = {}
 
-    for agent in net.graph:
-        same_id_other_instance = Agent(agent.id, L2RegularizerCost(agent.cost.shape))
-        x0_dict[same_id_other_instance] = np.full(agent.cost.shape, fill_value=float(agent.id + 1))
+    for idx, agent in enumerate(net.graph):
+        same_id_other_instance = deepcopy(agent)
+        x0_dict[same_id_other_instance] = np.full(agent.cost.shape, fill_value=float(idx + 1))
 
     x0s = initial_states(x0_dict, net)
 
-    for agent in net.graph:
-        np.testing.assert_array_equal(iop.to_numpy(x0s[agent]), np.full(agent.cost.shape, float(agent.id + 1)))
+    for idx, agent in enumerate(net.graph):
+        np.testing.assert_array_equal(iop.to_numpy(x0s[agent]), np.full(agent.cost.shape, float(idx + 1)))
 
 
 def test_initial_states_non_fed_missing_agent_raises() -> None:
@@ -83,7 +85,7 @@ def test_initial_states_invalid_type_raises() -> None:
 
 
 def test_initial_states_fed_infers_server_as_client_mean() -> None:
-    clients = [Agent(0, L2RegularizerCost((2,))), Agent(1, L2RegularizerCost((2,)))]
+    clients = [Agent(L2RegularizerCost((2,))), Agent(L2RegularizerCost((2,)))]
     net = FedNetwork(clients=clients)
 
     x0_dict = {
@@ -100,7 +102,7 @@ def test_initial_states_fed_infers_server_as_client_mean() -> None:
 
 
 def test_initial_states_fed_missing_client_raises() -> None:
-    clients = [Agent(0, L2RegularizerCost((2,))), Agent(1, L2RegularizerCost((2,)))]
+    clients = [Agent(L2RegularizerCost((2,))), Agent(L2RegularizerCost((2,)))]
     net = FedNetwork(clients=clients)
 
     with pytest.raises(ValueError, match="x0 not provided for agent"):
@@ -136,7 +138,7 @@ def test_uniform_initialization_samples_within_range() -> None:
 
 
 def test_infer_client_weight_prefers_n_samples_over_A_and_b() -> None:
-    client = Agent(0, L2RegularizerCost((2,)))
+    client = Agent(L2RegularizerCost((2,)))
     client.cost.A = np.zeros((7, 2))  # type: ignore[attr-defined]
     client.cost.b = np.zeros((5,))  # type: ignore[attr-defined]
     client.cost.n_samples = 11  # type: ignore[attr-defined]
@@ -147,7 +149,7 @@ def test_infer_client_weight_prefers_n_samples_over_A_and_b() -> None:
 
 
 def test_infer_client_weight_falls_back_to_A_when_n_samples_is_missing() -> None:
-    client = Agent(0, L2RegularizerCost((2,)))
+    client = Agent(L2RegularizerCost((2,)))
     client.cost.A = np.zeros((7, 2))  # type: ignore[attr-defined]
 
     weight = infer_client_weight(client)
@@ -159,7 +161,7 @@ def test_infer_client_weight_falls_back_to_b() -> None:
     class UnsupportedArray:
         pass
 
-    client = Agent(0, L2RegularizerCost((2,)))
+    client = Agent(L2RegularizerCost((2,)))
     client.cost.A = UnsupportedArray()  # type: ignore[attr-defined]
     client.cost.b = np.zeros((5,))  # type: ignore[attr-defined]
 
@@ -172,7 +174,7 @@ def test_infer_client_weight_falls_back_to_n_samples() -> None:
     class UnsupportedArray:
         pass
 
-    client = Agent(0, L2RegularizerCost((2,)))
+    client = Agent(L2RegularizerCost((2,)))
     client.cost.A = UnsupportedArray()  # type: ignore[attr-defined]
     client.cost.b = UnsupportedArray()  # type: ignore[attr-defined]
     client.cost.n_samples = 11  # type: ignore[attr-defined]
@@ -192,7 +194,7 @@ def test_infer_client_weight_falls_back_to_n_samples() -> None:
     ],
 )
 def test_infer_client_weight_raises_when_inferred_size_is_not_positive(attribute: str, value: object) -> None:
-    client = Agent(0, L2RegularizerCost((2,)))
+    client = Agent(L2RegularizerCost((2,)))
     setattr(client.cost, attribute, value)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="Client data size must be positive"):
@@ -200,7 +202,7 @@ def test_infer_client_weight_raises_when_inferred_size_is_not_positive(attribute
 
 
 def test_infer_client_weight_raises_when_no_size_signal() -> None:
-    client = Agent(0, L2RegularizerCost((2,)))
+    client = Agent(L2RegularizerCost((2,)))
 
     with pytest.raises(ValueError, match="Cannot infer client data size"):
         infer_client_weight(client)
@@ -222,7 +224,7 @@ def test_pytorch_initialization_extracts_flattened_model_parameters() -> None:
     ]
     model = SimpleLinearModel(input_size=2, hidden_sizes=[3], output_size=1)
     cost = PyTorchCost(dataset=dataset, model=model, loss_fn=torch.nn.MSELoss())
-    agent = Agent(0, cost)
+    agent = Agent(cost)
     net = P2PNetwork(graph=nx.complete_graph(1), agents=[agent])
 
     x0s = pytorch_initialization(net)

--- a/test/utils/test_checkpoints.py
+++ b/test/utils/test_checkpoints.py
@@ -74,7 +74,7 @@ def _build_problem_and_algorithms(
     network = P2PNetwork(
         graph=nx.complete_graph(len(agents)),
         agents=agents,
-        message_compression=Quantization(8),
+        message_compression=Quantization(quantization_step=1e-2),
         message_noise=GaussianNoise(0.0, 0.01),
         message_drop=UniformDropRate(0.1),
     )

--- a/test/utils/test_checkpoints.py
+++ b/test/utils/test_checkpoints.py
@@ -56,8 +56,8 @@ def _skip_if_max_processes_exceeds_cpu_count(max_processes: int) -> None:
 class DummyAlg(DGD):
     def finalize(self, network: P2PNetwork) -> None:
         for agent in network.agents():
-            if agent.id == 0:
-                print(f"Agent {agent.id} finalizing with x: {agent.x}")  # noqa: T201
+            if agent.index == 0:
+                print(f"Agent {agent.index} finalizing with x: {agent.x}")  # noqa: T201
             agent.x = agent.x + 100
 
 
@@ -70,7 +70,7 @@ def _build_problem_and_algorithms(
         cost_cls=cost_cls,
         n_agents=4,
     )
-    agents = [Agent(i, cost, activation=UniformActivationRate(0.8)) for i, cost in enumerate(costs)]
+    agents = [Agent(cost, activation=UniformActivationRate(0.8)) for cost in costs]
     network = P2PNetwork(
         graph=nx.complete_graph(len(agents)),
         agents=agents,

--- a/test/utils/test_checkpoints.py
+++ b/test/utils/test_checkpoints.py
@@ -7,7 +7,7 @@ import sys
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import networkx as nx
 import numpy as np
@@ -96,6 +96,21 @@ def test_init_validates_arguments(tmp_path: Path) -> None:  # noqa: D103
 
     with pytest.raises(ValueError, match="keep_n_checkpoints must be a positive integer"):
         CheckpointManager(tmp_path / "ckpt", keep_n_checkpoints=0)
+
+
+def test_checkpoint_restores_top_level_agent_keyed_algorithm_dict(tmp_path: Path) -> None:  # noqa: D103
+    problem, algorithms = _build_problem_and_algorithms(iterations=5, cost_cls=LogisticRegressionCost)
+    algorithm = algorithms[0]
+    algorithm.custom_agent_map = {agent: float(idx) for idx, agent in enumerate(problem.network.agents())}  # type: ignore[attr-defined]
+    manager = CheckpointManager(tmp_path / "ckpt", keep_n_checkpoints=3)
+    manager.initialize(algorithms=[algorithm], problem=problem, n_trials=1)
+
+    loaded_algs = manager.load_initial_algorithms(network=problem.network)
+    loaded_alg = loaded_algs[0]
+
+    loaded_map = cast("dict[Agent, float]", loaded_alg.custom_agent_map)  # type: ignore[attr-defined]
+    assert all(isinstance(key, Agent) for key in loaded_map)
+    assert set(loaded_map) == set(problem.network.agents())
 
 
 def test_initialize_saves_structure_and_metadata(tmp_path: Path) -> None:  # noqa: D103


### PR DESCRIPTION
the PR addresses a few issues and adds a few small enhancements.

1. agent id:
    - agents now have a unique id assigned at init using uuid; this is used as the hash of the agent and is immutable
    - the constructor no longer requires an id
    - the agents also have an index (which implements `__index__`) that is-1 at init and assigned by a network; the network init raises if an agent has index != -1 (it's already assigned). the index is mutable
    - id was also added to AgentMetricsView (in preparation for addressing #313 )
2. networks:
    - P2PNetwork can now only be constructed from a list of agents and nx.Graph (nx.Graph[Agent] not allowed anymore)
    - _send_one was removed, centralizing all functionality in send to make noise generation more efficient
    - message counters are now updated according to their shape; in particular, counters are updated as the fraction of mssage size to cost shape. added `compressed_msg_size` to compression schemes to account for the reduction in size that would occur in real life
    - plot_networks now takes directly Network object instead of nx.Graph
3. schemes: changed Quantization to uniform quantization, which allows using much more efficient numpy function `rint`
4. metrics computation/display pipeline:
    - table_description and plot_description unified in `description` property
    - removed the option to pass a list of lists for plot_metrics, simplifying internal logic significantly; option for individual_plots is still available, and still max 3 subplots per figure
    - simplified some minor logic here and there
    - added `to_dataframe` to `MetricResult`
5. statistics:
    - statistics is now an optional arg, defaulting to None; in that case, it applies `default_statistic`, which is average if the get_trial_data returns a list, or the single value otherwise
    - table header specifies "statistic across agents"
    - removed utils.single, since the default None takes care of that through the new `default_statistic`; passing an empty list also defaults to `default_statistic`
    - table lables only have "(statistic)" if specified by the user
6. metrics:
    - XError now computes w.r.t. to the mean; this is more efficent (since x_mean is cached) and provides basically the same info
    - Regret and GradientNorm use batch=all when applied to empirical costs that admit a x_optimal (logistic and linear regression)
    - GradientNorm: removed squaring the norm
    - Regret: divided by the num. of agents
7. create problems:
    - added option to avoid computing x_optimal
    - custom branch for Sum(LinearRegressionCost) and custom x_optimal computation in create_classification_problem
8. storing initial algorithms: now all Agent-keyed dicts are stored replacing the Agent instance with its hash, and restoring to Agent at unpickle
9. logistic and linear regression:
    - removed custom add (which had the potential to give incorrect results e.g. when computing x_optimal for costs with different n_samples
    - make _get_batch_data more efficient
 
closes #312 closes #299 closes #296 closes #293 closes #288 closes #285 closes #268