### PR TITLE
enh(metrics): Add optional/extra federated-specific bencmark metrics

### DIFF
--- a/decent_bench/agents.py
+++ b/decent_bench/agents.py
@@ -53,6 +53,8 @@ class Agent:
         self._n_sent_messages = 0
         self._n_received_messages = 0
         self._n_sent_messages_dropped = 0
+        self._n_times_selected = 0
+        self._n_times_update_received_by_server = 0
         self._n_function_calls: float = 0
         self._n_gradient_calls: float = 0
         self._n_hessian_calls: float = 0
@@ -138,6 +140,8 @@ class Agent:
         self._n_sent_messages = 0
         self._n_received_messages = 0
         self._n_sent_messages_dropped = 0
+        self._n_times_selected = 0
+        self._n_times_update_received_by_server = 0
         self._n_function_calls = 0
         self._n_gradient_calls = 0
         self._n_hessian_calls = 0
@@ -397,6 +401,8 @@ class AgentMetricsView:
     n_sent_messages: int
     n_received_messages: int
     n_sent_messages_dropped: int
+    n_times_selected: int
+    n_times_update_received_by_server: int
 
     @staticmethod
     def from_agent(agent: Agent) -> AgentMetricsView:
@@ -412,4 +418,6 @@ class AgentMetricsView:
             n_sent_messages=agent._n_sent_messages,  # noqa: SLF001
             n_received_messages=agent._n_received_messages,  # noqa: SLF001
             n_sent_messages_dropped=agent._n_sent_messages_dropped,  # noqa: SLF001
+            n_times_selected=agent._n_times_selected,  # noqa: SLF001
+            n_times_update_received_by_server=agent._n_times_update_received_by_server,  # noqa: SLF001
         )

--- a/decent_bench/agents.py
+++ b/decent_bench/agents.py
@@ -54,6 +54,7 @@ class Agent:
         self._n_received_messages = 0
         self._n_sent_messages_dropped = 0
         self._n_times_selected = 0
+        self._is_server = False
         self._n_function_calls: float = 0
         self._n_gradient_calls: float = 0
         self._n_hessian_calls: float = 0
@@ -400,6 +401,7 @@ class AgentMetricsView:
     n_received_messages: int
     n_sent_messages_dropped: int
     n_times_selected: int
+    is_server: bool
 
     @staticmethod
     def from_agent(agent: Agent) -> AgentMetricsView:
@@ -416,4 +418,5 @@ class AgentMetricsView:
             n_received_messages=agent._n_received_messages,  # noqa: SLF001
             n_sent_messages_dropped=agent._n_sent_messages_dropped,  # noqa: SLF001
             n_times_selected=getattr(agent, "_n_times_selected", 0),
+            is_server=getattr(agent, "_is_server", False),
         )

--- a/decent_bench/agents.py
+++ b/decent_bench/agents.py
@@ -54,7 +54,6 @@ class Agent:
         self._n_received_messages = 0
         self._n_sent_messages_dropped = 0
         self._n_times_selected = 0
-        self._n_times_update_received_by_server = 0
         self._n_function_calls: float = 0
         self._n_gradient_calls: float = 0
         self._n_hessian_calls: float = 0
@@ -141,7 +140,6 @@ class Agent:
         self._n_received_messages = 0
         self._n_sent_messages_dropped = 0
         self._n_times_selected = 0
-        self._n_times_update_received_by_server = 0
         self._n_function_calls = 0
         self._n_gradient_calls = 0
         self._n_hessian_calls = 0
@@ -402,7 +400,6 @@ class AgentMetricsView:
     n_received_messages: int
     n_sent_messages_dropped: int
     n_times_selected: int
-    n_times_update_received_by_server: int
 
     @staticmethod
     def from_agent(agent: Agent) -> AgentMetricsView:
@@ -419,5 +416,4 @@ class AgentMetricsView:
             n_received_messages=agent._n_received_messages,  # noqa: SLF001
             n_sent_messages_dropped=agent._n_sent_messages_dropped,  # noqa: SLF001
             n_times_selected=agent._n_times_selected,  # noqa: SLF001
-            n_times_update_received_by_server=agent._n_times_update_received_by_server,  # noqa: SLF001
         )

--- a/decent_bench/agents.py
+++ b/decent_bench/agents.py
@@ -415,5 +415,5 @@ class AgentMetricsView:
             n_sent_messages=agent._n_sent_messages,  # noqa: SLF001
             n_received_messages=agent._n_received_messages,  # noqa: SLF001
             n_sent_messages_dropped=agent._n_sent_messages_dropped,  # noqa: SLF001
-            n_times_selected=agent._n_times_selected,  # noqa: SLF001
+            n_times_selected=getattr(agent, "_n_times_selected", 0),
         )

--- a/decent_bench/agents.py
+++ b/decent_bench/agents.py
@@ -417,6 +417,6 @@ class AgentMetricsView:
             n_sent_messages=agent._n_sent_messages,  # noqa: SLF001
             n_received_messages=agent._n_received_messages,  # noqa: SLF001
             n_sent_messages_dropped=agent._n_sent_messages_dropped,  # noqa: SLF001
-            n_times_selected=getattr(agent, "_n_times_selected", 0),
-            is_server=getattr(agent, "_is_server", False),
+            n_times_selected=agent._n_times_selected,  # noqa: SLF001
+            is_server=agent._is_server,  # noqa: SLF001
         )

--- a/decent_bench/algorithms/_algorithm.py
+++ b/decent_bench/algorithms/_algorithm.py
@@ -93,7 +93,7 @@ class Algorithm[NetworkT: Network](ABC):
 
     @final
     def _snapshot_agents(self, network: NetworkT, iteration: int) -> None:
-        for i in network.agents():
+        for i in network.snapshot_agents():
             # Forcefully save a snapshot on the final iteration
             i._snapshot(iteration=iteration, force=iteration == self.iterations)  # noqa: SLF001
 

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -82,7 +82,7 @@ class FedAlgorithm(Algorithm[FedNetwork]):
     def _record_selected_clients(selected_clients: Sequence["Agent"]) -> None:
         """Record clients selected by a federated round."""
         for client in selected_clients:
-            client._n_times_selected += 1  # noqa: SLF001
+            client._n_times_selected = getattr(client, "_n_times_selected", 0) + 1  # noqa: SLF001
 
     def server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
         """Send the current server model to the selected clients."""

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -64,7 +64,7 @@ class FedAlgorithm(Algorithm[FedNetwork]):
 
     def _selected_clients_for_round(self, network: FedNetwork, iteration: int) -> list["Agent"]:
         """
-        Select participating clients for the current round from the currently active clients.
+        Select participating clients for the current round from the currently active clients and record them.
 
         If ``self.selection_scheme`` is ``None``, all active clients are selected.
         """

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -62,14 +62,16 @@ class FedAlgorithm(Algorithm[FedNetwork]):
             )
         return {client: self.num_local_steps[client] for client in clients}
 
-    def _selected_clients_for_round(self, network: FedNetwork, iteration: int) -> list["Agent"]:
+    def selected_clients_for_round(self, network: FedNetwork, iteration: int) -> list["Agent"]:
         """
-        Select participating clients for the current round from the currently active clients and record them.
+        Select participating clients for the current round and record participation.
+
+        Use this method once per federated round when selecting participating clients in the round. It applies
+        ``self.selection_scheme`` to the currently active clients and updates the selection counters used by
+        participation metrics. Calling it more than once in the same round will increment the selected-client counters
+        more than once.
 
         If ``self.selection_scheme`` is ``None``, all active clients are selected.
-
-        Federated algorithms should use this helper for round-level client selection so participation counters remain
-        consistent with the executed training path.
         """
         active_clients = network.active_clients()
         if not active_clients:

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -124,14 +124,7 @@ class FedAlgorithm(Algorithm[FedNetwork]):
         received_clients = [client for client in participating_clients if client in network.server().messages]
         if not received_clients:
             return
-        self._record_updates_received_by_server(received_clients)
         updates = [network.server().messages[client] for client in received_clients]
         weights = [1.0] * len(received_clients)
         total_weight = float(len(received_clients))
         network.server().x = self._weighted_average(updates, weights, total_weight)
-
-    @staticmethod
-    def _record_updates_received_by_server(received_clients: Sequence["Agent"]) -> None:
-        """Record clients whose update contributed to a server aggregation."""
-        for client in received_clients:
-            client._n_times_update_received_by_server += 1  # noqa: SLF001

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -67,6 +67,9 @@ class FedAlgorithm(Algorithm[FedNetwork]):
         Select participating clients for the current round from the currently active clients and record them.
 
         If ``self.selection_scheme`` is ``None``, all active clients are selected.
+
+        Federated algorithms should use this helper for round-level client selection so participation counters remain
+        consistent with the executed training path.
         """
         active_clients = network.active_clients()
         if not active_clients:

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -62,14 +62,12 @@ class FedAlgorithm(Algorithm[FedNetwork]):
             )
         return {client: self.num_local_steps[client] for client in clients}
 
-    def selected_clients_for_round(self, network: FedNetwork, iteration: int) -> list["Agent"]:
+    def select_clients(self, network: FedNetwork, iteration: int) -> list["Agent"]:
         """
-        Select participating clients for the current round and record participation.
+        Select clients for the current federated round.
 
-        Use this method once per federated round when selecting participating clients in the round. It applies
-        ``self.selection_scheme`` to the currently active clients and updates the selection counters used by
-        participation metrics. Calling it more than once in the same round will increment the selected-client counters
-        more than once.
+        The method selects the subset of active clients that will receive the server broadcast and perform local
+        training. The clients are selected using ``self.selection_scheme``.
 
         If ``self.selection_scheme`` is ``None``, all active clients are selected.
         """
@@ -87,7 +85,7 @@ class FedAlgorithm(Algorithm[FedNetwork]):
     def _record_selected_clients(selected_clients: Sequence["Agent"]) -> None:
         """Record clients selected by a federated round."""
         for client in selected_clients:
-            client._n_times_selected = getattr(client, "_n_times_selected", 0) + 1  # noqa: SLF001
+            client._n_times_selected += 1  # noqa: SLF001
 
     def server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
         """Send the current server model to the selected clients."""

--- a/decent_bench/algorithms/federated/_fed_algorithm.py
+++ b/decent_bench/algorithms/federated/_fed_algorithm.py
@@ -72,8 +72,17 @@ class FedAlgorithm(Algorithm[FedNetwork]):
         if not active_clients:
             return []
         if self.selection_scheme is None:
-            return list(active_clients)
-        return self.selection_scheme.select(active_clients, iteration)
+            selected_clients = list(active_clients)
+        else:
+            selected_clients = self.selection_scheme.select(active_clients, iteration)
+        self._record_selected_clients(selected_clients)
+        return selected_clients
+
+    @staticmethod
+    def _record_selected_clients(selected_clients: Sequence["Agent"]) -> None:
+        """Record clients selected by a federated round."""
+        for client in selected_clients:
+            client._n_times_selected += 1  # noqa: SLF001
 
     def server_broadcast(self, network: FedNetwork, selected_clients: Sequence["Agent"]) -> None:
         """Send the current server model to the selected clients."""
@@ -115,7 +124,14 @@ class FedAlgorithm(Algorithm[FedNetwork]):
         received_clients = [client for client in participating_clients if client in network.server().messages]
         if not received_clients:
             return
+        self._record_updates_received_by_server(received_clients)
         updates = [network.server().messages[client] for client in received_clients]
         weights = [1.0] * len(received_clients)
         total_weight = float(len(received_clients))
         network.server().x = self._weighted_average(updates, weights, total_weight)
+
+    @staticmethod
+    def _record_updates_received_by_server(received_clients: Sequence["Agent"]) -> None:
+        """Record clients whose update contributed to a server aggregation."""
+        for client in received_clients:
+            client._n_times_update_received_by_server += 1  # noqa: SLF001

--- a/decent_bench/algorithms/federated/_fed_avg.py
+++ b/decent_bench/algorithms/federated/_fed_avg.py
@@ -71,7 +71,7 @@ class FedAvg(FedAlgorithm):
             client.initialize(x=self.x0[client])
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self._selected_clients_for_round(network, iteration)
+        selected_clients = self.selected_clients_for_round(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_avg.py
+++ b/decent_bench/algorithms/federated/_fed_avg.py
@@ -71,7 +71,7 @@ class FedAvg(FedAlgorithm):
             client.initialize(x=self.x0[client])
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self.selected_clients_for_round(network, iteration)
+        selected_clients = self.select_clients(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_dyn.py
+++ b/decent_bench/algorithms/federated/_fed_dyn.py
@@ -140,8 +140,6 @@ class FedDyn(FedAlgorithm):
         received_clients = [client for client in participating_clients if client in server.messages]
         if not received_clients:
             return
-        self._record_updates_received_by_server(received_clients)
-
         reference_x = iop.copy(server.x)
         client_models = [server.messages[client] for client in received_clients]
         average_model = self._weighted_average(

--- a/decent_bench/algorithms/federated/_fed_dyn.py
+++ b/decent_bench/algorithms/federated/_fed_dyn.py
@@ -93,7 +93,7 @@ class FedDyn(FedAlgorithm):
             client.initialize(x=client_x0, aux_vars={"g": iop.zeros_like(client_x0)})
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self.selected_clients_for_round(network, iteration)
+        selected_clients = self.select_clients(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_dyn.py
+++ b/decent_bench/algorithms/federated/_fed_dyn.py
@@ -140,6 +140,7 @@ class FedDyn(FedAlgorithm):
         received_clients = [client for client in participating_clients if client in server.messages]
         if not received_clients:
             return
+        self._record_updates_received_by_server(received_clients)
 
         reference_x = iop.copy(server.x)
         client_models = [server.messages[client] for client in received_clients]

--- a/decent_bench/algorithms/federated/_fed_dyn.py
+++ b/decent_bench/algorithms/federated/_fed_dyn.py
@@ -93,7 +93,7 @@ class FedDyn(FedAlgorithm):
             client.initialize(x=client_x0, aux_vars={"g": iop.zeros_like(client_x0)})
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self._selected_clients_for_round(network, iteration)
+        selected_clients = self.selected_clients_for_round(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -290,4 +290,3 @@ class FedLT(FedAlgorithm):
             if client in network.server().messages:
                 received_clients.append(client)
                 z_by_client[client] = network.server().messages[client]
-        self._record_updates_received_by_server(received_clients)

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -285,6 +285,9 @@ class FedLT(FedAlgorithm):
         aggregation in partial participation and lossy communication settings.
         """
         z_by_client = network.server().aux_vars["z_by_client"]
+        received_clients = []
         for client in participating_clients:
             if client in network.server().messages:
+                received_clients.append(client)
                 z_by_client[client] = network.server().messages[client]
+        self._record_updates_received_by_server(received_clients)

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -200,7 +200,7 @@ class FedLT(FedAlgorithm):
         y = self._compute_server_y(network)
         network.server().x = y
 
-        selected_clients = self._selected_clients_for_round(network, iteration)
+        selected_clients = self.selected_clients_for_round(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -81,7 +81,7 @@ class FedLT(FedAlgorithm):
     One possible centralized strongly-convex choice is
     :math:`\beta=(\sqrt{L_i + 1/\rho} - \sqrt{\mu_i + 1/\rho}) / (\sqrt{L_i + 1/\rho}
     + \sqrt{\mu_i + 1/\rho})`, with local step size :math:`1/(L_i + 1/\rho)`, where
-    :math:`L_i=\texttt{m_smooth}` and :math:`\mu_i=\texttt{m_cvx}`.
+    ``m_smooth`` supplies :math:`L_i` and ``m_cvx`` supplies :math:`\mu_i`.
 
     **Adam.**
     The ``local_solver="adam"`` option applies Adam to the same local gradient. Adam moments are reset at the start

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -200,7 +200,7 @@ class FedLT(FedAlgorithm):
         y = self._compute_server_y(network)
         network.server().x = y
 
-        selected_clients = self.selected_clients_for_round(network, iteration)
+        selected_clients = self.select_clients(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_lt.py
+++ b/decent_bench/algorithms/federated/_fed_lt.py
@@ -285,8 +285,6 @@ class FedLT(FedAlgorithm):
         aggregation in partial participation and lossy communication settings.
         """
         z_by_client = network.server().aux_vars["z_by_client"]
-        received_clients = []
         for client in participating_clients:
             if client in network.server().messages:
-                received_clients.append(client)
                 z_by_client[client] = network.server().messages[client]

--- a/decent_bench/algorithms/federated/_fed_nova.py
+++ b/decent_bench/algorithms/federated/_fed_nova.py
@@ -162,7 +162,7 @@ class FedNova(FedAlgorithm):
         self.num_local_steps = self._num_local_steps_by_client
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self.selected_clients_for_round(network, iteration)
+        selected_clients = self.select_clients(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_nova.py
+++ b/decent_bench/algorithms/federated/_fed_nova.py
@@ -270,8 +270,6 @@ class FedNova(FedAlgorithm):
         received_clients = [client for client in received_gradient_clients if client in received_normalizers]
         if not received_clients:
             return
-        self._record_updates_received_by_server(received_clients)
-
         server_sample_counts = server.aux_vars["client_sample_counts"]
         server_x = iop.copy(server.x)
         cumulative_gradients = [server.messages[client] for client in received_clients]

--- a/decent_bench/algorithms/federated/_fed_nova.py
+++ b/decent_bench/algorithms/federated/_fed_nova.py
@@ -162,7 +162,7 @@ class FedNova(FedAlgorithm):
         self.num_local_steps = self._num_local_steps_by_client
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self._selected_clients_for_round(network, iteration)
+        selected_clients = self.selected_clients_for_round(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_nova.py
+++ b/decent_bench/algorithms/federated/_fed_nova.py
@@ -270,6 +270,7 @@ class FedNova(FedAlgorithm):
         received_clients = [client for client in received_gradient_clients if client in received_normalizers]
         if not received_clients:
             return
+        self._record_updates_received_by_server(received_clients)
 
         server_sample_counts = server.aux_vars["client_sample_counts"]
         server_x = iop.copy(server.x)

--- a/decent_bench/algorithms/federated/_fed_opt.py
+++ b/decent_bench/algorithms/federated/_fed_opt.py
@@ -149,8 +149,6 @@ class FedOpt(FedAlgorithm, ABC):
         received_clients = [client for client in participating_clients if client in server.messages]
         if not received_clients:
             return
-        self._record_updates_received_by_server(received_clients)
-
         server_x = iop.copy(server.x)
         model_deltas = [server.messages[client] for client in received_clients]
         weights = [1.0] * len(received_clients)

--- a/decent_bench/algorithms/federated/_fed_opt.py
+++ b/decent_bench/algorithms/federated/_fed_opt.py
@@ -104,7 +104,7 @@ class FedOpt(FedAlgorithm, ABC):
             client.initialize(x=self.x0[client])
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self.selected_clients_for_round(network, iteration)
+        selected_clients = self.select_clients(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_opt.py
+++ b/decent_bench/algorithms/federated/_fed_opt.py
@@ -149,6 +149,7 @@ class FedOpt(FedAlgorithm, ABC):
         received_clients = [client for client in participating_clients if client in server.messages]
         if not received_clients:
             return
+        self._record_updates_received_by_server(received_clients)
 
         server_x = iop.copy(server.x)
         model_deltas = [server.messages[client] for client in received_clients]

--- a/decent_bench/algorithms/federated/_fed_opt.py
+++ b/decent_bench/algorithms/federated/_fed_opt.py
@@ -104,7 +104,7 @@ class FedOpt(FedAlgorithm, ABC):
             client.initialize(x=self.x0[client])
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self._selected_clients_for_round(network, iteration)
+        selected_clients = self.selected_clients_for_round(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_pd.py
+++ b/decent_bench/algorithms/federated/_fed_pd.py
@@ -100,9 +100,7 @@ class FedPD(FedAlgorithm):
         self.num_local_steps = self._num_local_steps_by_client
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        if self.selection_scheme is not None:
-            raise ValueError("FedPD does not support client selection")
-        participating_clients = self.selected_clients_for_round(network, iteration)
+        participating_clients = self.select_clients(network, iteration)
         if not participating_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_pd.py
+++ b/decent_bench/algorithms/federated/_fed_pd.py
@@ -102,7 +102,7 @@ class FedPD(FedAlgorithm):
     def step(self, network: FedNetwork, iteration: int) -> None:
         if self.selection_scheme is not None:
             raise ValueError("FedPD does not support client selection")
-        participating_clients = self._selected_clients_for_round(network, iteration)
+        participating_clients = self.selected_clients_for_round(network, iteration)
         if not participating_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_pd.py
+++ b/decent_bench/algorithms/federated/_fed_pd.py
@@ -103,6 +103,7 @@ class FedPD(FedAlgorithm):
         participating_clients = network.active_clients()
         if not participating_clients:
             return
+        self._record_selected_clients(participating_clients)
 
         self._run_local_updates(participating_clients)
         if random.random() >= self.skip_probability:
@@ -160,6 +161,7 @@ class FedPD(FedAlgorithm):
         received_clients = [client for client in participating_clients if client in network.server().messages]
         if not received_clients:
             return
+        self._record_updates_received_by_server(received_clients)
         center_candidates = [server.messages[client] for client in received_clients]
         weights = [1.0] * len(received_clients)
         total_weight = float(len(received_clients))

--- a/decent_bench/algorithms/federated/_fed_pd.py
+++ b/decent_bench/algorithms/federated/_fed_pd.py
@@ -161,7 +161,6 @@ class FedPD(FedAlgorithm):
         received_clients = [client for client in participating_clients if client in network.server().messages]
         if not received_clients:
             return
-        self._record_updates_received_by_server(received_clients)
         center_candidates = [server.messages[client] for client in received_clients]
         weights = [1.0] * len(received_clients)
         total_weight = float(len(received_clients))

--- a/decent_bench/algorithms/federated/_fed_pd.py
+++ b/decent_bench/algorithms/federated/_fed_pd.py
@@ -99,11 +99,12 @@ class FedPD(FedAlgorithm):
         self._num_local_steps_by_client = self._settle_num_local_steps(network)
         self.num_local_steps = self._num_local_steps_by_client
 
-    def step(self, network: FedNetwork, _: int) -> None:
-        participating_clients = network.active_clients()
+    def step(self, network: FedNetwork, iteration: int) -> None:
+        if self.selection_scheme is not None:
+            raise ValueError("FedPD does not support client selection")
+        participating_clients = self._selected_clients_for_round(network, iteration)
         if not participating_clients:
             return
-        self._record_selected_clients(participating_clients)
 
         self._run_local_updates(participating_clients)
         if random.random() >= self.skip_probability:

--- a/decent_bench/algorithms/federated/_fed_prox.py
+++ b/decent_bench/algorithms/federated/_fed_prox.py
@@ -80,7 +80,7 @@ class FedProx(FedAlgorithm):
             client.initialize(x=self.x0[client])
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self.selected_clients_for_round(network, iteration)
+        selected_clients = self.select_clients(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_fed_prox.py
+++ b/decent_bench/algorithms/federated/_fed_prox.py
@@ -80,7 +80,7 @@ class FedProx(FedAlgorithm):
             client.initialize(x=self.x0[client])
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self._selected_clients_for_round(network, iteration)
+        selected_clients = self.selected_clients_for_round(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_scaffold.py
+++ b/decent_bench/algorithms/federated/_scaffold.py
@@ -111,7 +111,7 @@ class Scaffold(FedAlgorithm):
             )
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self._selected_clients_for_round(network, iteration)
+        selected_clients = self.selected_clients_for_round(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_scaffold.py
+++ b/decent_bench/algorithms/federated/_scaffold.py
@@ -111,7 +111,7 @@ class Scaffold(FedAlgorithm):
             )
 
     def step(self, network: FedNetwork, iteration: int) -> None:
-        selected_clients = self.selected_clients_for_round(network, iteration)
+        selected_clients = self.select_clients(network, iteration)
         if not selected_clients:
             return
 

--- a/decent_bench/algorithms/federated/_scaffold.py
+++ b/decent_bench/algorithms/federated/_scaffold.py
@@ -172,8 +172,6 @@ class Scaffold(FedAlgorithm):
         received_clients = [client for client in participating_clients if client in server.messages]
         if not received_clients:
             return
-        self._record_updates_received_by_server(received_clients)
-
         uploads = [server.messages[client] for client in received_clients]
         model_deltas = [upload[0] for upload in uploads]
         weights = [1.0] * len(received_clients)

--- a/decent_bench/algorithms/federated/_scaffold.py
+++ b/decent_bench/algorithms/federated/_scaffold.py
@@ -172,6 +172,7 @@ class Scaffold(FedAlgorithm):
         received_clients = [client for client in participating_clients if client in server.messages]
         if not received_clients:
             return
+        self._record_updates_received_by_server(received_clients)
 
         uploads = [server.messages[client] for client in received_clients]
         model_deltas = [upload[0] for upload in uploads]

--- a/decent_bench/benchmark/_benchmark_result.py
+++ b/decent_bench/benchmark/_benchmark_result.py
@@ -14,7 +14,7 @@ class BenchmarkResult:
     This class is used to store the results and metadata of a benchmark execution.
     It is returned by the :func:`~decent_bench.benchmark.benchmark` function and contains
     all the information about the benchmark run, including the problem definition,
-    algorithm states, table results, and plot results.
+    and final algorithm states.
 
     * `problem`: contains the definition of the benchmark problem that was executed.
     * `states`: contains the final states of the algorithms after execution, organized by algorithm where

--- a/decent_bench/benchmark/_compute.py
+++ b/decent_bench/benchmark/_compute.py
@@ -178,9 +178,9 @@ def _validate_unique_metric_descriptions(
         duplicates = ", ".join(duplicate_table_descriptions)
         raise ValueError(f"Table metric descriptions must be unique, duplicates found: {duplicates}")
 
-    duplicate_plot_descriptions = _find_duplicates([
-        metric.plot_description for metric in _flatten_plot_metrics(plot_metrics)
-    ])
+    duplicate_plot_descriptions = _find_duplicates(
+        [metric.plot_description for metric in _flatten_plot_metrics(plot_metrics)]
+    )
     if duplicate_plot_descriptions:
         duplicates = ", ".join(duplicate_plot_descriptions)
         raise ValueError(f"Plot metric descriptions must be unique, duplicates found: {duplicates}")

--- a/decent_bench/benchmark/_compute.py
+++ b/decent_bench/benchmark/_compute.py
@@ -42,12 +42,11 @@ def compute_metrics(
             checkpoint manager
         checkpoint_manager: if provided, will be used to save results of metrics computation and/or load benchmark
             result.
-        table_metrics: metrics to tabulate as confidence intervals after the execution. Defaults to
-            :const:`~decent_bench.metrics.metric_library.DEFAULT_TABLE_METRICS` for non-federated problems and
-            :const:`~decent_bench.metrics.metric_library.FEDERATED_TABLE_METRICS` for federated problems.
-        plot_metrics: metrics to plot after the execution. Defaults to
-            :const:`~decent_bench.metrics.metric_library.DEFAULT_PLOT_METRICS` for non-federated problems and
-            :const:`~decent_bench.metrics.metric_library.FEDERATED_PLOT_METRICS` for federated problems.
+        table_metrics: metrics to tabulate as confidence intervals after the execution. If ``None``, all table metrics
+            available for the benchmark problem will be used. For example, federated-only metrics are removed when a
+            non-federated network is passed.
+        plot_metrics: metrics to plot after the execution. If ``None``, all plot metrics available for the benchmark
+            problem will be used.
             If a list of lists is provided, each inner list will be plotted in a separate figure. Otherwise up to 3
             metrics will be grouped and plotted in their own figure with subplots.
         confidence_level: confidence level for computing confidence intervals of the table metrics, expressed as a value
@@ -98,7 +97,7 @@ def compute_metrics(
         if len(benchmark_result.states) == 0:
             raise ValueError("No benchmark result found in checkpoint manager to compute metrics")
 
-    table_metrics, plot_metrics = _resolve_default_metrics(table_metrics, plot_metrics, benchmark_result.problem)
+    table_metrics, plot_metrics = _resolve_default_metrics(table_metrics, plot_metrics)
 
     # work on independent metric instances
     table_metrics = deepcopy(table_metrics)
@@ -168,14 +167,11 @@ def compute_metrics(
 def _resolve_default_metrics(
     table_metrics: list[Metric] | None,
     plot_metrics: list[Metric] | list[list[Metric]] | None,
-    problem: "BenchmarkProblem",
 ) -> tuple[list[Metric], list[Metric] | list[list[Metric]]]:
     if table_metrics is None:
-        table_metrics = (
-            ml.FEDERATED_TABLE_METRICS if isinstance(problem.network, FedNetwork) else ml.DEFAULT_TABLE_METRICS
-        )
+        table_metrics = ml._DEFAULT_TABLE_METRICS  # noqa: SLF001
     if plot_metrics is None:
-        plot_metrics = ml.FEDERATED_PLOT_METRICS if isinstance(problem.network, FedNetwork) else ml.DEFAULT_PLOT_METRICS
+        plot_metrics = ml._DEFAULT_PLOT_METRICS  # noqa: SLF001
     return table_metrics, plot_metrics
 
 

--- a/decent_bench/benchmark/_compute.py
+++ b/decent_bench/benchmark/_compute.py
@@ -16,7 +16,7 @@ from decent_bench.metrics import (
     metric_utils,
 )
 from decent_bench.metrics import metric_library as ml
-from decent_bench.networks import FedNetwork, Network
+from decent_bench.networks import Network
 from decent_bench.utils._metric_helpers import _find_duplicates, _flatten_plot_metrics
 from decent_bench.utils.logger import LOGGER, start_logger
 
@@ -119,25 +119,20 @@ def compute_metrics(
 
     # compute table and plot results
     resulting_agent_states: dict[Algorithm[Network], list[list[AgentMetricsView]]] = {}
-    resulting_server_states: dict[Algorithm[Network], list[AgentMetricsView]] = {}
     for alg, networks in benchmark_result.states.items():
-        resulting_agent_states[alg] = [[AgentMetricsView.from_agent(a) for a in nw.agents()] for nw in networks]
-        fed_networks = [nw for nw in networks if isinstance(nw, FedNetwork)]
-        if len(fed_networks) == len(networks):
-            resulting_server_states[alg] = [AgentMetricsView.from_agent(nw.server()) for nw in fed_networks]
-    server_states = resulting_server_states or None
+        resulting_agent_states[alg] = [
+            [AgentMetricsView.from_agent(a) for a in nw.snapshot_agents()] for nw in networks
+        ]
     table_results = compute_tables(
         resulting_agent_states,
         benchmark_result.problem,
         table_metrics,
         confidence_level,
-        resulting_server_states=server_states,
     )
     plot_results = compute_plots(
         resulting_agent_states,
         benchmark_result.problem,
         plot_metrics,
-        resulting_server_states=server_states,
     )
 
     result = MetricResult(
@@ -146,7 +141,6 @@ def compute_metrics(
         plot_metrics=plot_metrics,
         table_results=table_results,
         plot_results=plot_results,
-        server_metrics=server_states,
     )
 
     if checkpoint_manager is not None:

--- a/decent_bench/benchmark/_compute.py
+++ b/decent_bench/benchmark/_compute.py
@@ -16,7 +16,7 @@ from decent_bench.metrics import (
     metric_utils,
 )
 from decent_bench.metrics import metric_library as ml
-from decent_bench.networks import Network
+from decent_bench.networks import FedNetwork, Network
 from decent_bench.utils._metric_helpers import _find_duplicates, _flatten_plot_metrics
 from decent_bench.utils.logger import LOGGER, start_logger
 
@@ -29,8 +29,8 @@ def compute_metrics(
     benchmark_result: BenchmarkResult | None = None,
     checkpoint_manager: "CheckpointManager | None" = None,
     *,
-    table_metrics: list[Metric] = ml.DEFAULT_TABLE_METRICS,
-    plot_metrics: list[Metric] | list[list[Metric]] = ml.DEFAULT_PLOT_METRICS,
+    table_metrics: list[Metric] | None = None,
+    plot_metrics: list[Metric] | list[list[Metric]] | None = None,
     confidence_level: float = 0.95,
     log_level: int = logging.INFO,
 ) -> MetricResult:
@@ -42,10 +42,12 @@ def compute_metrics(
             checkpoint manager
         checkpoint_manager: if provided, will be used to save results of metrics computation and/or load benchmark
             result.
-        table_metrics: metrics to tabulate as confidence intervals after the execution, defaults to
-            :const:`~decent_bench.metrics.metric_library.DEFAULT_TABLE_METRICS`
-        plot_metrics: metrics to plot after the execution, defaults to
-            :const:`~decent_bench.metrics.metric_library.DEFAULT_PLOT_METRICS`.
+        table_metrics: metrics to tabulate as confidence intervals after the execution. Defaults to
+            :const:`~decent_bench.metrics.metric_library.DEFAULT_TABLE_METRICS` for non-federated problems and
+            :const:`~decent_bench.metrics.metric_library.FEDERATED_TABLE_METRICS` for federated problems.
+        plot_metrics: metrics to plot after the execution. Defaults to
+            :const:`~decent_bench.metrics.metric_library.DEFAULT_PLOT_METRICS` for non-federated problems and
+            :const:`~decent_bench.metrics.metric_library.FEDERATED_PLOT_METRICS` for federated problems.
             If a list of lists is provided, each inner list will be plotted in a separate figure. Otherwise up to 3
             metrics will be grouped and plotted in their own figure with subplots.
         confidence_level: confidence level for computing confidence intervals of the table metrics, expressed as a value
@@ -96,6 +98,8 @@ def compute_metrics(
         if len(benchmark_result.states) == 0:
             raise ValueError("No benchmark result found in checkpoint manager to compute metrics")
 
+    table_metrics, plot_metrics = _resolve_default_metrics(table_metrics, plot_metrics, benchmark_result.problem)
+
     # work on independent metric instances
     table_metrics = deepcopy(table_metrics)
     plot_metrics = deepcopy(plot_metrics)
@@ -116,10 +120,26 @@ def compute_metrics(
 
     # compute table and plot results
     resulting_agent_states: dict[Algorithm[Network], list[list[AgentMetricsView]]] = {}
+    resulting_server_states: dict[Algorithm[Network], list[AgentMetricsView]] = {}
     for alg, networks in benchmark_result.states.items():
         resulting_agent_states[alg] = [[AgentMetricsView.from_agent(a) for a in nw.agents()] for nw in networks]
-    table_results = compute_tables(resulting_agent_states, benchmark_result.problem, table_metrics, confidence_level)
-    plot_results = compute_plots(resulting_agent_states, benchmark_result.problem, plot_metrics)
+        fed_networks = [nw for nw in networks if isinstance(nw, FedNetwork)]
+        if len(fed_networks) == len(networks):
+            resulting_server_states[alg] = [AgentMetricsView.from_agent(nw.server()) for nw in fed_networks]
+    server_states = resulting_server_states or None
+    table_results = compute_tables(
+        resulting_agent_states,
+        benchmark_result.problem,
+        table_metrics,
+        confidence_level,
+        resulting_server_states=server_states,
+    )
+    plot_results = compute_plots(
+        resulting_agent_states,
+        benchmark_result.problem,
+        plot_metrics,
+        resulting_server_states=server_states,
+    )
 
     result = MetricResult(
         agent_metrics=resulting_agent_states,
@@ -127,6 +147,7 @@ def compute_metrics(
         plot_metrics=plot_metrics,
         table_results=table_results,
         plot_results=plot_results,
+        server_metrics=server_states,
     )
 
     if checkpoint_manager is not None:
@@ -142,6 +163,20 @@ def compute_metrics(
     metric_utils._clear_caches()  # noqa: SLF001
 
     return result
+
+
+def _resolve_default_metrics(
+    table_metrics: list[Metric] | None,
+    plot_metrics: list[Metric] | list[list[Metric]] | None,
+    problem: "BenchmarkProblem",
+) -> tuple[list[Metric], list[Metric] | list[list[Metric]]]:
+    if table_metrics is None:
+        table_metrics = (
+            ml.FEDERATED_TABLE_METRICS if isinstance(problem.network, FedNetwork) else ml.DEFAULT_TABLE_METRICS
+        )
+    if plot_metrics is None:
+        plot_metrics = ml.FEDERATED_PLOT_METRICS if isinstance(problem.network, FedNetwork) else ml.DEFAULT_PLOT_METRICS
+    return table_metrics, plot_metrics
 
 
 def _validate_unique_metric_descriptions(

--- a/decent_bench/benchmark/_display.py
+++ b/decent_bench/benchmark/_display.py
@@ -130,7 +130,6 @@ def display_metrics(  # noqa: PLR0912
     # filter `metrics_result` based on `plot_metrics`, `table_metrics`, and `algorithms` (if provided)
     prev_values = {
         "agent_metrics": metrics_result.agent_metrics,
-        "server_metrics": getattr(metrics_result, "server_metrics", None),
         "table_results": metrics_result.table_results,
         "plot_results": metrics_result.plot_results,
         "table_metrics": metrics_result.table_metrics,
@@ -204,7 +203,7 @@ def _filter_algorithms(
             f"{', '.join(missing_names)}. Available algorithms: {', '.join(metrics_result.available_algorithms)}"
         )
 
-    for attribute in ("agent_metrics", "server_metrics", "table_results", "plot_results"):
+    for attribute in ("agent_metrics", "table_results", "plot_results"):
         mapping = getattr(metrics_result, attribute, None)
         if mapping is not None:
             setattr(

--- a/decent_bench/benchmark/_display.py
+++ b/decent_bench/benchmark/_display.py
@@ -130,6 +130,7 @@ def display_metrics(  # noqa: PLR0912
     # filter `metrics_result` based on `plot_metrics`, `table_metrics`, and `algorithms` (if provided)
     prev_values = {
         "agent_metrics": metrics_result.agent_metrics,
+        "server_metrics": getattr(metrics_result, "server_metrics", None),
         "table_results": metrics_result.table_results,
         "plot_results": metrics_result.plot_results,
         "table_metrics": metrics_result.table_metrics,
@@ -203,8 +204,8 @@ def _filter_algorithms(
             f"{', '.join(missing_names)}. Available algorithms: {', '.join(metrics_result.available_algorithms)}"
         )
 
-    for attribute in ("agent_metrics", "table_results", "plot_results"):
-        mapping = getattr(metrics_result, attribute)
+    for attribute in ("agent_metrics", "server_metrics", "table_results", "plot_results"):
+        mapping = getattr(metrics_result, attribute, None)
         if mapping is not None:
             setattr(
                 metrics_result,

--- a/decent_bench/benchmark/_metric_result.py
+++ b/decent_bench/benchmark/_metric_result.py
@@ -21,6 +21,7 @@ class MetricResult:
     * `agent_metrics`: contains the raw agent-level metrics for each algorithm, organized by algorithm where
       each algorithm maps to a sequence of trials, with each trial containing metrics for all agents.
     * `server_metrics`: contains one server metric view per trial for federated algorithms, organized by algorithm.
+      It is ``None`` when the result does not include a :class:`~decent_bench.networks.FedNetwork`.
     * `table_metrics`: contains the list of metrics that were tabulated as confidence intervals.
     * `plot_metrics`: contains the list of metrics that were plotted.
     * `table_results`: contains the computed table statistics for each algorithm and metric, organized by

--- a/decent_bench/benchmark/_metric_result.py
+++ b/decent_bench/benchmark/_metric_result.py
@@ -19,9 +19,8 @@ class MetricResult:
     and plot data for visualization.
 
     * `agent_metrics`: contains the raw agent-level metrics for each algorithm, organized by algorithm where
-      each algorithm maps to a sequence of trials, with each trial containing metrics for all agents.
-    * `server_metrics`: contains one server metric view per trial for federated algorithms, organized by algorithm.
-      It is ``None`` when the result does not include a :class:`~decent_bench.networks.FedNetwork`.
+      each algorithm maps to a sequence of trials, with each trial containing metrics for all snapshotted agents.
+      For federated networks, this includes the server.
     * `table_metrics`: contains the list of metrics that were tabulated as confidence intervals.
     * `plot_metrics`: contains the list of metrics that were plotted.
     * `table_results`: contains the computed table statistics for each algorithm and metric, organized by
@@ -44,7 +43,6 @@ class MetricResult:
         ]
         | None
     )
-    server_metrics: Mapping[Algorithm[Network], Sequence[AgentMetricsView]] | None = None
 
     @property
     def available_algorithms(self) -> list[str]:
@@ -53,7 +51,6 @@ class MetricResult:
             algorithm.name
             for mapping in (
                 self.agent_metrics,
-                getattr(self, "server_metrics", None),
                 self.table_results,
                 self.plot_results,
             )

--- a/decent_bench/benchmark/_metric_result.py
+++ b/decent_bench/benchmark/_metric_result.py
@@ -47,16 +47,18 @@ class MetricResult:
     @property
     def available_algorithms(self) -> list[str]:
         """Return ``name`` of available algorithms, which can be used for filtering in :func:`~decent_bench.benchmark.display_metrics`."""  # noqa: E501
-        return sorted({
-            algorithm.name
-            for mapping in (
-                self.agent_metrics,
-                self.table_results,
-                self.plot_results,
-            )
-            if mapping is not None
-            for algorithm in mapping
-        })
+        return sorted(
+            {
+                algorithm.name
+                for mapping in (
+                    self.agent_metrics,
+                    self.table_results,
+                    self.plot_results,
+                )
+                if mapping is not None
+                for algorithm in mapping
+            }
+        )
 
     @property
     def available_table_metrics(self) -> list[str]:

--- a/decent_bench/benchmark/_metric_result.py
+++ b/decent_bench/benchmark/_metric_result.py
@@ -20,6 +20,7 @@ class MetricResult:
 
     * `agent_metrics`: contains the raw agent-level metrics for each algorithm, organized by algorithm where
       each algorithm maps to a sequence of trials, with each trial containing metrics for all agents.
+    * `server_metrics`: contains one server metric view per trial for federated algorithms, organized by algorithm.
     * `table_metrics`: contains the list of metrics that were tabulated as confidence intervals.
     * `plot_metrics`: contains the list of metrics that were plotted.
     * `table_results`: contains the computed table statistics for each algorithm and metric, organized by
@@ -42,13 +43,19 @@ class MetricResult:
         ]
         | None
     )
+    server_metrics: Mapping[Algorithm[Network], Sequence[AgentMetricsView]] | None = None
 
     @property
     def available_algorithms(self) -> list[str]:
         """Return ``name`` of available algorithms, which can be used for filtering in :func:`~decent_bench.benchmark.display_metrics`."""  # noqa: E501
         return sorted({
             algorithm.name
-            for mapping in (self.agent_metrics, self.table_results, self.plot_results)
+            for mapping in (
+                self.agent_metrics,
+                getattr(self, "server_metrics", None),
+                self.table_results,
+                self.plot_results,
+            )
             if mapping is not None
             for algorithm in mapping
         })

--- a/decent_bench/metrics/_metric.py
+++ b/decent_bench/metrics/_metric.py
@@ -115,12 +115,12 @@ class Metric(ABC):
         Get the data for this metric from a trial.
 
         Args:
-            agents: the agents being evaluated
+            agents: the snapshotted agent views being evaluated. For federated networks, this may include the server.
             problem: the benchmark problem being evaluated
             iteration: the iteration at which to evaluate the metric, or -1 to use the agents' final x
 
         Returns:
-            a list of floats, one for each agent
+            a sequence of metric values
 
         """
 
@@ -134,20 +134,6 @@ class Metric(ABC):
         """
         return self.get_data_from_trial(agents, problem, -1)
 
-    def get_federated_table_data(
-        self,
-        agents: Sequence[AgentMetricsView],
-        server: AgentMetricsView,  # noqa: ARG002
-        problem: "BenchmarkProblem",
-    ) -> Sequence[float]:
-        """
-        Extract trial data to be used in the table when a federated server view is available.
-
-        The default preserves the existing client-only metric semantics. Federated metrics can override this method
-        to use the server view explicitly.
-        """
-        return self.get_table_data(agents, problem)
-
     def get_plot_data(self, agents: Sequence[AgentMetricsView], problem: "BenchmarkProblem") -> Sequence[tuple[X, Y]]:
         """
         Extract trial data to be used in plots for this metric.
@@ -160,17 +146,3 @@ class Metric(ABC):
             (i, float(np.mean(self.get_data_from_trial(agents, problem, i))))
             for i in utils.all_sorted_iterations(agents)
         ]
-
-    def get_federated_plot_data(
-        self,
-        agents: Sequence[AgentMetricsView],
-        server: AgentMetricsView,  # noqa: ARG002
-        problem: "BenchmarkProblem",
-    ) -> Sequence[tuple[X, Y]]:
-        """
-        Extract trial data to be used in plots when a federated server view is available.
-
-        The default preserves the existing client-only metric semantics. Federated metrics can override this method
-        to use the server view explicitly.
-        """
-        return self.get_plot_data(agents, problem)

--- a/decent_bench/metrics/_metric.py
+++ b/decent_bench/metrics/_metric.py
@@ -134,6 +134,20 @@ class Metric(ABC):
         """
         return self.get_data_from_trial(agents, problem, -1)
 
+    def get_federated_table_data(
+        self,
+        agents: Sequence[AgentMetricsView],
+        server: AgentMetricsView,  # noqa: ARG002
+        problem: "BenchmarkProblem",
+    ) -> Sequence[float]:
+        """
+        Extract trial data to be used in the table when a federated server view is available.
+
+        The default preserves the existing client-only metric semantics. Federated metrics can override this method
+        to use the server view explicitly.
+        """
+        return self.get_table_data(agents, problem)
+
     def get_plot_data(self, agents: Sequence[AgentMetricsView], problem: "BenchmarkProblem") -> Sequence[tuple[X, Y]]:
         """
         Extract trial data to be used in plots for this metric.
@@ -146,3 +160,17 @@ class Metric(ABC):
             (i, float(np.mean(self.get_data_from_trial(agents, problem, i))))
             for i in utils.all_sorted_iterations(agents)
         ]
+
+    def get_federated_plot_data(
+        self,
+        agents: Sequence[AgentMetricsView],
+        server: AgentMetricsView,  # noqa: ARG002
+        problem: "BenchmarkProblem",
+    ) -> Sequence[tuple[X, Y]]:
+        """
+        Extract trial data to be used in plots when a federated server view is available.
+
+        The default preserves the existing client-only metric semantics. Federated metrics can override this method
+        to use the server view explicitly.
+        """
+        return self.get_plot_data(agents, problem)

--- a/decent_bench/metrics/_metric.py
+++ b/decent_bench/metrics/_metric.py
@@ -115,7 +115,7 @@ class Metric(ABC):
         Get the data for this metric from a trial.
 
         Args:
-            agents: the snapshotted agent views being evaluated. For federated networks, this may include the server.
+            agents: the snapshotted agent views being evaluated. For federated networks, this includes the server.
             problem: the benchmark problem being evaluated
             iteration: the iteration at which to evaluate the metric, or -1 to use the agents' final x
 

--- a/decent_bench/metrics/_plots.py
+++ b/decent_bench/metrics/_plots.py
@@ -142,8 +142,6 @@ def compute_plots(  # noqa: PLR0914
     resulting_agent_states: dict[Algorithm[Network], list[list[AgentMetricsView]]],
     problem: "BenchmarkProblem",
     metrics: list[Metric] | list[list[Metric]],
-    *,
-    resulting_server_states: Mapping[Algorithm[Network], Sequence[AgentMetricsView]] | None = None,
 ) -> Mapping[
     Algorithm[Network], Mapping[Metric, tuple[Sequence[float], Sequence[float], Sequence[float], Sequence[float]]]
 ]:
@@ -157,7 +155,6 @@ def compute_plots(  # noqa: PLR0914
         problem: benchmark problem whose properties are used for metric calculations
         metrics: metrics to calculate and plot. If a list of lists is provided, each inner list will be plotted in a
             separate figure. Otherwise groups of 3 metrics will be plotted together in subplots of the same figure
-        resulting_server_states: optional federated server states from the trial executions, grouped by algorithm
 
     Returns:
         A nested dictionary containing plot data for each algorithm and metric, structured as
@@ -201,7 +198,6 @@ def compute_plots(  # noqa: PLR0914
                     agent_states,
                     problem,
                     metric,
-                    None if resulting_server_states is None else resulting_server_states.get(alg),
                 )
 
                 truncated_data_per_trial, had_non_finite = _truncate_to_common_finite_prefix(data_per_trial)
@@ -637,11 +633,12 @@ def _get_marker_style_color(
 
 
 def _calc_total_cost(agent_states: list[list[AgentMetricsView]], computational_cost: ComputationalCost) -> float:
-    mean_function_calls = np.mean([a.n_function_calls for agents in agent_states for a in agents])
-    mean_gradient_calls = np.mean([a.n_gradient_calls for agents in agent_states for a in agents])
-    mean_hessian_calls = np.mean([a.n_hessian_calls for agents in agent_states for a in agents])
-    mean_proximal_calls = np.mean([a.n_proximal_calls for agents in agent_states for a in agents])
-    mean_communication_calls = np.mean([a.n_sent_messages for agents in agent_states for a in agents])
+    client_states = [a for agents in agent_states for a in agents if not a.is_server]
+    mean_function_calls = np.mean([a.n_function_calls for a in client_states])
+    mean_gradient_calls = np.mean([a.n_gradient_calls for a in client_states])
+    mean_hessian_calls = np.mean([a.n_hessian_calls for a in client_states])
+    mean_proximal_calls = np.mean([a.n_proximal_calls for a in client_states])
+    mean_communication_calls = np.mean([a.n_sent_messages for a in client_states])
 
     return float(
         computational_cost.function * mean_function_calls
@@ -656,15 +653,11 @@ def _plot_data_per_trial(
     agents_per_trial: list[list[AgentMetricsView]],
     problem: "BenchmarkProblem",
     metric: Metric,
-    server_per_trial: Sequence[AgentMetricsView] | None = None,
 ) -> list[Sequence[tuple[X, Y]]]:
     data_per_trial: list[Sequence[tuple[X, Y]]] = []
-    for trial_idx, agents in enumerate(agents_per_trial):
+    for agents in agents_per_trial:
         with warnings.catch_warnings(action="ignore"):
-            if server_per_trial is None:
-                trial_data = metric.get_plot_data(agents, problem)
-            else:
-                trial_data = metric.get_federated_plot_data(agents, server_per_trial[trial_idx], problem)
+            trial_data = metric.get_plot_data(agents, problem)
         data_per_trial.append(trial_data)
     return data_per_trial
 

--- a/decent_bench/metrics/_plots.py
+++ b/decent_bench/metrics/_plots.py
@@ -142,6 +142,8 @@ def compute_plots(  # noqa: PLR0914
     resulting_agent_states: dict[Algorithm[Network], list[list[AgentMetricsView]]],
     problem: "BenchmarkProblem",
     metrics: list[Metric] | list[list[Metric]],
+    *,
+    resulting_server_states: Mapping[Algorithm[Network], Sequence[AgentMetricsView]] | None = None,
 ) -> Mapping[
     Algorithm[Network], Mapping[Metric, tuple[Sequence[float], Sequence[float], Sequence[float], Sequence[float]]]
 ]:
@@ -155,6 +157,7 @@ def compute_plots(  # noqa: PLR0914
         problem: benchmark problem whose properties are used for metric calculations
         metrics: metrics to calculate and plot. If a list of lists is provided, each inner list will be plotted in a
             separate figure. Otherwise groups of 3 metrics will be plotted together in subplots of the same figure
+        resulting_server_states: optional federated server states from the trial executions, grouped by algorithm
 
     Returns:
         A nested dictionary containing plot data for each algorithm and metric, structured as
@@ -198,6 +201,7 @@ def compute_plots(  # noqa: PLR0914
                     agent_states,
                     problem,
                     metric,
+                    None if resulting_server_states is None else resulting_server_states.get(alg),
                 )
 
                 truncated_data_per_trial, had_non_finite = _truncate_to_common_finite_prefix(data_per_trial)
@@ -652,11 +656,15 @@ def _plot_data_per_trial(
     agents_per_trial: list[list[AgentMetricsView]],
     problem: "BenchmarkProblem",
     metric: Metric,
+    server_per_trial: Sequence[AgentMetricsView] | None = None,
 ) -> list[Sequence[tuple[X, Y]]]:
     data_per_trial: list[Sequence[tuple[X, Y]]] = []
-    for agents in agents_per_trial:
+    for trial_idx, agents in enumerate(agents_per_trial):
         with warnings.catch_warnings(action="ignore"):
-            trial_data = metric.get_plot_data(agents, problem)
+            if server_per_trial is None:
+                trial_data = metric.get_plot_data(agents, problem)
+            else:
+                trial_data = metric.get_federated_plot_data(agents, server_per_trial[trial_idx], problem)
         data_per_trial.append(trial_data)
     return data_per_trial
 

--- a/decent_bench/metrics/_plots.py
+++ b/decent_bench/metrics/_plots.py
@@ -633,12 +633,12 @@ def _get_marker_style_color(
 
 
 def _calc_total_cost(agent_states: list[list[AgentMetricsView]], computational_cost: ComputationalCost) -> float:
-    client_states = [a for agents in agent_states for a in agents if not a.is_server]
-    mean_function_calls = np.mean([a.n_function_calls for a in client_states])
-    mean_gradient_calls = np.mean([a.n_gradient_calls for a in client_states])
-    mean_hessian_calls = np.mean([a.n_hessian_calls for a in client_states])
-    mean_proximal_calls = np.mean([a.n_proximal_calls for a in client_states])
-    mean_communication_calls = np.mean([a.n_sent_messages for a in client_states])
+    non_server_states = [a for agents in agent_states for a in agents if not a.is_server]
+    mean_function_calls = np.mean([a.n_function_calls for a in non_server_states])
+    mean_gradient_calls = np.mean([a.n_gradient_calls for a in non_server_states])
+    mean_hessian_calls = np.mean([a.n_hessian_calls for a in non_server_states])
+    mean_proximal_calls = np.mean([a.n_proximal_calls for a in non_server_states])
+    mean_communication_calls = np.mean([a.n_sent_messages for a in non_server_states])
 
     return float(
         computational_cost.function * mean_function_calls

--- a/decent_bench/metrics/_tables.py
+++ b/decent_bench/metrics/_tables.py
@@ -112,8 +112,6 @@ def compute_tables(
     problem: "BenchmarkProblem",
     metrics: list[Metric],
     confidence_level: float,
-    *,
-    resulting_server_states: Mapping[Algorithm[Network], Sequence[AgentMetricsView]] | None = None,
 ) -> Mapping[Algorithm[Network], Mapping[Metric, Mapping[str, tuple[float, float]]]]:
     """
     Compute table metrics with confidence intervals.
@@ -125,7 +123,6 @@ def compute_tables(
         confidence_level: confidence level for computing confidence intervals of the metrics, expressed as a value
             between 0 and 1 (e.g., 0.95 for 95% confidence, 0.99 for 99% confidence). Higher values result in
             wider confidence intervals.
-        resulting_server_states: optional federated server states from the trial executions, grouped by algorithm
 
     Returns:
         A nested dictionary containing the mean and margin of error for each metric and statistic, structured as
@@ -152,7 +149,6 @@ def compute_tables(
                     resulting_agent_states[a],
                     problem,
                     metric,
-                    None if resulting_server_states is None else resulting_server_states.get(a),
                 )
                 for a in algs
             ]
@@ -177,17 +173,8 @@ def _table_data_per_trial(
     agents_per_trial: list[list[AgentMetricsView]],
     problem: "BenchmarkProblem",
     metric: Metric,
-    server_per_trial: Sequence[AgentMetricsView] | None = None,
 ) -> list[Sequence[float]]:
-    data_per_trial: list[Sequence[float]] = []
-    for trial_idx, agents in enumerate(agents_per_trial):
-        if server_per_trial is None:
-            trial_data = metric.get_table_data(agents, problem)
-        else:
-            trial_data = metric.get_federated_table_data(agents, server_per_trial[trial_idx], problem)
-        data_per_trial.append(trial_data)
-
-    return data_per_trial
+    return [metric.get_table_data(agents, problem) for agents in agents_per_trial]
 
 
 def _calculate_mean_and_margin_of_error(data: list[float], confidence_level: float) -> tuple[float, float]:

--- a/decent_bench/metrics/_tables.py
+++ b/decent_bench/metrics/_tables.py
@@ -112,6 +112,8 @@ def compute_tables(
     problem: "BenchmarkProblem",
     metrics: list[Metric],
     confidence_level: float,
+    *,
+    resulting_server_states: Mapping[Algorithm[Network], Sequence[AgentMetricsView]] | None = None,
 ) -> Mapping[Algorithm[Network], Mapping[Metric, Mapping[str, tuple[float, float]]]]:
     """
     Compute table metrics with confidence intervals.
@@ -123,6 +125,7 @@ def compute_tables(
         confidence_level: confidence level for computing confidence intervals of the metrics, expressed as a value
             between 0 and 1 (e.g., 0.95 for 95% confidence, 0.99 for 99% confidence). Higher values result in
             wider confidence intervals.
+        resulting_server_states: optional federated server states from the trial executions, grouped by algorithm
 
     Returns:
         A nested dictionary containing the mean and margin of error for each metric and statistic, structured as
@@ -144,7 +147,15 @@ def compute_tables(
         for metric in metrics:
             progress.update(table_task, status=f"Task: {metric.table_description}")
 
-            data_per_trial = [_table_data_per_trial(resulting_agent_states[a], problem, metric) for a in algs]
+            data_per_trial = [
+                _table_data_per_trial(
+                    resulting_agent_states[a],
+                    problem,
+                    metric,
+                    None if resulting_server_states is None else resulting_server_states.get(a),
+                )
+                for a in algs
+            ]
 
             for statistic in metric.statistics:
                 statistic_name = STATISTICS_ABBR.get(statistic.__name__) or statistic.__name__
@@ -166,10 +177,14 @@ def _table_data_per_trial(
     agents_per_trial: list[list[AgentMetricsView]],
     problem: "BenchmarkProblem",
     metric: Metric,
+    server_per_trial: Sequence[AgentMetricsView] | None = None,
 ) -> list[Sequence[float]]:
     data_per_trial: list[Sequence[float]] = []
-    for agents in agents_per_trial:
-        trial_data = metric.get_table_data(agents, problem)
+    for trial_idx, agents in enumerate(agents_per_trial):
+        if server_per_trial is None:
+            trial_data = metric.get_table_data(agents, problem)
+        else:
+            trial_data = metric.get_federated_table_data(agents, server_per_trial[trial_idx], problem)
         data_per_trial.append(trial_data)
 
     return data_per_trial

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -16,16 +16,6 @@ if TYPE_CHECKING:
     from decent_bench.benchmark import BenchmarkProblem
 
 
-def _non_server_views(agents: Sequence[AgentMetricsView]) -> list[AgentMetricsView]:
-    """Return all non-server agent views."""
-    return [agent for agent in agents if not agent.is_server]
-
-
-def _server_view(agents: Sequence[AgentMetricsView]) -> AgentMetricsView:
-    """Return the federated server view."""
-    return next(agent for agent in agents if agent.is_server)
-
-
 class Regret(Metric):
     r"""
     Global regret.
@@ -62,7 +52,7 @@ class Regret(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        agent_views = _non_server_views(agents)
+        agent_views = utils.non_server_views(agents)
         return (utils._regret(agent_views, problem, iteration),)  # noqa: SLF001
 
 
@@ -91,7 +81,7 @@ class GradientNorm(Metric):
         _: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        agent_views = _non_server_views(agents)
+        agent_views = utils.non_server_views(agents)
         return (utils._gradient_norm(agent_views, iteration),)  # noqa: SLF001
 
 
@@ -136,7 +126,7 @@ class XError(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        return [utils._x_error(a, problem, iteration) for a in _non_server_views(agents)]  # noqa: SLF001
+        return [utils._x_error(a, problem, iteration) for a in utils.non_server_views(agents)]  # noqa: SLF001
 
 
 class ConsensusError(Metric):
@@ -172,7 +162,7 @@ class ConsensusError(Metric):
         iteration: int,
     ) -> list[float]:
 
-        agent_views = _non_server_views(agents)
+        agent_views = utils.non_server_views(agents)
         x_mean = utils.x_mean(tuple(agent_views), iteration)
         return [float(iop.norm(x_mean - a.x_history[iteration])) for a in agent_views]
 
@@ -200,7 +190,7 @@ class XUpdates(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_x_updates for a in _non_server_views(agents)]
+        return [a.n_x_updates for a in utils.non_server_views(agents)]
 
 
 class FunctionCalls(Metric):
@@ -230,7 +220,7 @@ class FunctionCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_function_calls for a in _non_server_views(agents)]
+        return [a.n_function_calls for a in utils.non_server_views(agents)]
 
 
 class GradientCalls(Metric):
@@ -260,7 +250,7 @@ class GradientCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_gradient_calls for a in _non_server_views(agents)]
+        return [a.n_gradient_calls for a in utils.non_server_views(agents)]
 
 
 class HessianCalls(Metric):
@@ -290,7 +280,7 @@ class HessianCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_hessian_calls for a in _non_server_views(agents)]
+        return [a.n_hessian_calls for a in utils.non_server_views(agents)]
 
 
 class ProximalCalls(Metric):
@@ -316,7 +306,7 @@ class ProximalCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_proximal_calls for a in _non_server_views(agents)]
+        return [a.n_proximal_calls for a in utils.non_server_views(agents)]
 
 
 class SentMessages(Metric):
@@ -324,7 +314,7 @@ class SentMessages(Metric):
     Number of sent messages.
 
     Table:
-        Number of sent messages per agent.
+        Number of sent messages per agent. For federated networks, this includes the server.
 
     Plot:
         Number of sent messages (y-axis) per iteration (x-axis).
@@ -342,7 +332,7 @@ class SentMessages(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_sent_messages for a in _non_server_views(agents)]
+        return [a.n_sent_messages for a in agents]
 
 
 class ReceivedMessages(Metric):
@@ -350,7 +340,7 @@ class ReceivedMessages(Metric):
     Number of received messages.
 
     Table:
-        Number of received messages per agent.
+        Number of received messages per agent. For federated networks, this includes the server.
 
     Plot:
         Number of received messages (y-axis) per iteration (x-axis).
@@ -368,7 +358,7 @@ class ReceivedMessages(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_received_messages for a in _non_server_views(agents)]
+        return [a.n_received_messages for a in agents]
 
 
 class SentMessagesDropped(Metric):
@@ -376,7 +366,7 @@ class SentMessagesDropped(Metric):
     Number of sent messages dropped.
 
     Table:
-        Number of sent messages dropped per agent.
+        Number of sent messages dropped per agent. For federated networks, this includes the server.
 
     Plot:
         Number of sent messages dropped (y-axis) per iteration (x-axis).
@@ -394,7 +384,7 @@ class SentMessagesDropped(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_sent_messages_dropped for a in _non_server_views(agents)]
+        return [a.n_sent_messages_dropped for a in agents]
 
 
 class Accuracy(Metric):
@@ -452,7 +442,7 @@ class Accuracy(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = _non_server_views(agents)
+        agent_views = utils.non_server_views(agents)
         return utils._accuracy(agent_views, problem, iteration)  # noqa: SLF001
 
 
@@ -506,7 +496,7 @@ class MSE(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = _non_server_views(agents)
+        agent_views = utils.non_server_views(agents)
         return utils._mse(agent_views, problem, iteration)  # noqa: SLF001
 
 
@@ -565,7 +555,7 @@ class Precision(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = _non_server_views(agents)
+        agent_views = utils.non_server_views(agents)
         return utils._precision(agent_views, problem, iteration)  # noqa: SLF001
 
 
@@ -624,7 +614,7 @@ class Recall(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = _non_server_views(agents)
+        agent_views = utils.non_server_views(agents)
         return utils._recall(agent_views, problem, iteration)  # noqa: SLF001
 
 
@@ -653,7 +643,7 @@ class Loss(Metric):
         _: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = _non_server_views(agents)
+        agent_views = utils.non_server_views(agents)
         return utils._losses(agent_views, iteration)  # noqa: SLF001
 
 
@@ -664,7 +654,7 @@ def _requires_fednetwork(problem: "BenchmarkProblem", metric_name: str) -> tuple
 
 
 def _server_metric_cost(agents: Sequence[AgentMetricsView], metric_name: str) -> Cost:
-    agent_views = _non_server_views(agents)
+    agent_views = utils.non_server_views(agents)
     if not agent_views:
         raise ValueError(f"{metric_name} requires at least one client metrics view")
     return agent_views[0].cost
@@ -707,8 +697,8 @@ class ClientDriftFromServer(Metric):
         problem: "BenchmarkProblem",  # noqa: ARG002
         iteration: int,
     ) -> list[float]:
-        server = _server_view(agents)
-        return self._drifts(_non_server_views(agents), server, iteration)
+        server = utils.server_view(agents)
+        return utils.drifts(utils.non_server_views(agents), server, iteration)
 
     def get_plot_data(
         self,
@@ -716,32 +706,27 @@ class ClientDriftFromServer(Metric):
         _: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
         """Extract client drift trajectory."""
-        server = _server_view(agents)
-        agent_views = _non_server_views(agents)
+        server = utils.server_view(agents)
+        agent_views = utils.non_server_views(agents)
         return [
-            (i, float(np.mean(self._drifts(agent_views, server, i)))) for i in utils.all_sorted_iterations([server])
+            (i, float(np.mean(utils.drifts(agent_views, server, i)))) for i in utils.all_sorted_iterations([server])
         ]
 
-    @staticmethod
-    def _drifts(agents: Sequence[AgentMetricsView], server: AgentMetricsView, iteration: int) -> list[float]:
-        server_x = server.x_history[iteration]
-        return [float(iop.norm(agent.x_history[iteration] - server_x)) for agent in agents]
 
-
-class SelectedParticipationFraction(Metric):
+class FractionSelectedClients(Metric):
     r"""
-    Fraction of client-rounds selected by the federated algorithm.
+    Fraction of clients selected by the federated algorithm to perform local training.
 
     Table:
-        Average selected participation fraction over observed rounds.
+        Fraction of selected clients over the algorithm run.
 
     Note:
         Available only for :class:`~decent_bench.networks.FedNetwork`.
 
     """
 
-    table_description: str = "selected participation fraction"
-    plot_description: str = "selected participation fraction"
+    table_description: str = "fraction selected clients"
+    plot_description: str = "fraction selected clients"
     can_diverge: bool = False
 
     def is_available(  # noqa: D102
@@ -756,44 +741,11 @@ class SelectedParticipationFraction(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> tuple[float]:
-        agent_views = _non_server_views(agents)
+        agent_views = utils.non_server_views(agents)
         n_rounds = utils._observed_rounds(agent_views)  # noqa: SLF001
         if n_rounds == 0 or not agent_views:
             return (np.nan,)
         return (sum(agent.n_times_selected for agent in agent_views) / (n_rounds * len(agent_views)),)
-
-
-class TotalCommunication(Metric):
-    r"""
-    Total sent message attempts by clients and the server.
-
-    Table:
-        Sum of client sent messages and server sent messages, including messages dropped by the communication scheme.
-
-    Note:
-        Available only for :class:`~decent_bench.networks.FedNetwork`. For peer-to-peer networks, use the ``sum``
-        statistic of :class:`SentMessages`.
-
-    """
-
-    table_description: str = "total communication"
-    plot_description: str = "total communication"
-    can_diverge: bool = False
-
-    def is_available(  # noqa: D102
-        self,
-        problem: "BenchmarkProblem",
-    ) -> tuple[bool, str | None]:
-        return _requires_fednetwork(problem, self.table_description)
-
-    def get_data_from_trial(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],
-        problem: "BenchmarkProblem",  # noqa: ARG002
-        iteration: int,  # noqa: ARG002
-    ) -> tuple[int]:
-        _server_view(agents)
-        return (sum(agent.n_sent_messages for agent in agents),)
 
 
 class ServerMSE(Metric):
@@ -835,7 +787,7 @@ class ServerMSE(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        server = _server_view(agents)
+        server = utils.server_view(agents)
         cost = _server_metric_cost(agents, self.table_description)
         return (utils._mse_at_x(cost, server.x_history[iteration], problem),)  # noqa: SLF001
 
@@ -845,7 +797,7 @@ class ServerMSE(Metric):
         problem: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
         """Extract server MSE trajectory."""
-        server = _server_view(agents)
+        server = utils.server_view(agents)
         return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([server])]
 
 
@@ -891,7 +843,7 @@ class ServerAccuracy(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        server = _server_view(agents)
+        server = utils.server_view(agents)
         cost = _server_metric_cost(agents, self.table_description)
         return (utils._accuracy_at_x(cost, server.x_history[iteration], problem),)  # noqa: SLF001
 
@@ -901,7 +853,7 @@ class ServerAccuracy(Metric):
         problem: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
         """Extract server accuracy trajectory."""
-        server = _server_view(agents)
+        server = utils.server_view(agents)
         return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([server])]
 
 
@@ -997,13 +949,11 @@ _CLASSIFICATION_PLOT_METRICS: list[Metric] = _CLASSIFICATION_TABLE_METRICS
 
 _FEDERATED_TABLE_METRICS: list[Metric] = [
     ClientDriftFromServer([min, np.average, max]),
-    SelectedParticipationFraction([utils.single], fmt=".2%", x_log=False, y_log=False),
-    TotalCommunication([utils.single]),
+    FractionSelectedClients([utils.single], fmt=".2%", x_log=False, y_log=False),
 ]
 """
 - :class:`ClientDriftFromServer` - min, average, max
-- :class:`SelectedParticipationFraction` - single value with percentage format
-- :class:`TotalCommunication` - single value
+- :class:`FractionSelectedClients` - single value with percentage format
 
 :meta hide-value:
 """

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -7,8 +7,8 @@ import numpy as np
 
 import decent_bench.metrics.metric_utils as utils
 import decent_bench.utils.interoperability as iop
-from decent_bench import costs
 from decent_bench.agents import AgentMetricsView
+from decent_bench.costs import Cost, EmpiricalRiskCost
 from decent_bench.metrics._metric import Metric
 from decent_bench.networks import FedNetwork
 
@@ -446,7 +446,7 @@ class Accuracy(Metric):
     ) -> tuple[bool, str | None]:
         if getattr(problem, "test_data", None) is None:
             return False, "requires problem.test_data"
-        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
+        if not all(isinstance(a.cost, EmpiricalRiskCost) for a in problem.network.agents()):
             return False, "accuracy only applies if all agents have EmpiricalRiskCost"
         _, test_y = utils._split_dataset(problem.test_data)  # type: ignore[arg-type] # noqa: SLF001
         if test_y.dtype.kind not in {"i", "u"}:
@@ -506,7 +506,7 @@ class MSE(Metric):
     ) -> tuple[bool, str | None]:
         if getattr(problem, "test_data", None) is None:
             return False, "requires problem.test_data"
-        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
+        if not all(isinstance(a.cost, EmpiricalRiskCost) for a in problem.network.agents()):
             return False, "MSE only applies if all agents have EmpiricalRiskCost"
         return True, None
 
@@ -565,7 +565,7 @@ class Precision(Metric):
     ) -> tuple[bool, str | None]:
         if getattr(problem, "test_data", None) is None:
             return False, "requires problem.test_data"
-        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
+        if not all(isinstance(a.cost, EmpiricalRiskCost) for a in problem.network.agents()):
             return False, "precision only applies if all agents have EmpiricalRiskCost"
         _, test_y = utils._split_dataset(problem.test_data)  # type: ignore[arg-type] # noqa: SLF001
         if test_y.dtype.kind not in {"i", "u"}:
@@ -627,7 +627,7 @@ class Recall(Metric):
     ) -> tuple[bool, str | None]:
         if getattr(problem, "test_data", None) is None:
             return False, "requires problem.test_data"
-        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
+        if not all(isinstance(a.cost, EmpiricalRiskCost) for a in problem.network.agents()):
             return False, "recall only applies if all agents have EmpiricalRiskCost"
         _, test_y = utils._split_dataset(problem.test_data)  # type: ignore[arg-type]  # noqa: SLF001
         if test_y.dtype.kind not in {"i", "u"}:
@@ -681,7 +681,7 @@ def _requires_fednetwork(problem: "BenchmarkProblem", metric_name: str) -> tuple
     return True, None
 
 
-def _server_metric_cost(agents: Sequence[AgentMetricsView], metric_name: str) -> costs.Cost:
+def _server_metric_cost(agents: Sequence[AgentMetricsView], metric_name: str) -> Cost:
     if not agents:
         raise ValueError(f"{metric_name} requires at least one client metrics view")
     return agents[0].cost
@@ -750,40 +750,6 @@ class ClientDriftFromServer(Metric):
         return [float(iop.norm(agent.x_history[iteration] - server_x)) for agent in agents]
 
 
-class ClientLossGap(Metric):
-    r"""
-    Gap between the worst and best client local-model loss.
-
-    Table:
-        Difference between the maximum and minimum client loss using the clients' final x.
-
-    Plot:
-        Client loss gap (y-axis) per iteration (x-axis).
-
-    Note:
-        Available only for :class:`~decent_bench.networks.FedNetwork`.
-
-    """
-
-    table_description: str = "client loss gap"
-    plot_description: str = "client loss gap"
-
-    def is_available(  # noqa: D102
-        self,
-        problem: "BenchmarkProblem",
-    ) -> tuple[bool, str | None]:
-        return _requires_fednetwork(problem, self.table_description)
-
-    def get_data_from_trial(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],
-        _: "BenchmarkProblem",
-        iteration: int,
-    ) -> tuple[float]:
-        losses = utils._losses(agents, iteration)  # noqa: SLF001
-        return (max(losses) - min(losses),)
-
-
 class SelectedParticipationFraction(Metric):
     r"""
     Fraction of client-rounds selected by the federated algorithm.
@@ -816,40 +782,6 @@ class SelectedParticipationFraction(Metric):
         if n_rounds == 0 or not agents:
             return (np.nan,)
         return (sum(agent.n_times_selected for agent in agents) / (n_rounds * len(agents)),)
-
-
-class EffectiveParticipationFraction(Metric):
-    r"""
-    Fraction of client-rounds whose update was included in server aggregation.
-
-    Table:
-        Average effective participation fraction over observed rounds.
-
-    Note:
-        Available only for :class:`~decent_bench.networks.FedNetwork`.
-
-    """
-
-    table_description: str = "effective participation fraction"
-    plot_description: str = "effective participation fraction"
-    can_diverge: bool = False
-
-    def is_available(  # noqa: D102
-        self,
-        problem: "BenchmarkProblem",
-    ) -> tuple[bool, str | None]:
-        return _requires_fednetwork(problem, self.table_description)
-
-    def get_data_from_trial(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],
-        _: "BenchmarkProblem",
-        __: int,
-    ) -> tuple[float]:
-        n_rounds = utils._observed_rounds(agents)  # noqa: SLF001
-        if n_rounds == 0 or not agents:
-            return (np.nan,)
-        return (sum(agent.n_times_update_received_by_server for agent in agents) / (n_rounds * len(agents)),)
 
 
 class TotalCommunication(Metric):
@@ -1041,7 +973,7 @@ class ServerMSE(Metric):
             return False, reason
         if getattr(problem, "test_data", None) is None:
             return False, "requires problem.test_data"
-        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
+        if not all(isinstance(a.cost, EmpiricalRiskCost) for a in problem.network.agents()):
             return False, "server MSE only applies if all clients have EmpiricalRiskCost"
         return True, None
 
@@ -1111,7 +1043,7 @@ class ServerAccuracy(Metric):
             return False, reason
         if getattr(problem, "test_data", None) is None:
             return False, "requires problem.test_data"
-        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
+        if not all(isinstance(a.cost, EmpiricalRiskCost) for a in problem.network.agents()):
             return False, "server accuracy only applies if all clients have EmpiricalRiskCost"
         _, test_y = utils._split_dataset(problem.test_data)  # type: ignore[arg-type] # noqa: SLF001
         if test_y.dtype.kind not in {"i", "u"}:
@@ -1153,52 +1085,6 @@ class ServerAccuracy(Metric):
             (i, utils._accuracy_at_x(cost, server.x_history[i], problem))  # noqa: SLF001
             for i in utils.all_sorted_iterations([server])
         ]
-
-
-class ClientAccuracyGap(Metric):
-    r"""
-    Gap between the best and worst client local-model accuracy.
-
-    Table:
-        Difference between the maximum and minimum client accuracy using the clients' final x.
-
-    Plot:
-        Client accuracy gap (y-axis) per iteration (x-axis).
-
-    Note:
-        Available only for :class:`~decent_bench.networks.FedNetwork` with ``problem.test_data``, empirical-risk
-        client costs, and integer-valued targets.
-
-    """
-
-    table_description: str = "client accuracy gap"
-    plot_description: str = "client accuracy gap"
-    can_diverge: bool = False
-
-    def is_available(  # noqa: D102
-        self,
-        problem: "BenchmarkProblem",
-    ) -> tuple[bool, str | None]:
-        available, reason = _requires_fednetwork(problem, self.table_description)
-        if not available:
-            return False, reason
-        if getattr(problem, "test_data", None) is None:
-            return False, "requires problem.test_data"
-        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
-            return False, "client accuracy gap only applies if all clients have EmpiricalRiskCost"
-        _, test_y = utils._split_dataset(problem.test_data)  # type: ignore[arg-type] # noqa: SLF001
-        if test_y.dtype.kind not in {"i", "u"}:
-            return False, f"client accuracy gap only applies for integer targets, dtype {test_y.dtype} found"
-        return True, None
-
-    def get_data_from_trial(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],
-        problem: "BenchmarkProblem",
-        iteration: int,
-    ) -> tuple[float]:
-        accuracies = utils._accuracy(agents, problem, iteration)  # noqa: SLF001
-        return (max(accuracies) - min(accuracies),)
 
 
 DEFAULT_TABLE_METRICS: list[Metric] = [
@@ -1294,9 +1180,7 @@ CLASSIFICATION_PLOT_METRICS: list[Metric] = CLASSIFICATION_TABLE_METRICS
 FEDERATED_TABLE_METRICS: list[Metric] = [
     *DEFAULT_TABLE_METRICS,
     ClientDriftFromServer([min, np.average, max]),
-    ClientLossGap([utils.single], x_log=False, y_log=False),
     SelectedParticipationFraction([utils.single], fmt=".2%", x_log=False, y_log=False),
-    EffectiveParticipationFraction([utils.single], fmt=".2%", x_log=False, y_log=False),
     TotalCommunication([utils.single]),
     UplinkMessages([utils.single]),
     DownlinkMessages([utils.single]),
@@ -1305,9 +1189,7 @@ FEDERATED_TABLE_METRICS: list[Metric] = [
 """
 - :const:`DEFAULT_TABLE_METRICS`
 - :class:`ClientDriftFromServer` - min, average, max
-- :class:`ClientLossGap` - single value
 - :class:`SelectedParticipationFraction` - single value with percentage format
-- :class:`EffectiveParticipationFraction` - single value with percentage format
 - :class:`TotalCommunication` - single value
 - :class:`UplinkMessages` - single value
 - :class:`DownlinkMessages` - single value
@@ -1319,12 +1201,10 @@ FEDERATED_TABLE_METRICS: list[Metric] = [
 FEDERATED_PLOT_METRICS: list[Metric] = [
     *DEFAULT_PLOT_METRICS,
     ClientDriftFromServer([], x_log=False, y_log=True),
-    ClientLossGap([], x_log=False, y_log=False),
 ]
 """
 - :const:`DEFAULT_PLOT_METRICS`
 - :class:`ClientDriftFromServer` (semi-log)
-- :class:`ClientLossGap` (linear)
 
 :meta hide-value:
 """
@@ -1354,12 +1234,10 @@ FEDERATED_REGRESSION_PLOT_METRICS: list[Metric] = [
 FEDERATED_CLASSIFICATION_TABLE_METRICS: list[Metric] = [
     *CLASSIFICATION_TABLE_METRICS,
     ServerAccuracy([utils.single], fmt=".2%", x_log=False, y_log=False),
-    ClientAccuracyGap([utils.single], fmt=".2%", x_log=False, y_log=False),
 ]
 """
 - :const:`CLASSIFICATION_TABLE_METRICS`
 - :class:`ServerAccuracy` - single value with percentage format
-- :class:`ClientAccuracyGap` - single value with percentage format
 
 :meta hide-value:
 """
@@ -1367,12 +1245,10 @@ FEDERATED_CLASSIFICATION_TABLE_METRICS: list[Metric] = [
 FEDERATED_CLASSIFICATION_PLOT_METRICS: list[Metric] = [
     *CLASSIFICATION_PLOT_METRICS,
     ServerAccuracy([], fmt=".2%", x_log=False, y_log=False),
-    ClientAccuracyGap([], fmt=".2%", x_log=False, y_log=False),
 ]
 """
 - :const:`CLASSIFICATION_PLOT_METRICS`
 - :class:`ServerAccuracy` (linear)
-- :class:`ClientAccuracyGap` (linear)
 
 :meta hide-value:
 """

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -52,7 +52,8 @@ class Regret(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        return (utils._regret(agents, problem, iteration),)  # noqa: SLF001
+        clients = [agent for agent in agents if not agent.is_server]
+        return (utils._regret(clients, problem, iteration),)  # noqa: SLF001
 
 
 class GradientNorm(Metric):
@@ -80,7 +81,8 @@ class GradientNorm(Metric):
         _: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        return (utils._gradient_norm(agents, iteration),)  # noqa: SLF001
+        clients = [agent for agent in agents if not agent.is_server]
+        return (utils._gradient_norm(clients, iteration),)  # noqa: SLF001
 
 
 class XError(Metric):
@@ -124,7 +126,7 @@ class XError(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        return [utils._x_error(a, problem, iteration) for a in agents]  # noqa: SLF001
+        return [utils._x_error(a, problem, iteration) for a in agents if not a.is_server]  # noqa: SLF001
 
 
 class ConsensusError(Metric):
@@ -160,8 +162,9 @@ class ConsensusError(Metric):
         iteration: int,
     ) -> list[float]:
 
-        x_mean = utils.x_mean(tuple(agents), iteration)
-        return [float(iop.norm(x_mean - a.x_history[iteration])) for a in agents]
+        clients = [agent for agent in agents if not agent.is_server]
+        x_mean = utils.x_mean(tuple(clients), iteration)
+        return [float(iop.norm(x_mean - a.x_history[iteration])) for a in clients]
 
 
 class XUpdates(Metric):
@@ -187,7 +190,7 @@ class XUpdates(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_x_updates for a in agents]
+        return [a.n_x_updates for a in agents if not a.is_server]
 
 
 class FunctionCalls(Metric):
@@ -217,7 +220,7 @@ class FunctionCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_function_calls for a in agents]
+        return [a.n_function_calls for a in agents if not a.is_server]
 
 
 class GradientCalls(Metric):
@@ -247,7 +250,7 @@ class GradientCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_gradient_calls for a in agents]
+        return [a.n_gradient_calls for a in agents if not a.is_server]
 
 
 class HessianCalls(Metric):
@@ -277,7 +280,7 @@ class HessianCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_hessian_calls for a in agents]
+        return [a.n_hessian_calls for a in agents if not a.is_server]
 
 
 class ProximalCalls(Metric):
@@ -303,7 +306,7 @@ class ProximalCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_proximal_calls for a in agents]
+        return [a.n_proximal_calls for a in agents if not a.is_server]
 
 
 class SentMessages(Metric):
@@ -329,7 +332,7 @@ class SentMessages(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_sent_messages for a in agents]
+        return [a.n_sent_messages for a in agents if not a.is_server]
 
 
 class ReceivedMessages(Metric):
@@ -355,7 +358,7 @@ class ReceivedMessages(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_received_messages for a in agents]
+        return [a.n_received_messages for a in agents if not a.is_server]
 
 
 class SentMessagesDropped(Metric):
@@ -381,7 +384,7 @@ class SentMessagesDropped(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_sent_messages_dropped for a in agents]
+        return [a.n_sent_messages_dropped for a in agents if not a.is_server]
 
 
 class Accuracy(Metric):
@@ -439,7 +442,8 @@ class Accuracy(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        return utils._accuracy(agents, problem, iteration)  # noqa: SLF001
+        clients = [agent for agent in agents if not agent.is_server]
+        return utils._accuracy(clients, problem, iteration)  # noqa: SLF001
 
 
 class MSE(Metric):
@@ -492,7 +496,8 @@ class MSE(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        return utils._mse(agents, problem, iteration)  # noqa: SLF001
+        clients = [agent for agent in agents if not agent.is_server]
+        return utils._mse(clients, problem, iteration)  # noqa: SLF001
 
 
 class Precision(Metric):
@@ -550,7 +555,8 @@ class Precision(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        return utils._precision(agents, problem, iteration)  # noqa: SLF001
+        clients = [agent for agent in agents if not agent.is_server]
+        return utils._precision(clients, problem, iteration)  # noqa: SLF001
 
 
 class Recall(Metric):
@@ -608,7 +614,8 @@ class Recall(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        return utils._recall(agents, problem, iteration)  # noqa: SLF001
+        clients = [agent for agent in agents if not agent.is_server]
+        return utils._recall(clients, problem, iteration)  # noqa: SLF001
 
 
 class Loss(Metric):
@@ -636,7 +643,8 @@ class Loss(Metric):
         _: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        return utils._losses(agents, iteration)  # noqa: SLF001
+        clients = [agent for agent in agents if not agent.is_server]
+        return utils._losses(clients, iteration)  # noqa: SLF001
 
 
 def _requires_fednetwork(problem: "BenchmarkProblem", metric_name: str) -> tuple[bool, str | None]:
@@ -646,9 +654,10 @@ def _requires_fednetwork(problem: "BenchmarkProblem", metric_name: str) -> tuple
 
 
 def _server_metric_cost(agents: Sequence[AgentMetricsView], metric_name: str) -> Cost:
-    if not agents:
+    clients = [agent for agent in agents if not agent.is_server]
+    if not clients:
         raise ValueError(f"{metric_name} requires at least one client metrics view")
-    return agents[0].cost
+    return clients[0].cost
 
 
 class ClientDriftFromServer(Metric):
@@ -684,29 +693,15 @@ class ClientDriftFromServer(Metric):
 
     def get_data_from_trial(  # noqa: D102
         self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
-        problem: "BenchmarkProblem",  # noqa: ARG002
-        iteration: int,  # noqa: ARG002
-    ) -> list[float]:
-        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
-
-    def get_federated_table_data(  # noqa: D102
-        self,
         agents: Sequence[AgentMetricsView],
-        server: AgentMetricsView,
         problem: "BenchmarkProblem",  # noqa: ARG002
+        iteration: int,
     ) -> list[float]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        return self._drifts(agents, server, -1)
-
-    def get_federated_plot_data(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],
-        server: AgentMetricsView,
-        problem: "BenchmarkProblem",  # noqa: ARG002
-    ) -> list[tuple[float, float]]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        return [(i, float(np.mean(self._drifts(agents, server, i)))) for i in utils.all_sorted_iterations(agents)]
+        servers = [agent for agent in agents if agent.is_server]
+        if len(servers) != 1:
+            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
+        clients = [agent for agent in agents if not agent.is_server]
+        return self._drifts(clients, servers[0], iteration)
 
     @staticmethod
     def _drifts(agents: Sequence[AgentMetricsView], server: AgentMetricsView, iteration: int) -> list[float]:
@@ -742,10 +737,11 @@ class SelectedParticipationFraction(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> tuple[float]:
-        n_rounds = utils._observed_rounds(agents)  # noqa: SLF001
-        if n_rounds == 0 or not agents:
+        clients = [agent for agent in agents if not agent.is_server]
+        n_rounds = utils._observed_rounds(clients)  # noqa: SLF001
+        if n_rounds == 0 or not clients:
             return (np.nan,)
-        return (sum(agent.n_times_selected for agent in agents) / (n_rounds * len(agents)),)
+        return (sum(agent.n_times_selected for agent in clients) / (n_rounds * len(clients)),)
 
 
 class TotalCommunication(Metric):
@@ -773,20 +769,13 @@ class TotalCommunication(Metric):
 
     def get_data_from_trial(  # noqa: D102
         self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        agents: Sequence[AgentMetricsView],
         problem: "BenchmarkProblem",  # noqa: ARG002
         iteration: int,  # noqa: ARG002
     ) -> tuple[int]:
-        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
-
-    def get_federated_table_data(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],
-        server: AgentMetricsView,
-        problem: "BenchmarkProblem",  # noqa: ARG002
-    ) -> tuple[int]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        return (sum(agent.n_sent_messages for agent in agents) + server.n_sent_messages,)
+        if not any(agent.is_server for agent in agents):
+            raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
+        return (sum(agent.n_sent_messages for agent in agents),)
 
 
 class ServerMSE(Metric):
@@ -824,39 +813,32 @@ class ServerMSE(Metric):
 
     def get_data_from_trial(  # noqa: D102
         self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
-        problem: "BenchmarkProblem",  # noqa: ARG002
-        iteration: int,  # noqa: ARG002
-    ) -> tuple[float]:
-        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
-
-    def get_federated_table_data(  # noqa: D102
-        self,
         agents: Sequence[AgentMetricsView],
-        server: AgentMetricsView,
         problem: "BenchmarkProblem",
+        iteration: int,
     ) -> tuple[float]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        return (
-            utils._mse_at_x(  # noqa: SLF001
-                _server_metric_cost(agents, self.table_description),
-                server.x_history[-1],
-                problem,
-            ),
-        )
+        servers = [agent for agent in agents if agent.is_server]
+        if len(servers) != 1:
+            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
+        cost = _server_metric_cost(agents, self.table_description)
+        return (utils._mse_at_x(cost, servers[0].x_history[iteration], problem),)  # noqa: SLF001
 
-    def get_federated_plot_data(  # noqa: D102
+    def get_plot_data(
         self,
         agents: Sequence[AgentMetricsView],
-        server: AgentMetricsView,
         problem: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        cost = _server_metric_cost(agents, self.table_description)
-        return [
-            (i, utils._mse_at_x(cost, server.x_history[i], problem))  # noqa: SLF001
-            for i in utils.all_sorted_iterations([server])
-        ]
+        """
+        Extract server MSE trajectory.
+
+        Raises:
+            ValueError: if there is not exactly one server metrics view.
+
+        """
+        servers = [agent for agent in agents if agent.is_server]
+        if len(servers) != 1:
+            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
+        return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([servers[0]])]
 
 
 class ServerAccuracy(Metric):
@@ -897,39 +879,32 @@ class ServerAccuracy(Metric):
 
     def get_data_from_trial(  # noqa: D102
         self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
-        problem: "BenchmarkProblem",  # noqa: ARG002
-        iteration: int,  # noqa: ARG002
-    ) -> tuple[float]:
-        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
-
-    def get_federated_table_data(  # noqa: D102
-        self,
         agents: Sequence[AgentMetricsView],
-        server: AgentMetricsView,
         problem: "BenchmarkProblem",
+        iteration: int,
     ) -> tuple[float]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        return (
-            utils._accuracy_at_x(  # noqa: SLF001
-                _server_metric_cost(agents, self.table_description),
-                server.x_history[-1],
-                problem,
-            ),
-        )
+        servers = [agent for agent in agents if agent.is_server]
+        if len(servers) != 1:
+            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
+        cost = _server_metric_cost(agents, self.table_description)
+        return (utils._accuracy_at_x(cost, servers[0].x_history[iteration], problem),)  # noqa: SLF001
 
-    def get_federated_plot_data(  # noqa: D102
+    def get_plot_data(
         self,
         agents: Sequence[AgentMetricsView],
-        server: AgentMetricsView,
         problem: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        cost = _server_metric_cost(agents, self.table_description)
-        return [
-            (i, utils._accuracy_at_x(cost, server.x_history[i], problem))  # noqa: SLF001
-            for i in utils.all_sorted_iterations([server])
-        ]
+        """
+        Extract server accuracy trajectory.
+
+        Raises:
+            ValueError: if there is not exactly one server metrics view.
+
+        """
+        servers = [agent for agent in agents if agent.is_server]
+        if len(servers) != 1:
+            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
+        return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([servers[0]])]
 
 
 _BASE_TABLE_METRICS: list[Metric] = [

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -52,7 +52,7 @@ class Regret(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        agent_views = utils.non_server_views(agents)
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         return (utils._regret(agent_views, problem, iteration),)  # noqa: SLF001
 
 
@@ -81,7 +81,7 @@ class GradientNorm(Metric):
         _: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        agent_views = utils.non_server_views(agents)
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         return (utils._gradient_norm(agent_views, iteration),)  # noqa: SLF001
 
 
@@ -126,7 +126,7 @@ class XError(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        return [utils._x_error(a, problem, iteration) for a in utils.non_server_views(agents)]  # noqa: SLF001
+        return [utils._x_error(a, problem, iteration) for a in utils._non_server_views(tuple(agents))]  # noqa: SLF001
 
 
 class ConsensusError(Metric):
@@ -162,7 +162,7 @@ class ConsensusError(Metric):
         iteration: int,
     ) -> list[float]:
 
-        agent_views = utils.non_server_views(agents)
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         x_mean = utils.x_mean(tuple(agent_views), iteration)
         return [float(iop.norm(x_mean - a.x_history[iteration])) for a in agent_views]
 
@@ -190,7 +190,7 @@ class XUpdates(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_x_updates for a in utils.non_server_views(agents)]
+        return [a.n_x_updates for a in utils._non_server_views(tuple(agents))]  # noqa: SLF001
 
 
 class FunctionCalls(Metric):
@@ -220,7 +220,7 @@ class FunctionCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_function_calls for a in utils.non_server_views(agents)]
+        return [a.n_function_calls for a in utils._non_server_views(tuple(agents))]  # noqa: SLF001
 
 
 class GradientCalls(Metric):
@@ -250,7 +250,7 @@ class GradientCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_gradient_calls for a in utils.non_server_views(agents)]
+        return [a.n_gradient_calls for a in utils._non_server_views(tuple(agents))]  # noqa: SLF001
 
 
 class HessianCalls(Metric):
@@ -280,7 +280,7 @@ class HessianCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_hessian_calls for a in utils.non_server_views(agents)]
+        return [a.n_hessian_calls for a in utils._non_server_views(tuple(agents))]  # noqa: SLF001
 
 
 class ProximalCalls(Metric):
@@ -306,7 +306,7 @@ class ProximalCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_proximal_calls for a in utils.non_server_views(agents)]
+        return [a.n_proximal_calls for a in utils._non_server_views(tuple(agents))]  # noqa: SLF001
 
 
 class SentMessages(Metric):
@@ -442,7 +442,7 @@ class Accuracy(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = utils.non_server_views(agents)
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         return utils._accuracy(agent_views, problem, iteration)  # noqa: SLF001
 
 
@@ -496,7 +496,7 @@ class MSE(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = utils.non_server_views(agents)
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         return utils._mse(agent_views, problem, iteration)  # noqa: SLF001
 
 
@@ -555,7 +555,7 @@ class Precision(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = utils.non_server_views(agents)
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         return utils._precision(agent_views, problem, iteration)  # noqa: SLF001
 
 
@@ -614,7 +614,7 @@ class Recall(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = utils.non_server_views(agents)
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         return utils._recall(agent_views, problem, iteration)  # noqa: SLF001
 
 
@@ -643,7 +643,7 @@ class Loss(Metric):
         _: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        agent_views = utils.non_server_views(agents)
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         return utils._losses(agent_views, iteration)  # noqa: SLF001
 
 
@@ -654,7 +654,7 @@ def _requires_fednetwork(problem: "BenchmarkProblem", metric_name: str) -> tuple
 
 
 def _server_metric_cost(agents: Sequence[AgentMetricsView], metric_name: str) -> Cost:
-    agent_views = utils.non_server_views(agents)
+    agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
     if not agent_views:
         raise ValueError(f"{metric_name} requires at least one client metrics view")
     return agent_views[0].cost
@@ -697,8 +697,8 @@ class ClientDriftFromServer(Metric):
         problem: "BenchmarkProblem",  # noqa: ARG002
         iteration: int,
     ) -> list[float]:
-        server = utils.server_view(agents)
-        return utils.drifts(utils.non_server_views(agents), server, iteration)
+        server = utils._server_view(tuple(agents))  # noqa: SLF001
+        return utils._drifts(utils._non_server_views(tuple(agents)), server, iteration)  # noqa: SLF001
 
     def get_plot_data(
         self,
@@ -706,10 +706,11 @@ class ClientDriftFromServer(Metric):
         _: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
         """Extract client drift trajectory."""
-        server = utils.server_view(agents)
-        agent_views = utils.non_server_views(agents)
+        server = utils._server_view(tuple(agents))  # noqa: SLF001
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         return [
-            (i, float(np.mean(utils.drifts(agent_views, server, i)))) for i in utils.all_sorted_iterations([server])
+            (i, float(np.mean(utils._drifts(agent_views, server, i))))  # noqa: SLF001
+            for i in utils.all_sorted_iterations([server])
         ]
 
 
@@ -741,7 +742,7 @@ class FractionSelectedClients(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> tuple[float]:
-        agent_views = utils.non_server_views(agents)
+        agent_views = utils._non_server_views(tuple(agents))  # noqa: SLF001
         n_rounds = utils._observed_rounds(agent_views)  # noqa: SLF001
         if n_rounds == 0 or not agent_views:
             return (np.nan,)
@@ -787,7 +788,7 @@ class ServerMSE(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        server = utils.server_view(agents)
+        server = utils._server_view(tuple(agents))  # noqa: SLF001
         cost = _server_metric_cost(agents, self.table_description)
         return (utils._mse_at_x(cost, server.x_history[iteration], problem),)  # noqa: SLF001
 
@@ -797,7 +798,7 @@ class ServerMSE(Metric):
         problem: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
         """Extract server MSE trajectory."""
-        server = utils.server_view(agents)
+        server = utils._server_view(tuple(agents))  # noqa: SLF001
         return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([server])]
 
 
@@ -832,7 +833,7 @@ class ServerAccuracy(Metric):
             return False, "requires problem.test_data"
         if not all(isinstance(a.cost, EmpiricalRiskCost) for a in problem.network.agents()):
             return False, "server accuracy only applies if all clients have EmpiricalRiskCost"
-        _, test_y = utils._split_dataset(problem.test_data)  # type: ignore[arg-type] # noqa: SLF001
+        _, test_y = utils._split_dataset(problem.test_data)  # type: ignore[arg-type]  # noqa: SLF001
         if test_y.dtype.kind not in {"i", "u"}:
             return False, f"server accuracy only applies for integer targets, dtype {test_y.dtype} found"
         return True, None
@@ -843,7 +844,7 @@ class ServerAccuracy(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        server = utils.server_view(agents)
+        server = utils._server_view(tuple(agents))  # noqa: SLF001
         cost = _server_metric_cost(agents, self.table_description)
         return (utils._accuracy_at_x(cost, server.x_history[iteration], problem),)  # noqa: SLF001
 
@@ -853,7 +854,7 @@ class ServerAccuracy(Metric):
         problem: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
         """Extract server accuracy trajectory."""
-        server = utils.server_view(agents)
+        server = utils._server_view(tuple(agents))  # noqa: SLF001
         return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([server])]
 
 

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -9,8 +9,8 @@ import decent_bench.metrics.metric_utils as utils
 import decent_bench.utils.interoperability as iop
 from decent_bench import costs
 from decent_bench.agents import AgentMetricsView
-from decent_bench.costs import EmpiricalRiskCost
 from decent_bench.metrics._metric import Metric
+from decent_bench.networks import FedNetwork
 
 if TYPE_CHECKING:
     from decent_bench.benchmark import BenchmarkProblem
@@ -32,6 +32,10 @@ class Regret(Metric):
 
     Note:
         Available only when ``problem.x_optimal`` is provided.
+
+    Note:
+        For :class:`~decent_bench.networks.FedNetwork`, this metric is evaluated at the mean client model, not at the
+        server model.
 
     """
 
@@ -69,6 +73,10 @@ class GradientNorm(Metric):
 
     .. include:: snippets/global_gradient_optimality.rst
 
+    Note:
+        For :class:`~decent_bench.networks.FedNetwork`, this metric is evaluated at the mean client model, not at the
+        server model.
+
     """
 
     table_description: str = "gradient norm"
@@ -104,6 +112,10 @@ class XError(Metric):
 
     Note:
         Available only when ``problem.x_optimal`` is provided.
+
+    Note:
+        For :class:`~decent_bench.networks.FedNetwork`, this metric measures the error of client local models, not the
+        server model.
 
     """
 
@@ -147,6 +159,10 @@ class ConsensusError(Metric):
 
     .. seealso::
         :class:`~decent_bench.metrics.runtime_library.RuntimeConsensusError` for the runtime version.
+
+    Note:
+        For :class:`~decent_bench.networks.FedNetwork`, this metric measures client spread around the client mean. It
+        is not client drift from the server model.
 
     """
 
@@ -414,6 +430,10 @@ class Accuracy(Metric):
         - all agent costs are :class:`~decent_bench.costs.EmpiricalRiskCost`,
         - target labels are integer-valued.
 
+    Note:
+        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
+        model.
+
     """
 
     table_description: str = "accuracy"
@@ -470,6 +490,10 @@ class MSE(Metric):
         Available only when ``problem.test_data`` is provided and all agent costs are
         :class:`~decent_bench.costs.EmpiricalRiskCost`.
 
+    Note:
+        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
+        model.
+
     """
 
     table_description: str = "mse"
@@ -524,6 +548,10 @@ class Precision(Metric):
         - ``problem.test_data`` is provided,
         - all agent costs are :class:`~decent_bench.costs.EmpiricalRiskCost`,
         - target labels are integer-valued.
+
+    Note:
+        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
+        model.
 
     """
 
@@ -583,6 +611,10 @@ class Recall(Metric):
         - all agent costs are :class:`~decent_bench.costs.EmpiricalRiskCost`,
         - target labels are integer-valued.
 
+    Note:
+        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
+        model.
+
     """
 
     table_description: str = "recall"
@@ -624,6 +656,10 @@ class Loss(Metric):
         Loss is calculated as the mean loss across agents, where each agent's loss is calculated using its
         recorded x at that iteration.
 
+    Note:
+        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
+        model.
+
     """
 
     table_description: str = "loss"
@@ -636,12 +672,533 @@ class Loss(Metric):
         _: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
+        return utils._losses(agents, iteration)  # noqa: SLF001
+
+
+def _requires_fednetwork(problem: "BenchmarkProblem", metric_name: str) -> tuple[bool, str | None]:
+    if not isinstance(problem.network, FedNetwork):
+        return False, f"{metric_name} only applies to FedNetwork"
+    return True, None
+
+
+def _server_metric_cost(agents: Sequence[AgentMetricsView], metric_name: str) -> costs.Cost:
+    if not agents:
+        raise ValueError(f"{metric_name} requires at least one client metrics view")
+    return agents[0].cost
+
+
+class ClientDriftFromServer(Metric):
+    r"""
+    Distance between client local models and the server model.
+
+    Table:
+        Distance of the clients' final states from the final server state.
+
+    Plot:
+        Client drift from server (y-axis) per iteration (x-axis).
+
+    The client drift per client is defined as:
+
+    .. math::
+        \{ \|\mathbf{x}_i - \mathbf{x}_s\|, \|\mathbf{x}_j - \mathbf{x}_s\|, ... \}
+
+    where :math:`\mathbf{x}_s` is the current server state.
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork`.
+
+    """
+
+    table_description: str = "client drift from server"
+    plot_description: str = "client drift from server"
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        return _requires_fednetwork(problem, self.table_description)
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        problem: "BenchmarkProblem",  # noqa: ARG002
+        iteration: int,  # noqa: ARG002
+    ) -> list[float]:
+        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
+
+    def get_federated_table_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",  # noqa: ARG002
+    ) -> list[float]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        return self._drifts(agents, server, -1)
+
+    def get_federated_plot_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",  # noqa: ARG002
+    ) -> list[tuple[float, float]]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        return [(i, float(np.mean(self._drifts(agents, server, i)))) for i in utils.all_sorted_iterations(agents)]
+
+    @staticmethod
+    def _drifts(agents: Sequence[AgentMetricsView], server: AgentMetricsView, iteration: int) -> list[float]:
+        server_x = server.x_history[iteration]
+        return [float(iop.norm(agent.x_history[iteration] - server_x)) for agent in agents]
+
+
+class ClientLossGap(Metric):
+    r"""
+    Gap between the worst and best client local-model loss.
+
+    Table:
+        Difference between the maximum and minimum client loss using the clients' final x.
+
+    Plot:
+        Client loss gap (y-axis) per iteration (x-axis).
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork`.
+
+    """
+
+    table_description: str = "client loss gap"
+    plot_description: str = "client loss gap"
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        return _requires_fednetwork(problem, self.table_description)
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        _: "BenchmarkProblem",
+        iteration: int,
+    ) -> tuple[float]:
+        losses = utils._losses(agents, iteration)  # noqa: SLF001
+        return (max(losses) - min(losses),)
+
+
+class SelectedParticipationFraction(Metric):
+    r"""
+    Fraction of client-rounds selected by the federated algorithm.
+
+    Table:
+        Average selected participation fraction over observed rounds.
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork`.
+
+    """
+
+    table_description: str = "selected participation fraction"
+    plot_description: str = "selected participation fraction"
+    can_diverge: bool = False
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        return _requires_fednetwork(problem, self.table_description)
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        _: "BenchmarkProblem",
+        __: int,
+    ) -> tuple[float]:
+        n_rounds = utils._observed_rounds(agents)  # noqa: SLF001
+        if n_rounds == 0 or not agents:
+            return (np.nan,)
+        return (sum(agent.n_times_selected for agent in agents) / (n_rounds * len(agents)),)
+
+
+class EffectiveParticipationFraction(Metric):
+    r"""
+    Fraction of client-rounds whose update was included in server aggregation.
+
+    Table:
+        Average effective participation fraction over observed rounds.
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork`.
+
+    """
+
+    table_description: str = "effective participation fraction"
+    plot_description: str = "effective participation fraction"
+    can_diverge: bool = False
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        return _requires_fednetwork(problem, self.table_description)
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        _: "BenchmarkProblem",
+        __: int,
+    ) -> tuple[float]:
+        n_rounds = utils._observed_rounds(agents)  # noqa: SLF001
+        if n_rounds == 0 or not agents:
+            return (np.nan,)
+        return (sum(agent.n_times_update_received_by_server for agent in agents) / (n_rounds * len(agents)),)
+
+
+class TotalCommunication(Metric):
+    r"""
+    Total sent message attempts by clients and the server.
+
+    Table:
+        Sum of client sent messages and server sent messages.
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork`.
+
+    """
+
+    table_description: str = "total communication"
+    plot_description: str = "total communication"
+    can_diverge: bool = False
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        return _requires_fednetwork(problem, self.table_description)
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        problem: "BenchmarkProblem",  # noqa: ARG002
+        iteration: int,  # noqa: ARG002
+    ) -> tuple[float]:
+        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
+
+    def get_federated_table_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",  # noqa: ARG002
+    ) -> tuple[float]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        return (sum(agent.n_sent_messages for agent in agents) + server.n_sent_messages,)
+
+
+class UplinkMessages(Metric):
+    r"""
+    Number of client-to-server messages received by the server.
+
+    Table:
+        Server received messages.
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork`.
+
+    """
+
+    table_description: str = "uplink messages"
+    plot_description: str = "uplink messages"
+    can_diverge: bool = False
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        return _requires_fednetwork(problem, self.table_description)
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        problem: "BenchmarkProblem",  # noqa: ARG002
+        iteration: int,  # noqa: ARG002
+    ) -> tuple[int]:
+        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
+
+    def get_federated_table_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",  # noqa: ARG002
+    ) -> tuple[int]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        return (server.n_received_messages,)
+
+
+class DownlinkMessages(Metric):
+    r"""
+    Number of server-to-client message attempts sent by the server.
+
+    Table:
+        Server sent messages.
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork`.
+
+    """
+
+    table_description: str = "downlink messages"
+    plot_description: str = "downlink messages"
+    can_diverge: bool = False
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        return _requires_fednetwork(problem, self.table_description)
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        problem: "BenchmarkProblem",  # noqa: ARG002
+        iteration: int,  # noqa: ARG002
+    ) -> tuple[int]:
+        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
+
+    def get_federated_table_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",  # noqa: ARG002
+    ) -> tuple[int]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        return (server.n_sent_messages,)
+
+
+class DownlinkMessagesDropped(Metric):
+    r"""
+    Number of server-to-client message attempts dropped.
+
+    Table:
+        Server sent messages dropped.
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork`.
+
+    """
+
+    table_description: str = "downlink messages dropped"
+    plot_description: str = "downlink messages dropped"
+    can_diverge: bool = False
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        return _requires_fednetwork(problem, self.table_description)
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        problem: "BenchmarkProblem",  # noqa: ARG002
+        iteration: int,  # noqa: ARG002
+    ) -> tuple[int]:
+        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
+
+    def get_federated_table_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",  # noqa: ARG002
+    ) -> tuple[int]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        return (server.n_sent_messages_dropped,)
+
+
+class ServerMSE(Metric):
+    r"""
+    Mean squared error of the server model's predictions.
+
+    Table:
+        Mean squared error of the final server x.
+
+    Plot:
+        Server MSE (y-axis) per iteration (x-axis).
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork` with ``problem.test_data`` and empirical-risk
+        client costs.
+
+    """
+
+    table_description: str = "server mse"
+    plot_description: str = "server mse"
+    can_diverge: bool = False
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        available, reason = _requires_fednetwork(problem, self.table_description)
+        if not available:
+            return False, reason
+        if getattr(problem, "test_data", None) is None:
+            return False, "requires problem.test_data"
+        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
+            return False, "server MSE only applies if all clients have EmpiricalRiskCost"
+        return True, None
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        problem: "BenchmarkProblem",  # noqa: ARG002
+        iteration: int,  # noqa: ARG002
+    ) -> tuple[float]:
+        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
+
+    def get_federated_table_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",
+    ) -> tuple[float]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        return (
+            utils._mse_at_x(  # noqa: SLF001
+                _server_metric_cost(agents, self.table_description),
+                server.x_history[-1],
+                problem,
+            ),
+        )
+
+    def get_federated_plot_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",
+    ) -> list[tuple[float, float]]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        cost = _server_metric_cost(agents, self.table_description)
         return [
-            a.cost.function(a.x_history[iteration], indices="all")
-            if isinstance(a.cost, EmpiricalRiskCost)
-            else a.cost.function(a.x_history[iteration])
-            for a in agents
+            (i, utils._mse_at_x(cost, server.x_history[i], problem))  # noqa: SLF001
+            for i in utils.all_sorted_iterations([server])
         ]
+
+
+class ServerAccuracy(Metric):
+    r"""
+    Accuracy of the server model's predictions.
+
+    Table:
+        Accuracy of the final server x.
+
+    Plot:
+        Server accuracy (y-axis) per iteration (x-axis).
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork` with ``problem.test_data``, empirical-risk
+        client costs, and integer-valued targets.
+
+    """
+
+    table_description: str = "server accuracy"
+    plot_description: str = "server accuracy"
+    can_diverge: bool = False
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        available, reason = _requires_fednetwork(problem, self.table_description)
+        if not available:
+            return False, reason
+        if getattr(problem, "test_data", None) is None:
+            return False, "requires problem.test_data"
+        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
+            return False, "server accuracy only applies if all clients have EmpiricalRiskCost"
+        _, test_y = utils._split_dataset(problem.test_data)  # type: ignore[arg-type] # noqa: SLF001
+        if test_y.dtype.kind not in {"i", "u"}:
+            return False, f"server accuracy only applies for integer targets, dtype {test_y.dtype} found"
+        return True, None
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],  # noqa: ARG002
+        problem: "BenchmarkProblem",  # noqa: ARG002
+        iteration: int,  # noqa: ARG002
+    ) -> tuple[float]:
+        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
+
+    def get_federated_table_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",
+    ) -> tuple[float]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        return (
+            utils._accuracy_at_x(  # noqa: SLF001
+                _server_metric_cost(agents, self.table_description),
+                server.x_history[-1],
+                problem,
+            ),
+        )
+
+    def get_federated_plot_data(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        server: AgentMetricsView,
+        problem: "BenchmarkProblem",
+    ) -> list[tuple[float, float]]:
+        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
+        cost = _server_metric_cost(agents, self.table_description)
+        return [
+            (i, utils._accuracy_at_x(cost, server.x_history[i], problem))  # noqa: SLF001
+            for i in utils.all_sorted_iterations([server])
+        ]
+
+
+class ClientAccuracyGap(Metric):
+    r"""
+    Gap between the best and worst client local-model accuracy.
+
+    Table:
+        Difference between the maximum and minimum client accuracy using the clients' final x.
+
+    Plot:
+        Client accuracy gap (y-axis) per iteration (x-axis).
+
+    Note:
+        Available only for :class:`~decent_bench.networks.FedNetwork` with ``problem.test_data``, empirical-risk
+        client costs, and integer-valued targets.
+
+    """
+
+    table_description: str = "client accuracy gap"
+    plot_description: str = "client accuracy gap"
+    can_diverge: bool = False
+
+    def is_available(  # noqa: D102
+        self,
+        problem: "BenchmarkProblem",
+    ) -> tuple[bool, str | None]:
+        available, reason = _requires_fednetwork(problem, self.table_description)
+        if not available:
+            return False, reason
+        if getattr(problem, "test_data", None) is None:
+            return False, "requires problem.test_data"
+        if not all(isinstance(a.cost, costs.EmpiricalRiskCost) for a in problem.network.agents()):
+            return False, "client accuracy gap only applies if all clients have EmpiricalRiskCost"
+        _, test_y = utils._split_dataset(problem.test_data)  # type: ignore[arg-type] # noqa: SLF001
+        if test_y.dtype.kind not in {"i", "u"}:
+            return False, f"client accuracy gap only applies for integer targets, dtype {test_y.dtype} found"
+        return True, None
+
+    def get_data_from_trial(  # noqa: D102
+        self,
+        agents: Sequence[AgentMetricsView],
+        problem: "BenchmarkProblem",
+        iteration: int,
+    ) -> tuple[float]:
+        accuracies = utils._accuracy(agents, problem, iteration)  # noqa: SLF001
+        return (max(accuracies) - min(accuracies),)
 
 
 DEFAULT_TABLE_METRICS: list[Metric] = [
@@ -730,6 +1287,92 @@ CLASSIFICATION_PLOT_METRICS: list[Metric] = CLASSIFICATION_TABLE_METRICS
 - :class:`Accuracy` (linear)
 - :class:`Precision` (linear)
 - :class:`Recall` (linear)
+
+:meta hide-value:
+"""
+
+FEDERATED_TABLE_METRICS: list[Metric] = [
+    *DEFAULT_TABLE_METRICS,
+    ClientDriftFromServer([min, np.average, max]),
+    ClientLossGap([utils.single], x_log=False, y_log=False),
+    SelectedParticipationFraction([utils.single], fmt=".2%", x_log=False, y_log=False),
+    EffectiveParticipationFraction([utils.single], fmt=".2%", x_log=False, y_log=False),
+    TotalCommunication([utils.single]),
+    UplinkMessages([utils.single]),
+    DownlinkMessages([utils.single]),
+    DownlinkMessagesDropped([utils.single]),
+]
+"""
+- :const:`DEFAULT_TABLE_METRICS`
+- :class:`ClientDriftFromServer` - min, average, max
+- :class:`ClientLossGap` - single value
+- :class:`SelectedParticipationFraction` - single value with percentage format
+- :class:`EffectiveParticipationFraction` - single value with percentage format
+- :class:`TotalCommunication` - single value
+- :class:`UplinkMessages` - single value
+- :class:`DownlinkMessages` - single value
+- :class:`DownlinkMessagesDropped` - single value
+
+:meta hide-value:
+"""
+
+FEDERATED_PLOT_METRICS: list[Metric] = [
+    *DEFAULT_PLOT_METRICS,
+    ClientDriftFromServer([], x_log=False, y_log=True),
+    ClientLossGap([], x_log=False, y_log=False),
+]
+"""
+- :const:`DEFAULT_PLOT_METRICS`
+- :class:`ClientDriftFromServer` (semi-log)
+- :class:`ClientLossGap` (linear)
+
+:meta hide-value:
+"""
+
+FEDERATED_REGRESSION_TABLE_METRICS: list[Metric] = [
+    *REGRESSION_TABLE_METRICS,
+    ServerMSE([utils.single], x_log=False, y_log=True),
+]
+"""
+- :const:`REGRESSION_TABLE_METRICS`
+- :class:`ServerMSE` - single value
+
+:meta hide-value:
+"""
+
+FEDERATED_REGRESSION_PLOT_METRICS: list[Metric] = [
+    *REGRESSION_PLOT_METRICS,
+    ServerMSE([], x_log=False, y_log=True),
+]
+"""
+- :const:`REGRESSION_PLOT_METRICS`
+- :class:`ServerMSE` (semi-log)
+
+:meta hide-value:
+"""
+
+FEDERATED_CLASSIFICATION_TABLE_METRICS: list[Metric] = [
+    *CLASSIFICATION_TABLE_METRICS,
+    ServerAccuracy([utils.single], fmt=".2%", x_log=False, y_log=False),
+    ClientAccuracyGap([utils.single], fmt=".2%", x_log=False, y_log=False),
+]
+"""
+- :const:`CLASSIFICATION_TABLE_METRICS`
+- :class:`ServerAccuracy` - single value with percentage format
+- :class:`ClientAccuracyGap` - single value with percentage format
+
+:meta hide-value:
+"""
+
+FEDERATED_CLASSIFICATION_PLOT_METRICS: list[Metric] = [
+    *CLASSIFICATION_PLOT_METRICS,
+    ServerAccuracy([], fmt=".2%", x_log=False, y_log=False),
+    ClientAccuracyGap([], fmt=".2%", x_log=False, y_log=False),
+]
+"""
+- :const:`CLASSIFICATION_PLOT_METRICS`
+- :class:`ServerAccuracy` (linear)
+- :class:`ClientAccuracyGap` (linear)
 
 :meta hide-value:
 """

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -21,7 +21,7 @@ class Regret(Metric):
     Global regret.
 
     Table:
-        Global regret using the agents' final x.
+        Global regret using the agents'/clients' final x.
 
     Plot:
         Global regret (y-axis) per iteration (x-axis).
@@ -32,10 +32,6 @@ class Regret(Metric):
 
     Note:
         Available only when ``problem.x_optimal`` is provided.
-
-    Note:
-        For :class:`~decent_bench.networks.FedNetwork`, this metric is evaluated at the mean client model, not at the
-        server model.
 
     """
 
@@ -64,7 +60,7 @@ class GradientNorm(Metric):
     Global gradient norm.
 
     Table:
-        Gradient norm using the agents' final x.
+        Gradient norm using the agents'/clients' final x.
 
     Plot:
         Gradient norm (y-axis) per iteration (x-axis).
@@ -72,10 +68,6 @@ class GradientNorm(Metric):
     Gradient norm is defined as:
 
     .. include:: snippets/global_gradient_optimality.rst
-
-    Note:
-        For :class:`~decent_bench.networks.FedNetwork`, this metric is evaluated at the mean client model, not at the
-        server model.
 
     """
 
@@ -96,26 +88,22 @@ class XError(Metric):
     Distance to optimal solution.
 
     Table:
-        Distance to optimal solution using the agents' final x.
+        Distance to optimal solution using the agents'/clients' final x.
 
     Plot:
         Distance to optimal solution (y-axis) per iteration (x-axis).
 
-    X error per agent is defined as:
+    X error per agent/client is defined as:
 
     .. math::
         \{ \|\mathbf{x}_i - \mathbf{x}^\star\|, \|\mathbf{x}_j - \mathbf{x}^\star\|, ... \}
 
-    where :math:`\mathbf{x}_i` is agent i's final x,
-    :math:`\mathbf{x}_j` is agent j's final x,
+    where :math:`\mathbf{x}_i` is agent/client i's final x,
+    :math:`\mathbf{x}_j` is agent/client j's final x,
     and :math:`\mathbf{x}^\star` is the optimal x defined in the *problem*.
 
     Note:
         Available only when ``problem.x_optimal`` is provided.
-
-    Note:
-        For :class:`~decent_bench.networks.FedNetwork`, this metric measures the error of client local models, not the
-        server model.
 
     """
 
@@ -144,25 +132,21 @@ class ConsensusError(Metric):
     Distance to consensus.
 
     Table:
-        Distance of the agents states from their current average.
+        Distance of the agents'/clients' states from their current average.
 
     Plot:
         Distance to consensus (y-axis) per iteration (x-axis).
 
-    The consensus error per agent is defined as:
+    The consensus error per agent/client is defined as:
 
     .. math::
         \{ \|\mathbf{x}_i - \bar{\mathbf{x}}\|, \|\mathbf{x}_j - \bar{\mathbf{x}}\|, ... \}
 
-    where :math:`\mathbf{x}_i` is agent i's current state,
-    :math:`\bar{\mathbf{x}}` is the average of all agents' states, and :math:`\| \cdot \|` is the 2-norm.
+    where :math:`\mathbf{x}_i` is agent/client i's current state,
+    :math:`\bar{\mathbf{x}}` is the average of all agents'/clients' states, and :math:`\| \cdot \|` is the 2-norm.
 
     .. seealso::
         :class:`~decent_bench.metrics.runtime_library.RuntimeConsensusError` for the runtime version.
-
-    Note:
-        For :class:`~decent_bench.networks.FedNetwork`, this metric measures client spread around the client mean. It
-        is not client drift from the server model.
 
     """
 
@@ -402,16 +386,16 @@ class SentMessagesDropped(Metric):
 
 class Accuracy(Metric):
     r"""
-    Accuracy of the agents' predictions.
+    Accuracy of the agents'/clients' predictions.
 
     Table:
-        Accuracy of the agents' final x.
+        Accuracy of the agents'/clients' final x.
 
     Plot:
         Accuracy (y-axis) per iteration (x-axis).
 
-        Accuracy is calculated as the mean accuracy across agents, where each agent's accuracy is calculated using its
-        recorded x at that iteration.
+        Accuracy is calculated as the mean accuracy across agents/clients, where each agent's/client's accuracy is
+        calculated using its recorded x at that iteration.
 
     Only available for :class:`~decent_bench.costs.EmpiricalRiskCost` and integer targets.
 
@@ -429,10 +413,6 @@ class Accuracy(Metric):
         - ``problem.test_data`` is provided,
         - all agent costs are :class:`~decent_bench.costs.EmpiricalRiskCost`,
         - target labels are integer-valued.
-
-    Note:
-        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
-        model.
 
     """
 
@@ -464,16 +444,16 @@ class Accuracy(Metric):
 
 class MSE(Metric):
     r"""
-    Mean squared error of the agents' predictions.
+    Mean squared error of the agents'/clients' predictions.
 
     Table:
-        Mean squared error of the agents' final x.
+        Mean squared error of the agents'/clients' final x.
 
     Plot:
         Mean Squared Error (MSE) (y-axis) per iteration (x-axis).
 
-        MSE is calculated as the mean MSE across agents, where each agent's MSE is calculated using its
-        recorded x at that iteration.
+        MSE is calculated as the mean MSE across agents/clients, where each agent's/client's MSE is calculated using
+        its recorded x at that iteration.
 
     Only available for :class:`~decent_bench.costs.EmpiricalRiskCost`.
 
@@ -489,10 +469,6 @@ class MSE(Metric):
     Note:
         Available only when ``problem.test_data`` is provided and all agent costs are
         :class:`~decent_bench.costs.EmpiricalRiskCost`.
-
-    Note:
-        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
-        model.
 
     """
 
@@ -521,16 +497,16 @@ class MSE(Metric):
 
 class Precision(Metric):
     r"""
-    Precision of the agents' predictions.
+    Precision of the agents'/clients' predictions.
 
     Table:
-        Precision of the agents' final x.
+        Precision of the agents'/clients' final x.
 
     Plot:
         Precision (y-axis) per iteration (x-axis).
 
-        Precision is calculated as the mean precision across agents, where each agent's precision is calculated using
-        its recorded x at that iteration.
+        Precision is calculated as the mean precision across agents/clients, where each agent's/client's precision is
+        calculated using its recorded x at that iteration.
 
     Only available for :class:`~decent_bench.costs.EmpiricalRiskCost` and integer targets.
 
@@ -548,10 +524,6 @@ class Precision(Metric):
         - ``problem.test_data`` is provided,
         - all agent costs are :class:`~decent_bench.costs.EmpiricalRiskCost`,
         - target labels are integer-valued.
-
-    Note:
-        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
-        model.
 
     """
 
@@ -583,16 +555,16 @@ class Precision(Metric):
 
 class Recall(Metric):
     r"""
-    Recall of the agents' predictions.
+    Recall of the agents'/clients' predictions.
 
     Table:
-        Recall of the agents' final x.
+        Recall of the agents'/clients' final x.
 
     Plot:
         Recall (y-axis) per iteration (x-axis).
 
-        Recall is calculated as the mean recall across agents, where each agent's recall is calculated using its
-        recorded x at that iteration.
+        Recall is calculated as the mean recall across agents/clients, where each agent's/client's recall is calculated
+        using its recorded x at that iteration.
 
     Only available for :class:`~decent_bench.costs.EmpiricalRiskCost` and integer targets.
 
@@ -610,10 +582,6 @@ class Recall(Metric):
         - ``problem.test_data`` is provided,
         - all agent costs are :class:`~decent_bench.costs.EmpiricalRiskCost`,
         - target labels are integer-valued.
-
-    Note:
-        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
-        model.
 
     """
 
@@ -645,20 +613,16 @@ class Recall(Metric):
 
 class Loss(Metric):
     r"""
-    Loss of the agents' predictions.
+    Loss of the agents'/clients' predictions.
 
     Table:
-        Loss of the agents' final x.
+        Loss of the agents'/clients' final x.
 
     Plot:
         Loss (y-axis) per iteration (x-axis).
 
-        Loss is calculated as the mean loss across agents, where each agent's loss is calculated using its
-        recorded x at that iteration.
-
-    Note:
-        For :class:`~decent_bench.networks.FedNetwork`, this metric evaluates client local models, not the server
-        model.
+        Loss is calculated as the mean loss across agents/clients, where each agent's/client's loss is calculated using
+        its recorded x at that iteration.
 
     """
 
@@ -789,10 +753,11 @@ class TotalCommunication(Metric):
     Total sent message attempts by clients and the server.
 
     Table:
-        Sum of client sent messages and server sent messages.
+        Sum of client sent messages and server sent messages, including messages dropped by the communication scheme.
 
     Note:
-        Available only for :class:`~decent_bench.networks.FedNetwork`.
+        Available only for :class:`~decent_bench.networks.FedNetwork`. For peer-to-peer networks, use the ``sum``
+        statistic of :class:`SentMessages`.
 
     """
 
@@ -811,7 +776,7 @@ class TotalCommunication(Metric):
         agents: Sequence[AgentMetricsView],  # noqa: ARG002
         problem: "BenchmarkProblem",  # noqa: ARG002
         iteration: int,  # noqa: ARG002
-    ) -> tuple[float]:
+    ) -> tuple[int]:
         raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
 
     def get_federated_table_data(  # noqa: D102
@@ -819,129 +784,9 @@ class TotalCommunication(Metric):
         agents: Sequence[AgentMetricsView],
         server: AgentMetricsView,
         problem: "BenchmarkProblem",  # noqa: ARG002
-    ) -> tuple[float]:
+    ) -> tuple[int]:
         server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
         return (sum(agent.n_sent_messages for agent in agents) + server.n_sent_messages,)
-
-
-class UplinkMessages(Metric):
-    r"""
-    Number of client-to-server messages received by the server.
-
-    Table:
-        Server received messages.
-
-    Note:
-        Available only for :class:`~decent_bench.networks.FedNetwork`.
-
-    """
-
-    table_description: str = "uplink messages"
-    plot_description: str = "uplink messages"
-    can_diverge: bool = False
-
-    def is_available(  # noqa: D102
-        self,
-        problem: "BenchmarkProblem",
-    ) -> tuple[bool, str | None]:
-        return _requires_fednetwork(problem, self.table_description)
-
-    def get_data_from_trial(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
-        problem: "BenchmarkProblem",  # noqa: ARG002
-        iteration: int,  # noqa: ARG002
-    ) -> tuple[int]:
-        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
-
-    def get_federated_table_data(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
-        server: AgentMetricsView,
-        problem: "BenchmarkProblem",  # noqa: ARG002
-    ) -> tuple[int]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        return (server.n_received_messages,)
-
-
-class DownlinkMessages(Metric):
-    r"""
-    Number of server-to-client message attempts sent by the server.
-
-    Table:
-        Server sent messages.
-
-    Note:
-        Available only for :class:`~decent_bench.networks.FedNetwork`.
-
-    """
-
-    table_description: str = "downlink messages"
-    plot_description: str = "downlink messages"
-    can_diverge: bool = False
-
-    def is_available(  # noqa: D102
-        self,
-        problem: "BenchmarkProblem",
-    ) -> tuple[bool, str | None]:
-        return _requires_fednetwork(problem, self.table_description)
-
-    def get_data_from_trial(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
-        problem: "BenchmarkProblem",  # noqa: ARG002
-        iteration: int,  # noqa: ARG002
-    ) -> tuple[int]:
-        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
-
-    def get_federated_table_data(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
-        server: AgentMetricsView,
-        problem: "BenchmarkProblem",  # noqa: ARG002
-    ) -> tuple[int]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        return (server.n_sent_messages,)
-
-
-class DownlinkMessagesDropped(Metric):
-    r"""
-    Number of server-to-client message attempts dropped.
-
-    Table:
-        Server sent messages dropped.
-
-    Note:
-        Available only for :class:`~decent_bench.networks.FedNetwork`.
-
-    """
-
-    table_description: str = "downlink messages dropped"
-    plot_description: str = "downlink messages dropped"
-    can_diverge: bool = False
-
-    def is_available(  # noqa: D102
-        self,
-        problem: "BenchmarkProblem",
-    ) -> tuple[bool, str | None]:
-        return _requires_fednetwork(problem, self.table_description)
-
-    def get_data_from_trial(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
-        problem: "BenchmarkProblem",  # noqa: ARG002
-        iteration: int,  # noqa: ARG002
-    ) -> tuple[int]:
-        raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
-
-    def get_federated_table_data(  # noqa: D102
-        self,
-        agents: Sequence[AgentMetricsView],  # noqa: ARG002
-        server: AgentMetricsView,
-        problem: "BenchmarkProblem",  # noqa: ARG002
-    ) -> tuple[int]:
-        server = utils._require_server_view(server, self.table_description)  # noqa: SLF001
-        return (server.n_sent_messages_dropped,)
 
 
 class ServerMSE(Metric):
@@ -1087,7 +932,7 @@ class ServerAccuracy(Metric):
         ]
 
 
-DEFAULT_TABLE_METRICS: list[Metric] = [
+_BASE_TABLE_METRICS: list[Metric] = [
     Regret([utils.single]),
     GradientNorm([utils.single]),
     XError([min, np.average, max]),
@@ -1120,7 +965,7 @@ DEFAULT_TABLE_METRICS: list[Metric] = [
 :meta hide-value:
 """
 
-REGRESSION_TABLE_METRICS: list[Metric] = [
+_REGRESSION_TABLE_METRICS: list[Metric] = [
     MSE([min, np.average, max], x_log=False, y_log=True),
 ]
 """
@@ -1129,7 +974,7 @@ REGRESSION_TABLE_METRICS: list[Metric] = [
 :meta hide-value:
 """
 
-CLASSIFICATION_TABLE_METRICS: list[Metric] = [
+_CLASSIFICATION_TABLE_METRICS: list[Metric] = [
     Accuracy([min, np.average, max], fmt=".2%", x_log=False, y_log=False),
     Precision([min, np.average, max], fmt=".2%", x_log=False, y_log=False),
     Recall([min, np.average, max], fmt=".2%", x_log=False, y_log=False),
@@ -1145,7 +990,7 @@ CLASSIFICATION_TABLE_METRICS: list[Metric] = [
 # No need to specify statistics for plot metrics as they are only
 # used for table metrics, if you were to use the same Metric object
 # for both, you would need to specify statistics
-DEFAULT_PLOT_METRICS: list[Metric] = [
+_BASE_PLOT_METRICS: list[Metric] = [
     Regret([], x_log=False, y_log=True),
     GradientNorm([], x_log=False, y_log=True),
     ConsensusError([], x_log=False, y_log=True),
@@ -1161,14 +1006,14 @@ DEFAULT_PLOT_METRICS: list[Metric] = [
 """
 
 
-REGRESSION_PLOT_METRICS: list[Metric] = REGRESSION_TABLE_METRICS
+_REGRESSION_PLOT_METRICS: list[Metric] = _REGRESSION_TABLE_METRICS
 """
 - :class:`MSE` (semi-log)
 
 :meta hide-value:
 """
 
-CLASSIFICATION_PLOT_METRICS: list[Metric] = CLASSIFICATION_TABLE_METRICS
+_CLASSIFICATION_PLOT_METRICS: list[Metric] = _CLASSIFICATION_TABLE_METRICS
 """
 - :class:`Accuracy` (linear)
 - :class:`Precision` (linear)
@@ -1177,78 +1022,78 @@ CLASSIFICATION_PLOT_METRICS: list[Metric] = CLASSIFICATION_TABLE_METRICS
 :meta hide-value:
 """
 
-FEDERATED_TABLE_METRICS: list[Metric] = [
-    *DEFAULT_TABLE_METRICS,
+_FEDERATED_TABLE_METRICS: list[Metric] = [
     ClientDriftFromServer([min, np.average, max]),
     SelectedParticipationFraction([utils.single], fmt=".2%", x_log=False, y_log=False),
     TotalCommunication([utils.single]),
-    UplinkMessages([utils.single]),
-    DownlinkMessages([utils.single]),
-    DownlinkMessagesDropped([utils.single]),
 ]
 """
-- :const:`DEFAULT_TABLE_METRICS`
 - :class:`ClientDriftFromServer` - min, average, max
 - :class:`SelectedParticipationFraction` - single value with percentage format
 - :class:`TotalCommunication` - single value
-- :class:`UplinkMessages` - single value
-- :class:`DownlinkMessages` - single value
-- :class:`DownlinkMessagesDropped` - single value
 
 :meta hide-value:
 """
 
-FEDERATED_PLOT_METRICS: list[Metric] = [
-    *DEFAULT_PLOT_METRICS,
+_FEDERATED_PLOT_METRICS: list[Metric] = [
     ClientDriftFromServer([], x_log=False, y_log=True),
 ]
 """
-- :const:`DEFAULT_PLOT_METRICS`
 - :class:`ClientDriftFromServer` (semi-log)
 
 :meta hide-value:
 """
 
-FEDERATED_REGRESSION_TABLE_METRICS: list[Metric] = [
-    *REGRESSION_TABLE_METRICS,
+_FEDERATED_REGRESSION_TABLE_METRICS: list[Metric] = [
     ServerMSE([utils.single], x_log=False, y_log=True),
 ]
 """
-- :const:`REGRESSION_TABLE_METRICS`
 - :class:`ServerMSE` - single value
 
 :meta hide-value:
 """
 
-FEDERATED_REGRESSION_PLOT_METRICS: list[Metric] = [
-    *REGRESSION_PLOT_METRICS,
+_FEDERATED_REGRESSION_PLOT_METRICS: list[Metric] = [
     ServerMSE([], x_log=False, y_log=True),
 ]
 """
-- :const:`REGRESSION_PLOT_METRICS`
 - :class:`ServerMSE` (semi-log)
 
 :meta hide-value:
 """
 
-FEDERATED_CLASSIFICATION_TABLE_METRICS: list[Metric] = [
-    *CLASSIFICATION_TABLE_METRICS,
+_FEDERATED_CLASSIFICATION_TABLE_METRICS: list[Metric] = [
     ServerAccuracy([utils.single], fmt=".2%", x_log=False, y_log=False),
 ]
 """
-- :const:`CLASSIFICATION_TABLE_METRICS`
 - :class:`ServerAccuracy` - single value with percentage format
 
 :meta hide-value:
 """
 
-FEDERATED_CLASSIFICATION_PLOT_METRICS: list[Metric] = [
-    *CLASSIFICATION_PLOT_METRICS,
+_FEDERATED_CLASSIFICATION_PLOT_METRICS: list[Metric] = [
     ServerAccuracy([], fmt=".2%", x_log=False, y_log=False),
 ]
 """
-- :const:`CLASSIFICATION_PLOT_METRICS`
 - :class:`ServerAccuracy` (linear)
 
 :meta hide-value:
 """
+
+_DEFAULT_TABLE_METRICS: list[Metric] = [
+    *_BASE_TABLE_METRICS,
+    *_REGRESSION_TABLE_METRICS,
+    *_CLASSIFICATION_TABLE_METRICS,
+    *_FEDERATED_TABLE_METRICS,
+    *_FEDERATED_REGRESSION_TABLE_METRICS,
+    *_FEDERATED_CLASSIFICATION_TABLE_METRICS,
+]
+
+_DEFAULT_PLOT_METRICS: list[Metric] = [
+    *_BASE_PLOT_METRICS,
+    *_REGRESSION_PLOT_METRICS,
+    *_CLASSIFICATION_PLOT_METRICS,
+    *_FEDERATED_PLOT_METRICS,
+    *_FEDERATED_REGRESSION_PLOT_METRICS,
+    *_FEDERATED_CLASSIFICATION_PLOT_METRICS,
+]

--- a/decent_bench/metrics/metric_library.py
+++ b/decent_bench/metrics/metric_library.py
@@ -16,6 +16,16 @@ if TYPE_CHECKING:
     from decent_bench.benchmark import BenchmarkProblem
 
 
+def _non_server_views(agents: Sequence[AgentMetricsView]) -> list[AgentMetricsView]:
+    """Return all non-server agent views."""
+    return [agent for agent in agents if not agent.is_server]
+
+
+def _server_view(agents: Sequence[AgentMetricsView]) -> AgentMetricsView:
+    """Return the federated server view."""
+    return next(agent for agent in agents if agent.is_server)
+
+
 class Regret(Metric):
     r"""
     Global regret.
@@ -52,8 +62,8 @@ class Regret(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        clients = [agent for agent in agents if not agent.is_server]
-        return (utils._regret(clients, problem, iteration),)  # noqa: SLF001
+        agent_views = _non_server_views(agents)
+        return (utils._regret(agent_views, problem, iteration),)  # noqa: SLF001
 
 
 class GradientNorm(Metric):
@@ -81,8 +91,8 @@ class GradientNorm(Metric):
         _: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        clients = [agent for agent in agents if not agent.is_server]
-        return (utils._gradient_norm(clients, iteration),)  # noqa: SLF001
+        agent_views = _non_server_views(agents)
+        return (utils._gradient_norm(agent_views, iteration),)  # noqa: SLF001
 
 
 class XError(Metric):
@@ -126,7 +136,7 @@ class XError(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        return [utils._x_error(a, problem, iteration) for a in agents if not a.is_server]  # noqa: SLF001
+        return [utils._x_error(a, problem, iteration) for a in _non_server_views(agents)]  # noqa: SLF001
 
 
 class ConsensusError(Metric):
@@ -162,9 +172,9 @@ class ConsensusError(Metric):
         iteration: int,
     ) -> list[float]:
 
-        clients = [agent for agent in agents if not agent.is_server]
-        x_mean = utils.x_mean(tuple(clients), iteration)
-        return [float(iop.norm(x_mean - a.x_history[iteration])) for a in clients]
+        agent_views = _non_server_views(agents)
+        x_mean = utils.x_mean(tuple(agent_views), iteration)
+        return [float(iop.norm(x_mean - a.x_history[iteration])) for a in agent_views]
 
 
 class XUpdates(Metric):
@@ -190,7 +200,7 @@ class XUpdates(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_x_updates for a in agents if not a.is_server]
+        return [a.n_x_updates for a in _non_server_views(agents)]
 
 
 class FunctionCalls(Metric):
@@ -220,7 +230,7 @@ class FunctionCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_function_calls for a in agents if not a.is_server]
+        return [a.n_function_calls for a in _non_server_views(agents)]
 
 
 class GradientCalls(Metric):
@@ -250,7 +260,7 @@ class GradientCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_gradient_calls for a in agents if not a.is_server]
+        return [a.n_gradient_calls for a in _non_server_views(agents)]
 
 
 class HessianCalls(Metric):
@@ -280,7 +290,7 @@ class HessianCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_hessian_calls for a in agents if not a.is_server]
+        return [a.n_hessian_calls for a in _non_server_views(agents)]
 
 
 class ProximalCalls(Metric):
@@ -306,7 +316,7 @@ class ProximalCalls(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[float]:
-        return [a.n_proximal_calls for a in agents if not a.is_server]
+        return [a.n_proximal_calls for a in _non_server_views(agents)]
 
 
 class SentMessages(Metric):
@@ -332,7 +342,7 @@ class SentMessages(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_sent_messages for a in agents if not a.is_server]
+        return [a.n_sent_messages for a in _non_server_views(agents)]
 
 
 class ReceivedMessages(Metric):
@@ -358,7 +368,7 @@ class ReceivedMessages(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_received_messages for a in agents if not a.is_server]
+        return [a.n_received_messages for a in _non_server_views(agents)]
 
 
 class SentMessagesDropped(Metric):
@@ -384,7 +394,7 @@ class SentMessagesDropped(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> list[int]:
-        return [a.n_sent_messages_dropped for a in agents if not a.is_server]
+        return [a.n_sent_messages_dropped for a in _non_server_views(agents)]
 
 
 class Accuracy(Metric):
@@ -442,8 +452,8 @@ class Accuracy(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        clients = [agent for agent in agents if not agent.is_server]
-        return utils._accuracy(clients, problem, iteration)  # noqa: SLF001
+        agent_views = _non_server_views(agents)
+        return utils._accuracy(agent_views, problem, iteration)  # noqa: SLF001
 
 
 class MSE(Metric):
@@ -496,8 +506,8 @@ class MSE(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        clients = [agent for agent in agents if not agent.is_server]
-        return utils._mse(clients, problem, iteration)  # noqa: SLF001
+        agent_views = _non_server_views(agents)
+        return utils._mse(agent_views, problem, iteration)  # noqa: SLF001
 
 
 class Precision(Metric):
@@ -555,8 +565,8 @@ class Precision(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        clients = [agent for agent in agents if not agent.is_server]
-        return utils._precision(clients, problem, iteration)  # noqa: SLF001
+        agent_views = _non_server_views(agents)
+        return utils._precision(agent_views, problem, iteration)  # noqa: SLF001
 
 
 class Recall(Metric):
@@ -614,8 +624,8 @@ class Recall(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        clients = [agent for agent in agents if not agent.is_server]
-        return utils._recall(clients, problem, iteration)  # noqa: SLF001
+        agent_views = _non_server_views(agents)
+        return utils._recall(agent_views, problem, iteration)  # noqa: SLF001
 
 
 class Loss(Metric):
@@ -643,8 +653,8 @@ class Loss(Metric):
         _: "BenchmarkProblem",
         iteration: int,
     ) -> list[float]:
-        clients = [agent for agent in agents if not agent.is_server]
-        return utils._losses(clients, iteration)  # noqa: SLF001
+        agent_views = _non_server_views(agents)
+        return utils._losses(agent_views, iteration)  # noqa: SLF001
 
 
 def _requires_fednetwork(problem: "BenchmarkProblem", metric_name: str) -> tuple[bool, str | None]:
@@ -654,10 +664,10 @@ def _requires_fednetwork(problem: "BenchmarkProblem", metric_name: str) -> tuple
 
 
 def _server_metric_cost(agents: Sequence[AgentMetricsView], metric_name: str) -> Cost:
-    clients = [agent for agent in agents if not agent.is_server]
-    if not clients:
+    agent_views = _non_server_views(agents)
+    if not agent_views:
         raise ValueError(f"{metric_name} requires at least one client metrics view")
-    return clients[0].cost
+    return agent_views[0].cost
 
 
 class ClientDriftFromServer(Metric):
@@ -697,11 +707,20 @@ class ClientDriftFromServer(Metric):
         problem: "BenchmarkProblem",  # noqa: ARG002
         iteration: int,
     ) -> list[float]:
-        servers = [agent for agent in agents if agent.is_server]
-        if len(servers) != 1:
-            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
-        clients = [agent for agent in agents if not agent.is_server]
-        return self._drifts(clients, servers[0], iteration)
+        server = _server_view(agents)
+        return self._drifts(_non_server_views(agents), server, iteration)
+
+    def get_plot_data(
+        self,
+        agents: Sequence[AgentMetricsView],
+        _: "BenchmarkProblem",
+    ) -> list[tuple[float, float]]:
+        """Extract client drift trajectory."""
+        server = _server_view(agents)
+        agent_views = _non_server_views(agents)
+        return [
+            (i, float(np.mean(self._drifts(agent_views, server, i)))) for i in utils.all_sorted_iterations([server])
+        ]
 
     @staticmethod
     def _drifts(agents: Sequence[AgentMetricsView], server: AgentMetricsView, iteration: int) -> list[float]:
@@ -737,11 +756,11 @@ class SelectedParticipationFraction(Metric):
         _: "BenchmarkProblem",
         __: int,
     ) -> tuple[float]:
-        clients = [agent for agent in agents if not agent.is_server]
-        n_rounds = utils._observed_rounds(clients)  # noqa: SLF001
-        if n_rounds == 0 or not clients:
+        agent_views = _non_server_views(agents)
+        n_rounds = utils._observed_rounds(agent_views)  # noqa: SLF001
+        if n_rounds == 0 or not agent_views:
             return (np.nan,)
-        return (sum(agent.n_times_selected for agent in clients) / (n_rounds * len(clients)),)
+        return (sum(agent.n_times_selected for agent in agent_views) / (n_rounds * len(agent_views)),)
 
 
 class TotalCommunication(Metric):
@@ -773,8 +792,7 @@ class TotalCommunication(Metric):
         problem: "BenchmarkProblem",  # noqa: ARG002
         iteration: int,  # noqa: ARG002
     ) -> tuple[int]:
-        if not any(agent.is_server for agent in agents):
-            raise ValueError(f"{self.table_description} requires a FedNetwork server metrics view")
+        _server_view(agents)
         return (sum(agent.n_sent_messages for agent in agents),)
 
 
@@ -817,28 +835,18 @@ class ServerMSE(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        servers = [agent for agent in agents if agent.is_server]
-        if len(servers) != 1:
-            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
+        server = _server_view(agents)
         cost = _server_metric_cost(agents, self.table_description)
-        return (utils._mse_at_x(cost, servers[0].x_history[iteration], problem),)  # noqa: SLF001
+        return (utils._mse_at_x(cost, server.x_history[iteration], problem),)  # noqa: SLF001
 
     def get_plot_data(
         self,
         agents: Sequence[AgentMetricsView],
         problem: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
-        """
-        Extract server MSE trajectory.
-
-        Raises:
-            ValueError: if there is not exactly one server metrics view.
-
-        """
-        servers = [agent for agent in agents if agent.is_server]
-        if len(servers) != 1:
-            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
-        return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([servers[0]])]
+        """Extract server MSE trajectory."""
+        server = _server_view(agents)
+        return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([server])]
 
 
 class ServerAccuracy(Metric):
@@ -883,28 +891,18 @@ class ServerAccuracy(Metric):
         problem: "BenchmarkProblem",
         iteration: int,
     ) -> tuple[float]:
-        servers = [agent for agent in agents if agent.is_server]
-        if len(servers) != 1:
-            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
+        server = _server_view(agents)
         cost = _server_metric_cost(agents, self.table_description)
-        return (utils._accuracy_at_x(cost, servers[0].x_history[iteration], problem),)  # noqa: SLF001
+        return (utils._accuracy_at_x(cost, server.x_history[iteration], problem),)  # noqa: SLF001
 
     def get_plot_data(
         self,
         agents: Sequence[AgentMetricsView],
         problem: "BenchmarkProblem",
     ) -> list[tuple[float, float]]:
-        """
-        Extract server accuracy trajectory.
-
-        Raises:
-            ValueError: if there is not exactly one server metrics view.
-
-        """
-        servers = [agent for agent in agents if agent.is_server]
-        if len(servers) != 1:
-            raise ValueError(f"{self.table_description} requires exactly one FedNetwork server metrics view")
-        return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([servers[0]])]
+        """Extract server accuracy trajectory."""
+        server = _server_view(agents)
+        return [(i, self.get_data_from_trial(agents, problem, i)[0]) for i in utils.all_sorted_iterations([server])]
 
 
 _BASE_TABLE_METRICS: list[Metric] = [

--- a/decent_bench/metrics/metric_utils.py
+++ b/decent_bench/metrics/metric_utils.py
@@ -501,13 +501,17 @@ def _fit_elbow_curve_given_breakpoint(y: NDArray[float64], b: int) -> tuple[NDAr
     m = len(y)  # num. datapoints
 
     # build the regression matrix, assuming the breakpoint is b
-    R: NDArray[float64] = np.hstack((  # noqa: N806
-        np.vstack((
-            np.arange(0, b + 1, 1).reshape((b + 1, 1)),
-            b * np.ones((m - b - 1, 1)),
-        )),
-        np.ones((m, 1)),
-    ))
+    R: NDArray[float64] = np.hstack(  # noqa: N806
+        (
+            np.vstack(
+                (
+                    np.arange(0, b + 1, 1).reshape((b + 1, 1)),
+                    b * np.ones((m - b - 1, 1)),
+                )
+            ),
+            np.ones((m, 1)),
+        )
+    )
 
     # analytical expression for inverse of R.T @ R
     S_00 = b * (b + 1) * (2 * b + 1) / 6.0 + (m - b - 1) * b**2  # noqa: N806

--- a/decent_bench/metrics/metric_utils.py
+++ b/decent_bench/metrics/metric_utils.py
@@ -51,22 +51,6 @@ def _clear_caches() -> None:
     _server_view.cache_clear()
 
 
-def non_server_views(agents: Sequence[AgentMetricsView]) -> tuple[AgentMetricsView, ...]:
-    """Return all non-server agent views."""
-    return _non_server_views(tuple(agents))
-
-
-def server_view(agents: Sequence[AgentMetricsView]) -> AgentMetricsView:
-    """Return the federated server view."""
-    return _server_view(tuple(agents))
-
-
-def drifts(agents: Sequence[AgentMetricsView], server: AgentMetricsView, iteration: int) -> list[float]:
-    """Calculate each agent's distance from the server state at *iteration*."""
-    server_x = server.x_history[iteration]
-    return [float(iop.norm(agent.x_history[iteration] - server_x)) for agent in agents]
-
-
 @cache
 def _non_server_views(agents: tuple[AgentMetricsView, ...]) -> tuple[AgentMetricsView, ...]:
     """Return all non-server agent views."""
@@ -77,6 +61,12 @@ def _non_server_views(agents: tuple[AgentMetricsView, ...]) -> tuple[AgentMetric
 def _server_view(agents: tuple[AgentMetricsView, ...]) -> AgentMetricsView:
     """Return the federated server view."""
     return next(agent for agent in agents if agent.is_server)
+
+
+def _drifts(agents: Sequence[AgentMetricsView], server: AgentMetricsView, iteration: int) -> list[float]:
+    """Calculate each agent's distance from the server state at *iteration*."""
+    server_x = server.x_history[iteration]
+    return [float(iop.norm(agent.x_history[iteration] - server_x)) for agent in agents]
 
 
 def single(values: Sequence[float]) -> float:

--- a/decent_bench/metrics/metric_utils.py
+++ b/decent_bench/metrics/metric_utils.py
@@ -47,6 +47,36 @@ def _clear_caches() -> None:
     x_mean.cache_clear()
     _x_error.cache_clear()
     _predict_agent.cache_clear()
+    _non_server_views.cache_clear()
+    _server_view.cache_clear()
+
+
+def non_server_views(agents: Sequence[AgentMetricsView]) -> tuple[AgentMetricsView, ...]:
+    """Return all non-server agent views."""
+    return _non_server_views(tuple(agents))
+
+
+def server_view(agents: Sequence[AgentMetricsView]) -> AgentMetricsView:
+    """Return the federated server view."""
+    return _server_view(tuple(agents))
+
+
+def drifts(agents: Sequence[AgentMetricsView], server: AgentMetricsView, iteration: int) -> list[float]:
+    """Calculate each agent's distance from the server state at *iteration*."""
+    server_x = server.x_history[iteration]
+    return [float(iop.norm(agent.x_history[iteration] - server_x)) for agent in agents]
+
+
+@cache
+def _non_server_views(agents: tuple[AgentMetricsView, ...]) -> tuple[AgentMetricsView, ...]:
+    """Return all non-server agent views."""
+    return tuple(agent for agent in agents if not agent.is_server)
+
+
+@cache
+def _server_view(agents: tuple[AgentMetricsView, ...]) -> AgentMetricsView:
+    """Return the federated server view."""
+    return next(agent for agent in agents if agent.is_server)
 
 
 def single(values: Sequence[float]) -> float:

--- a/decent_bench/metrics/metric_utils.py
+++ b/decent_bench/metrics/metric_utils.py
@@ -12,6 +12,7 @@ from sklearn import metrics as sk_metrics
 
 import decent_bench.utils.interoperability as iop
 from decent_bench.agents import AgentMetricsView
+from decent_bench.costs import Cost, EmpiricalRiskCost
 from decent_bench.utils.array import Array
 from decent_bench.utils.logger import LOGGER
 from decent_bench.utils.types import Dataset
@@ -127,6 +128,41 @@ def _x_error(agent: AgentMetricsView, problem: "BenchmarkProblem", iteration: in
     return float(la.norm(x_at_iteration - opt_x))
 
 
+def _observed_rounds(agents: Sequence[AgentMetricsView]) -> int:
+    """
+    Get the number of completed rounds observed in the agents' histories.
+
+    The initial snapshot is stored at iteration 0, so the maximum recorded iteration corresponds to the number of
+    completed algorithm rounds when the final snapshot is present.
+    """
+    if not agents:
+        return 0
+    return max(agent.x_history.max() for agent in agents)
+
+
+def _require_server_view(server: AgentMetricsView | None, metric_name: str) -> AgentMetricsView:
+    """
+    Return a server view or raise a clear error for federated-only metrics.
+
+    Raises:
+        ValueError: if *server* is ``None``
+
+    """
+    if server is None:
+        raise ValueError(f"{metric_name} requires a FedNetwork server metrics view")
+    return server
+
+
+def _losses(agents: Sequence[AgentMetricsView], iteration: int) -> list[float]:
+    """Calculate each agent's loss at *iteration*."""
+    return [
+        agent.cost.function(agent.x_history[iteration], indices="all")
+        if isinstance(agent.cost, EmpiricalRiskCost)
+        else agent.cost.function(agent.x_history[iteration])
+        for agent in agents
+    ]
+
+
 def _accuracy(agents: Sequence[AgentMetricsView], problem: "BenchmarkProblem", iteration: int) -> list[float]:
     """
     Calculate the accuracy per agent.
@@ -182,6 +218,37 @@ def _mse(agents: Sequence[AgentMetricsView], problem: "BenchmarkProblem", iterat
             return [np.nan for _ in agents]
         ret.append(sk_metrics.mean_squared_error(test_y, preds))
     return ret
+
+
+def _predict_cost_at_x(cost: Cost, x: Array, problem: "BenchmarkProblem") -> NDArray[float64]:
+    """Get predictions from *cost* at an arbitrary model state *x*."""
+    test_x, _ = _split_dataset(problem.test_data)  # type: ignore[arg-type]
+    return iop.to_numpy(cost.predict(x, list(test_x)))  # type: ignore[attr-defined]
+
+
+def _accuracy_at_x(cost: Cost, x: Array, problem: "BenchmarkProblem") -> float:
+    """Calculate accuracy from *cost* predictions at an arbitrary model state *x*."""
+    _, test_y = _split_dataset(problem.test_data)  # type: ignore[arg-type]
+    preds = _predict_cost_at_x(cost, x, problem)
+    if np.any(~np.isfinite(preds)):
+        LOGGER.warning(
+            "Predictions contain NaN or Inf values, which are not valid for Accuracy calculation, "
+            "returning NaN for Accuracy"
+        )
+        return np.nan
+    return float(sk_metrics.accuracy_score(test_y, preds))
+
+
+def _mse_at_x(cost: Cost, x: Array, problem: "BenchmarkProblem") -> float:
+    """Calculate MSE from *cost* predictions at an arbitrary model state *x*."""
+    _, test_y = _split_dataset(problem.test_data)  # type: ignore[arg-type]
+    preds = _predict_cost_at_x(cost, x, problem)
+    if np.any(~np.isfinite(preds)):
+        LOGGER.warning(
+            "Predictions contain NaN or Inf values, which are not valid for MSE calculation, returning NaN for MSE"
+        )
+        return np.nan
+    return float(sk_metrics.mean_squared_error(test_y, preds))
 
 
 def _precision(agents: Sequence[AgentMetricsView], problem: "BenchmarkProblem", iteration: int) -> list[float]:

--- a/decent_bench/metrics/metric_utils.py
+++ b/decent_bench/metrics/metric_utils.py
@@ -140,19 +140,6 @@ def _observed_rounds(agents: Sequence[AgentMetricsView]) -> int:
     return max(agent.x_history.max() for agent in agents)
 
 
-def _require_server_view(server: AgentMetricsView | None, metric_name: str) -> AgentMetricsView:
-    """
-    Return a server view or raise a clear error for federated-only metrics.
-
-    Raises:
-        ValueError: if *server* is ``None``
-
-    """
-    if server is None:
-        raise ValueError(f"{metric_name} requires a FedNetwork server metrics view")
-    return server
-
-
 def _losses(agents: Sequence[AgentMetricsView], iteration: int) -> list[float]:
     """Calculate each agent's loss at *iteration*."""
     return [

--- a/decent_bench/networks.py
+++ b/decent_bench/networks.py
@@ -182,7 +182,7 @@ class Network(ABC):  # noqa: B024
 
     def snapshot_agents(self) -> list[Agent]:
         """Get agents whose state should be snapshotted during algorithm execution."""
-        return self.agents()
+        return list(self.graph.nodes())
 
     @cached_property
     def _agents_cache(self) -> list[Agent]:
@@ -526,6 +526,9 @@ class FedNetwork(Network):
             )
         elif not isinstance(server._activation, AlwaysActive):  # noqa: SLF001
             raise ValueError("FedNetwork server must use AlwaysActive activation")
+        for client in clients:
+            client._is_server = False  # noqa: SLF001
+        server._is_server = True  # noqa: SLF001
         graph = nx.star_graph([server, *list(clients)])  # create AgentGraph
 
         # specify the server's message schemes if not provided
@@ -564,10 +567,6 @@ class FedNetwork(Network):
 
         """
         return self._clients_cache
-
-    def snapshot_agents(self) -> list[Agent]:
-        """Get the server and clients whose state should be snapshotted."""
-        return [self.server(), *self.clients()]
 
     @cached_property
     def _clients_cache(self) -> list[Agent]:

--- a/decent_bench/networks.py
+++ b/decent_bench/networks.py
@@ -180,6 +180,10 @@ class Network(ABC):  # noqa: B024
         """
         return self._agents_cache
 
+    def snapshot_agents(self) -> list[Agent]:
+        """Get agents whose state should be snapshotted during algorithm execution."""
+        return self.agents()
+
     @cached_property
     def _agents_cache(self) -> list[Agent]:
         """Cached list of agents; assumes the underlying graph is not mutated after construction."""
@@ -560,6 +564,10 @@ class FedNetwork(Network):
 
         """
         return self._clients_cache
+
+    def snapshot_agents(self) -> list[Agent]:
+        """Get the server and clients whose state should be snapshotted."""
+        return [self.server(), *self.clients()]
 
     @cached_property
     def _clients_cache(self) -> list[Agent]:

--- a/decent_bench/schemes.py
+++ b/decent_bench/schemes.py
@@ -86,10 +86,12 @@ class MarkovChainActivation(AgentActivationScheme):
         self.inactive_to_active = inactive_to_active
         self.active_to_inactive = active_to_inactive
         self._states = np.array([0, 1])  # inactive = 0, active = 1
-        self._P = np.array([
-            [1 - inactive_to_active, inactive_to_active],
-            [active_to_inactive, 1 - active_to_inactive],
-        ])  # transition matrix
+        self._P = np.array(
+            [
+                [1 - inactive_to_active, inactive_to_active],
+                [active_to_inactive, 1 - active_to_inactive],
+            ]
+        )  # transition matrix
         self._current_state = iop.rng_numpy().choice(self._states, p=[0, 1])
 
     def is_active(self, iteration: int) -> bool:  # noqa: D102, ARG002

--- a/decent_bench/utils/checkpoint_manager.py
+++ b/decent_bench/utils/checkpoint_manager.py
@@ -14,7 +14,7 @@ import decent_bench.utils.interoperability as iop
 from decent_bench.agents import AgentMetricsView
 from decent_bench.algorithms import Algorithm
 from decent_bench.benchmark import BenchmarkProblem, BenchmarkResult, MetricResult
-from decent_bench.networks import Network
+from decent_bench.networks import FedNetwork, Network
 from decent_bench.utils.logger import LOGGER
 
 # NOTE: On some platforms (notably Windows), the Python binding can expose the 32-bit
@@ -704,6 +704,7 @@ class CheckpointManager:  # noqa: PLR0904
             try:
                 benchmark_result = self.load_benchmark_result()
                 resulting_agent_states: dict[Algorithm[Network], list[list[AgentMetricsView]]] = {}
+                resulting_server_states: dict[Algorithm[Network], list[AgentMetricsView]] = {}
                 for alg, networks in benchmark_result.states.items():
                     algorithms = list(metrics_result.table_results or metrics_result.plot_results or [])
                     original_alg = next((a for a in algorithms if a.name == alg.name), None)
@@ -716,7 +717,14 @@ class CheckpointManager:  # noqa: PLR0904
                     resulting_agent_states[original_alg] = [
                         [AgentMetricsView.from_agent(a) for a in nw.agents()] for nw in networks
                     ]
+                    fed_networks = [nw for nw in networks if isinstance(nw, FedNetwork)]
+                    if len(fed_networks) == len(networks):
+                        resulting_server_states[original_alg] = [
+                            AgentMetricsView.from_agent(nw.server()) for nw in fed_networks
+                        ]
                 metrics_result.agent_metrics = resulting_agent_states
+                if getattr(metrics_result, "server_metrics", None) is None and resulting_server_states:
+                    metrics_result.server_metrics = resulting_server_states
             except Exception as e:
                 LOGGER.warning(
                     f"Failed to load benchmark result to reconstruct agent metrics: {e}"

--- a/decent_bench/utils/checkpoint_manager.py
+++ b/decent_bench/utils/checkpoint_manager.py
@@ -14,7 +14,7 @@ import decent_bench.utils.interoperability as iop
 from decent_bench.agents import AgentMetricsView
 from decent_bench.algorithms import Algorithm
 from decent_bench.benchmark import BenchmarkProblem, BenchmarkResult, MetricResult
-from decent_bench.networks import FedNetwork, Network
+from decent_bench.networks import Network
 from decent_bench.utils.logger import LOGGER
 
 # NOTE: On some platforms (notably Windows), the Python binding can expose the 32-bit
@@ -704,7 +704,6 @@ class CheckpointManager:  # noqa: PLR0904
             try:
                 benchmark_result = self.load_benchmark_result()
                 resulting_agent_states: dict[Algorithm[Network], list[list[AgentMetricsView]]] = {}
-                resulting_server_states: dict[Algorithm[Network], list[AgentMetricsView]] = {}
                 for alg, networks in benchmark_result.states.items():
                     algorithms = list(metrics_result.table_results or metrics_result.plot_results or [])
                     original_alg = next((a for a in algorithms if a.name == alg.name), None)
@@ -715,16 +714,9 @@ class CheckpointManager:  # noqa: PLR0904
                         )
                         continue
                     resulting_agent_states[original_alg] = [
-                        [AgentMetricsView.from_agent(a) for a in nw.agents()] for nw in networks
+                        [AgentMetricsView.from_agent(a) for a in nw.snapshot_agents()] for nw in networks
                     ]
-                    fed_networks = [nw for nw in networks if isinstance(nw, FedNetwork)]
-                    if len(fed_networks) == len(networks):
-                        resulting_server_states[original_alg] = [
-                            AgentMetricsView.from_agent(nw.server()) for nw in fed_networks
-                        ]
                 metrics_result.agent_metrics = resulting_agent_states
-                if getattr(metrics_result, "server_metrics", None) is None and resulting_server_states:
-                    metrics_result.server_metrics = resulting_server_states
             except Exception as e:
                 LOGGER.warning(
                     f"Failed to load benchmark result to reconstruct agent metrics: {e}"

--- a/decent_bench/utils/interoperability/_imports_types.py
+++ b/decent_bench/utils/interoperability/_imports_types.py
@@ -36,12 +36,14 @@ _torch_types = (torch.Tensor, float, int) if torch else (float,)
 _tf_types = (tf.Tensor, float, int) if tf else (float,)
 if jax and jnp:
     _jnp_array_types = tuple(
-        dict.fromkeys((
-            jnp.ndarray,
-            jnp.generic,
-            type(jnp.array(0)),
-            *((jax.Array,) if hasattr(jax, "Array") else ()),
-        ))
+        dict.fromkeys(
+            (
+                jnp.ndarray,
+                jnp.generic,
+                type(jnp.array(0)),
+                *((jax.Array,) if hasattr(jax, "Array") else ()),
+            )
+        )
     )
 else:
     _jnp_array_types = ()

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -565,8 +565,7 @@ Compression schemes transform messages before they are sent. The default
 number of significant digits. :class:`~decent_bench.schemes.TopK` and
 :class:`~decent_bench.schemes.RandK` keep only a subset of coordinates and set
 the rest to zero. :class:`~decent_bench.schemes.StochasticQuantization`
-implements stochastic norm-scaled quantization used in QSGD
-:footcite:p:`Scheme_QSGD`.
+implements stochastic norm-scaled quantization used in QSGD.
 
 Noise schemes perturb delivered messages. The default
 :class:`~decent_bench.schemes.NoNoise` leaves messages unchanged, while
@@ -602,9 +601,6 @@ across all senders.
         message_noise=GaussianNoise(mean=0, std=0.001),
         message_drop=UniformDropRate(drop_rate=0.1),
     )
-
-.. footbibliography::
-
 
 Create problems from scratch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -376,6 +376,8 @@ Some metrics require additional problem information.
 - ``accuracy``, ``mse``, ``precision``, and ``recall`` require ``problem.test_data`` and
     agents with :class:`~decent_bench.costs.EmpiricalRiskCost`.
 - ``accuracy``, ``precision``, and ``recall`` additionally require integer-valued targets.
+- Federated server metrics such as ``server accuracy`` and ``server mse`` require
+    :class:`~decent_bench.networks.FedNetwork` and use the explicit server model history.
 
 If these requirements are not met, the metric marks itself unavailable, a warning is given, and is omitted from the final
 metric lists returned by :func:`~decent_bench.benchmark.compute_metrics`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ lint.ignore = [
   "PLR0913",  # too-many-arguments, complains when there are more than 5 arguments
   "PLR2004",  # magic-value-comparison, complains about dimension checks in cost functions
   "PLR6301",  # no-self-use, complains when self is unused even when implementing an abstract method
+  "RUF100",   # unused-noqa, noisy when preview-only rules are disabled
   "S311",     # suspicious-non-cryptographic-random-usage, complains about `random.random()`
   "TC001",    # typing-only-first-party-import, reduced rt overhead but slower development and messy imports
   "TC002",    # typing-only-third-party-import, reduced rt overhead but slower development and messy imports
@@ -147,5 +148,4 @@ lint.ignore = [
   "FBT002",   # boolean-default-value-positional-argument, complains about bool args with default values in functions
   "ICN001",   # unconventional-import-alias, complains about common import aliases like `import numpy as np` but it doesn't work for most libraries
 ]
-preview = true
 line-length = 120

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -487,22 +487,10 @@ def test_compute_metrics_uses_federated_defaults_and_server_metrics() -> None:  
     total_communication_metric = next(
         metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.TotalCommunication)
     )
-    uplink_metric = next(
-        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.UplinkMessages)
-    )
-    downlink_metric = next(
-        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.DownlinkMessages)
-    )
-    downlink_dropped_metric = next(
-        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.DownlinkMessagesDropped)
-    )
 
     assert metrics_result.table_results is not None
     assert metrics_result.table_results[algorithm][selected_metric]["single"] == (1.0, 0.0)
     assert metrics_result.table_results[algorithm][total_communication_metric]["single"] == (8.0, 0.0)
-    assert metrics_result.table_results[algorithm][uplink_metric]["single"] == (4.0, 0.0)
-    assert metrics_result.table_results[algorithm][downlink_metric]["single"] == (4.0, 0.0)
-    assert metrics_result.table_results[algorithm][downlink_dropped_metric]["single"] == (0.0, 0.0)
 
 
 def test_compute_metrics_custom_metrics_do_not_append_federated_defaults(monkeypatch) -> None:  # noqa: D103

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -480,20 +480,19 @@ def test_compute_metrics_uses_federated_defaults_and_server_view() -> None:  # n
     table_metric_types = {type(metric) for metric in metrics_result.table_metrics or []}
     plot_metric_types = {type(metric) for metric in metrics_result.plot_metrics or []}
     assert ml.ClientDriftFromServer in table_metric_types
-    assert ml.SelectedParticipationFraction in table_metric_types
-    assert ml.TotalCommunication in table_metric_types
+    assert ml.FractionSelectedClients in table_metric_types
     assert ml.ClientDriftFromServer in plot_metric_types
 
     selected_metric = next(
-        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.SelectedParticipationFraction)
+        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.FractionSelectedClients)
     )
-    total_communication_metric = next(
-        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.TotalCommunication)
+    sent_messages_metric = next(
+        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.SentMessages)
     )
 
     assert metrics_result.table_results is not None
     assert metrics_result.table_results[algorithm][selected_metric]["single"] == (1.0, 0.0)
-    assert metrics_result.table_results[algorithm][total_communication_metric]["single"] == (8.0, 0.0)
+    assert metrics_result.table_results[algorithm][sent_messages_metric]["sum"] == (8.0, 0.0)
 
 
 def test_compute_metrics_custom_metrics_do_not_append_federated_defaults(monkeypatch) -> None:  # noqa: D103

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -13,7 +13,7 @@ from decent_bench.algorithms.federated import FedAvg
 from decent_bench.benchmark import BenchmarkProblem, BenchmarkResult, compute_metrics
 from decent_bench.benchmark._display import display_metrics
 from decent_bench.benchmark._metric_result import MetricResult
-from decent_bench.costs import LinearRegressionCost, QuadraticCost
+from decent_bench.costs import LinearRegressionCost, LogisticRegressionCost, QuadraticCost
 from decent_bench.metrics._metric import Metric
 from decent_bench.metrics import metric_library as ml
 from decent_bench.metrics._plots import (
@@ -798,6 +798,74 @@ def test_classification_metrics_unavailable_with_float_targets() -> None:  # noq
         available, reason = metric.is_available(problem)
         assert not available
         assert "integer targets" in reason
+
+
+def test_server_mse_availability_and_values() -> None:  # noqa: D103
+    test_data = [(np.array([1.0]), np.array([1.0]))]
+    cost = LinearRegressionCost(test_data)
+    client = Agent(0, cost)
+    client.initialize(x=np.array([0.0]))
+
+    unavailable_problem = SimpleNamespace(
+        test_data=test_data,
+        network=SimpleNamespace(agents=lambda: [client]),
+    )
+    available, reason = ml.ServerMSE([np.average]).is_available(unavailable_problem)
+    assert not available
+    assert "FedNetwork" in reason
+
+    fed_problem_without_test_data = BenchmarkProblem(network=FedNetwork([client]))
+    available, reason = ml.ServerMSE([np.average]).is_available(fed_problem_without_test_data)
+    assert not available
+    assert reason == "requires problem.test_data"
+
+    problem = BenchmarkProblem(network=FedNetwork([client]), test_data=test_data)
+    metric = ml.ServerMSE([np.average])
+    available, reason = metric.is_available(problem)
+    assert available
+    assert reason is None
+
+    server = Agent(1, cost)
+    server.initialize(x=np.array([0.0]))
+    server.x = np.array([1.0])
+    server._snapshot(1)
+    client_view = AgentMetricsView.from_agent(client)
+    server_view = AgentMetricsView.from_agent(server)
+
+    assert metric.get_federated_table_data([client_view], server_view, problem) == (0.0,)
+    assert metric.get_federated_plot_data([client_view], server_view, problem) == [(0, 1.0), (1, 0.0)]
+
+
+def test_server_accuracy_availability_and_values() -> None:  # noqa: D103
+    train_data = [(np.array([1.0]), np.array([1])), (np.array([-1.0]), np.array([0]))]
+    test_data = [(np.array([1.0]), 1), (np.array([-1.0]), 0)]
+    cost = LogisticRegressionCost(train_data)
+    client = Agent(0, cost)
+    client.initialize(x=np.array([0.0]))
+    problem = BenchmarkProblem(network=FedNetwork([client]), test_data=test_data)
+
+    float_target_problem = BenchmarkProblem(
+        network=FedNetwork([client]),
+        test_data=[(np.array([1.0]), 1.0), (np.array([-1.0]), 0.0)],
+    )
+    metric = ml.ServerAccuracy([np.average])
+    available, reason = metric.is_available(float_target_problem)
+    assert not available
+    assert "integer targets" in reason
+
+    available, reason = metric.is_available(problem)
+    assert available
+    assert reason is None
+
+    server = Agent(1, cost)
+    server.initialize(x=np.array([0.0]))
+    server.x = np.array([10.0])
+    server._snapshot(1)
+    client_view = AgentMetricsView.from_agent(client)
+    server_view = AgentMetricsView.from_agent(server)
+
+    assert metric.get_federated_table_data([client_view], server_view, problem) == (1.0,)
+    assert metric.get_federated_plot_data([client_view], server_view, problem) == [(0, 0.5), (1, 1.0)]
 
 
 def test_is_available_default_returns_true() -> None:  # noqa: D103

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -75,6 +75,7 @@ def _agent_metrics_view(x_value: float) -> AgentMetricsView:
         n_received_messages=0,
         n_sent_messages_dropped=0,
         n_times_selected=0,
+        is_server=False,
     )
 
 
@@ -467,13 +468,15 @@ def test_compute_metrics_rejects_duplicate_plot_metric_descriptions(monkeypatch)
         compute_metrics(benchmark_result=benchmark_result, table_metrics=[], plot_metrics=[[metric_1], [metric_2]])
 
 
-def test_compute_metrics_uses_federated_defaults_and_server_metrics() -> None:  # noqa: D103
+def test_compute_metrics_uses_federated_defaults_and_server_view() -> None:  # noqa: D103
     benchmark_result, algorithm = _build_federated_benchmark_result(iterations=2)
 
     metrics_result = compute_metrics(benchmark_result=benchmark_result, log_level=40)
 
-    assert metrics_result.server_metrics is not None
-    assert metrics_result.server_metrics[algorithm][0].x_history.max() == 2
+    assert metrics_result.agent_metrics is not None
+    server_views = [view for view in metrics_result.agent_metrics[algorithm][0] if view.is_server]
+    assert len(server_views) == 1
+    assert server_views[0].x_history.max() == 2
     table_metric_types = {type(metric) for metric in metrics_result.table_metrics or []}
     plot_metric_types = {type(metric) for metric in metrics_result.plot_metrics or []}
     assert ml.ClientDriftFromServer in table_metric_types
@@ -813,15 +816,27 @@ def test_server_mse_availability_and_values() -> None:  # noqa: D103
     assert available
     assert reason is None
 
-    server = Agent(1, cost)
-    server.initialize(x=np.array([0.0]))
-    server.x = np.array([1.0])
-    server._snapshot(1)
     client_view = AgentMetricsView.from_agent(client)
-    server_view = AgentMetricsView.from_agent(server)
+    server_history = AgentHistory()
+    server_history[0] = np.array([0.0])
+    server_history[1] = np.array([1.0])
+    server_view = AgentMetricsView(
+        cost=cost,
+        x_history=server_history,
+        n_x_updates=0,
+        n_function_calls=0.0,
+        n_gradient_calls=0.0,
+        n_hessian_calls=0.0,
+        n_proximal_calls=0.0,
+        n_sent_messages=0,
+        n_received_messages=0,
+        n_sent_messages_dropped=0,
+        n_times_selected=0,
+        is_server=True,
+    )
 
-    assert metric.get_federated_table_data([client_view], server_view, problem) == (0.0,)
-    assert metric.get_federated_plot_data([client_view], server_view, problem) == [(0, 1.0), (1, 0.0)]
+    assert metric.get_table_data([client_view, server_view], problem) == (0.0,)
+    assert metric.get_plot_data([client_view, server_view], problem) == [(0, 1.0), (1, 0.0)]
 
 
 def test_server_accuracy_availability_and_values() -> None:  # noqa: D103
@@ -845,15 +860,27 @@ def test_server_accuracy_availability_and_values() -> None:  # noqa: D103
     assert available
     assert reason is None
 
-    server = Agent(1, cost)
-    server.initialize(x=np.array([0.0]))
-    server.x = np.array([10.0])
-    server._snapshot(1)
     client_view = AgentMetricsView.from_agent(client)
-    server_view = AgentMetricsView.from_agent(server)
+    server_history = AgentHistory()
+    server_history[0] = np.array([0.0])
+    server_history[1] = np.array([10.0])
+    server_view = AgentMetricsView(
+        cost=cost,
+        x_history=server_history,
+        n_x_updates=0,
+        n_function_calls=0.0,
+        n_gradient_calls=0.0,
+        n_hessian_calls=0.0,
+        n_proximal_calls=0.0,
+        n_sent_messages=0,
+        n_received_messages=0,
+        n_sent_messages_dropped=0,
+        n_times_selected=0,
+        is_server=True,
+    )
 
-    assert metric.get_federated_table_data([client_view], server_view, problem) == (1.0,)
-    assert metric.get_federated_plot_data([client_view], server_view, problem) == [(0, 0.5), (1, 1.0)]
+    assert metric.get_table_data([client_view, server_view], problem) == (1.0,)
+    assert metric.get_plot_data([client_view, server_view], problem) == [(0, 0.5), (1, 1.0)]
 
 
 def test_is_available_default_returns_true() -> None:  # noqa: D103

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -8,12 +8,14 @@ from matplotlib.lines import Line2D
 from pathlib import Path
 from types import SimpleNamespace
 
-from decent_bench.agents import AgentHistory, AgentMetricsView
+from decent_bench.agents import Agent, AgentHistory, AgentMetricsView
+from decent_bench.algorithms.federated import FedAvg
 from decent_bench.benchmark import BenchmarkProblem, BenchmarkResult, compute_metrics
 from decent_bench.benchmark._display import display_metrics
 from decent_bench.benchmark._metric_result import MetricResult
-from decent_bench.costs import LinearRegressionCost
+from decent_bench.costs import LinearRegressionCost, QuadraticCost
 from decent_bench.metrics._metric import Metric
+from decent_bench.metrics import metric_library as ml
 from decent_bench.metrics._plots import (
     MAX_Y_PLOT_VALUE,
     _add_legend_and_save,
@@ -23,6 +25,7 @@ from decent_bench.metrics._plots import (
     compute_plots,
 )
 from decent_bench.metrics.metric_library import Accuracy, MSE, Precision, Recall, Regret, XError
+from decent_bench.networks import FedNetwork
 
 
 # -----------------------------------------------------------------------------
@@ -71,6 +74,8 @@ def _agent_metrics_view(x_value: float) -> AgentMetricsView:
         n_sent_messages=0,
         n_received_messages=0,
         n_sent_messages_dropped=0,
+        n_times_selected=0,
+        n_times_update_received_by_server=0,
     )
 
 
@@ -132,6 +137,8 @@ def _build_minimal_benchmark_result() -> BenchmarkResult:
         _n_sent_messages=0,
         _n_received_messages=0,
         _n_sent_messages_dropped=0,
+        _n_times_selected=0,
+        _n_times_update_received_by_server=0,
     )
     fake_network = SimpleNamespace(agents=lambda: [fake_agent])
     algorithm = _AlgorithmStub("A")
@@ -139,6 +146,17 @@ def _build_minimal_benchmark_result() -> BenchmarkResult:
         problem=BenchmarkProblem(network=fake_network),
         states={algorithm: [fake_network]},
     )
+
+
+def _build_federated_benchmark_result(iterations: int = 2) -> tuple[BenchmarkResult, FedAvg]:
+    clients = [
+        Agent(0, QuadraticCost(np.eye(1), np.array([0.0]))),
+        Agent(1, QuadraticCost(np.eye(1), np.array([0.0]))),
+    ]
+    network = FedNetwork(clients=clients)
+    algorithm = FedAvg(iterations=iterations, step_size=0.1)
+    algorithm.run(network)
+    return BenchmarkResult(problem=BenchmarkProblem(network=network), states={algorithm: [network]}), algorithm
 
 
 def _build_display_metric_result(
@@ -449,6 +467,72 @@ def test_compute_metrics_rejects_duplicate_plot_metric_descriptions(monkeypatch)
 
     with pytest.raises(ValueError, match="Plot metric descriptions must be unique"):
         compute_metrics(benchmark_result=benchmark_result, table_metrics=[], plot_metrics=[[metric_1], [metric_2]])
+
+
+def test_compute_metrics_uses_federated_defaults_and_server_metrics() -> None:  # noqa: D103
+    benchmark_result, algorithm = _build_federated_benchmark_result(iterations=2)
+
+    metrics_result = compute_metrics(benchmark_result=benchmark_result, log_level=40)
+
+    assert metrics_result.server_metrics is not None
+    assert metrics_result.server_metrics[algorithm][0].x_history.max() == 2
+    table_metric_types = {type(metric) for metric in metrics_result.table_metrics or []}
+    plot_metric_types = {type(metric) for metric in metrics_result.plot_metrics or []}
+    assert ml.ClientDriftFromServer in table_metric_types
+    assert ml.SelectedParticipationFraction in table_metric_types
+    assert ml.EffectiveParticipationFraction in table_metric_types
+    assert ml.TotalCommunication in table_metric_types
+    assert ml.ClientDriftFromServer in plot_metric_types
+    assert ml.ClientLossGap in plot_metric_types
+
+    selected_metric = next(
+        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.SelectedParticipationFraction)
+    )
+    effective_metric = next(
+        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.EffectiveParticipationFraction)
+    )
+    total_communication_metric = next(
+        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.TotalCommunication)
+    )
+    uplink_metric = next(
+        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.UplinkMessages)
+    )
+    downlink_metric = next(
+        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.DownlinkMessages)
+    )
+    downlink_dropped_metric = next(
+        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.DownlinkMessagesDropped)
+    )
+
+    assert metrics_result.table_results is not None
+    assert metrics_result.table_results[algorithm][selected_metric]["single"] == (1.0, 0.0)
+    assert metrics_result.table_results[algorithm][effective_metric]["single"] == (1.0, 0.0)
+    assert metrics_result.table_results[algorithm][total_communication_metric]["single"] == (8.0, 0.0)
+    assert metrics_result.table_results[algorithm][uplink_metric]["single"] == (4.0, 0.0)
+    assert metrics_result.table_results[algorithm][downlink_metric]["single"] == (4.0, 0.0)
+    assert metrics_result.table_results[algorithm][downlink_dropped_metric]["single"] == (0.0, 0.0)
+
+
+def test_compute_metrics_custom_metrics_do_not_append_federated_defaults(monkeypatch) -> None:  # noqa: D103
+    benchmark_result, _ = _build_federated_benchmark_result(iterations=1)
+    metric = _MetricStub("custom table", "custom plot")
+    captured: dict[str, object] = {}
+
+    def _capture_tables(*args, **kwargs):
+        captured["table_metrics"] = args[2]
+        return {}
+
+    def _capture_plots(*args, **kwargs):
+        captured["plot_metrics"] = args[2]
+        return {}
+
+    monkeypatch.setattr("decent_bench.benchmark._compute.compute_tables", _capture_tables)
+    monkeypatch.setattr("decent_bench.benchmark._compute.compute_plots", _capture_plots)
+
+    compute_metrics(benchmark_result=benchmark_result, table_metrics=[metric], plot_metrics=[])
+
+    assert [m.table_description for m in captured["table_metrics"]] == [metric.table_description]
+    assert captured["plot_metrics"] == []
 
 
 # -----------------------------------------------------------------------------

--- a/test/test_display.py
+++ b/test/test_display.py
@@ -75,7 +75,6 @@ def _agent_metrics_view(x_value: float) -> AgentMetricsView:
         n_received_messages=0,
         n_sent_messages_dropped=0,
         n_times_selected=0,
-        n_times_update_received_by_server=0,
     )
 
 
@@ -138,7 +137,6 @@ def _build_minimal_benchmark_result() -> BenchmarkResult:
         _n_received_messages=0,
         _n_sent_messages_dropped=0,
         _n_times_selected=0,
-        _n_times_update_received_by_server=0,
     )
     fake_network = SimpleNamespace(agents=lambda: [fake_agent])
     algorithm = _AlgorithmStub("A")
@@ -480,16 +478,11 @@ def test_compute_metrics_uses_federated_defaults_and_server_metrics() -> None:  
     plot_metric_types = {type(metric) for metric in metrics_result.plot_metrics or []}
     assert ml.ClientDriftFromServer in table_metric_types
     assert ml.SelectedParticipationFraction in table_metric_types
-    assert ml.EffectiveParticipationFraction in table_metric_types
     assert ml.TotalCommunication in table_metric_types
     assert ml.ClientDriftFromServer in plot_metric_types
-    assert ml.ClientLossGap in plot_metric_types
 
     selected_metric = next(
         metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.SelectedParticipationFraction)
-    )
-    effective_metric = next(
-        metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.EffectiveParticipationFraction)
     )
     total_communication_metric = next(
         metric for metric in metrics_result.table_metrics or [] if isinstance(metric, ml.TotalCommunication)
@@ -506,7 +499,6 @@ def test_compute_metrics_uses_federated_defaults_and_server_metrics() -> None:  
 
     assert metrics_result.table_results is not None
     assert metrics_result.table_results[algorithm][selected_metric]["single"] == (1.0, 0.0)
-    assert metrics_result.table_results[algorithm][effective_metric]["single"] == (1.0, 0.0)
     assert metrics_result.table_results[algorithm][total_communication_metric]["single"] == (8.0, 0.0)
     assert metrics_result.table_results[algorithm][uplink_metric]["single"] == (4.0, 0.0)
     assert metrics_result.table_results[algorithm][downlink_metric]["single"] == (4.0, 0.0)

--- a/test/test_fedpd.py
+++ b/test/test_fedpd.py
@@ -135,7 +135,7 @@ def test_fedpd_always_selects_all_active_clients() -> None:
 
 
 def test_fedpd_rejects_selection_scheme_argument() -> None:
-    with pytest.raises(TypeError, match="selection_scheme"):
+    with pytest.raises(TypeError, match="unexpected keyword argument 'selection_scheme'"):
         FedPD(selection_scheme=object())
 
 


### PR DESCRIPTION
### Summary

Add federated-specific benchmark metrics so that inspection of server behavior, participation, uplink/downlink communication, and client-server drift after running federated benchmarks is possible.

The existing client-based metrics remain unchanged.

### Changes
- Add server metric snapshots for federated benchmark results.
- Expose server metric views through `MetricResult`.
- Add federated metrics for:
  - client drift from server
  - selected participation fraction
  - total communication, uplink/downlink messages, downlink messages dropped
  - server MSE
  - server accuracy
- Add/update tests for federated defaults, server metrics, and custom
  metric override behavior.