### PR TITLE
decent-bench: add version ranges to dependencies and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # version update of dependencies (as specified in pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # version update of github action tools (as specified in workflows/ci.yaml)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/decent_bench/benchmark/_compute/compute_plots.py
+++ b/decent_bench/benchmark/_compute/compute_plots.py
@@ -60,11 +60,13 @@ def aggregate_plot_metrics(
 
     for metric, frame in plot_results.items():
         # 1) take mean of values across agents
-        new_frame = frame.groupby(["algorithm", "trial", "iteration"])["value"].mean().reset_index()
+        new_frame = frame.groupby(["algorithm", "trial", "iteration"], observed=False)["value"].mean().reset_index()
 
         # 2) compute mean, min, max across trials
         new_frame = (
-            new_frame.groupby(["algorithm", "iteration"])["value"].agg(mean="mean", min="min", max="max").reset_index()
+            new_frame.groupby(["algorithm", "iteration"], observed=False)["value"]
+            .agg(mean="mean", min="min", max="max")
+            .reset_index()
         )
 
         # 3) add metric column

--- a/decent_bench/benchmark/_compute/compute_tables.py
+++ b/decent_bench/benchmark/_compute/compute_tables.py
@@ -15,12 +15,36 @@ if TYPE_CHECKING:
     from decent_bench.benchmark import BenchmarkProblem
 
 
+# these are the aggregation function that pandas should use; if they are defined as np.mean etc only, they trigger
+# warnings. the current behavior is for pandas to use np.mean as an alias of the pandas-native mean, and not to apply
+# np.mean to the sequence. this behavior is changing in pandas>=3, so let's revisit this later to see if the code
+# here can be refactored
+def mean_(x: Sequence[float]) -> float:
+    return float(np.mean(x))
+
+
+def std_(x: Sequence[float]) -> float:
+    return float(np.std(x, ddof=0))
+
+
+def max_(x: Sequence[float]) -> float:
+    return float(np.max(x))
+
+
+def min_(x: Sequence[float]) -> float:
+    return float(np.min(x))
+
+
+def median_(x: Sequence[float]) -> float:
+    return float(np.median(x))
+
+
 STATISTICS: dict[str, Callable[[Sequence[float]], float]] = {
-    "mean": np.mean,
-    "std": np.std,
-    "max": np.max,
-    "min": np.min,
-    "median": np.median,
+    "mean": mean_,
+    "std": std_,
+    "max": max_,
+    "min": min_,
+    "median": median_,
 }
 STATISTICS_ALIASES = {
     "average": "mean",
@@ -123,7 +147,7 @@ def aggregate_table_metrics(
         else:
             # compute statistics
             agg_spec = {name: ("value", func) for name, func in resolved_statistics.items()}
-            new_frame = frame.groupby(["algorithm", "trial"]).agg(**agg_spec).reset_index()
+            new_frame = frame.groupby(["algorithm", "trial"], observed=False).agg(**agg_spec).reset_index()
             # turn the statistics into a new column
             new_frame = new_frame.melt(
                 id_vars=["algorithm", "trial"],
@@ -134,8 +158,8 @@ def aggregate_table_metrics(
 
         # 3) compute mean and std across trials, gives DataFrame with (algorithm, statistic, mean, std)
         new_frame = (
-            new_frame.groupby(["algorithm", "statistic"])["value"]
-            .agg(mean="mean", std=lambda x: x.std(ddof=0))
+            new_frame.groupby(["algorithm", "statistic"], observed=False)["value"]
+            .agg(mean="mean", std=std_)
             .reset_index()
         )
 

--- a/decent_bench/benchmark/_display/display_plots.py
+++ b/decent_bench/benchmark/_display/display_plots.py
@@ -105,7 +105,7 @@ def _preprocess(
         has_inf = frame[["mean", "min", "max"]].isin([np.inf, -np.inf]).any(axis=1)
         if has_inf.any():
             rows_with_inf = frame[has_inf]
-            cutoff = rows_with_inf.groupby("algorithm")["iteration"].min().rename("cutoff")
+            cutoff = rows_with_inf.groupby("algorithm", observed=False)["iteration"].min().rename("cutoff")
             # map cutoff iteration to the corresponding algorithm
             frame["cutoff"] = frame.set_index("algorithm").index.map(cutoff.to_dict())
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -151,6 +151,12 @@ def _fix_missing_ref(app, env, node, contnode):
                 "networkx.Graph",
                 refuri="https://networkx.org/documentation/stable/reference/classes/graph.html#networkx.Graph",
             )
+        if target in {"DataFrame", "pandas.DataFrame", "pandas.core.frame.DataFrame"}:
+            return nodes.reference(
+                "",
+                "DataFrame",
+                refuri="https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html",
+            )
     return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,14 @@ classifiers = [
 ]
 license = "AGPL-3.0-only"
 dependencies = [
-  "matplotlib",
-  "networkx",
-  "numpy",
-  "pandas",
-  "rich",
-  "scipy",
-  "scikit-learn",
-  "zstandard",
+  "matplotlib>=3.9,<4",
+  "networkx>=3.4,<4",
+  "numpy>=2.0,<3",
+  "pandas>=2.3.3,<3",
+  "rich>=13,<14",
+  "scipy>=1.14,<2",
+  "scikit-learn>=1.5,<2",
+  "zstandard>=0.23,<1",
 ]
 
 [project.urls]
@@ -29,35 +29,35 @@ Issues = "https://github.com/team-decent/decent-bench/issues"
 
 [project.optional-dependencies]
 dev = [
-  "hatch",
-  "mypy",
-  "pytest",
-  "ruff",
-  "scipy-stubs",
-  "types-networkx",
-  "torch",
-  "torchvision",
-  "types-tensorflow",
-  "pandas-stubs",
-  "kagglehub",
+  "hatch>=1.14,<2",
+  "mypy>=1.11,<2",
+  "pytest>=8,<9",
+  "ruff>=0.7,<1",
+  "scipy-stubs>=1.18,<2",
+  "types-networkx>=3.4,<4",
+  "torch>=2.5,<3",
+  "torchvision>=0.20,<1",
+  "types-tensorflow>=2.18,<3",
+  "pandas-stubs>=2.3.3,<3",
+  "kagglehub>=0.3,<1",
 ]
 dev-cpu = [
-  "tensorflow",
-  "jax",
+  "tensorflow>=2.18,<3",
+  "jax>=0.4,<1",
 ]
 dev-gpu = [
-  "tensorflow[and-cuda]",
-  "jax[cuda12]",
+  "tensorflow[and-cuda]>=2.18,<3",
+  "jax[cuda12]>=0.4,<1",
 ]
 sphinx-tools = [
-  "sphinx",
-  "pydata-sphinx-theme",
-  "sphinxcontrib-bibtex",
+  "sphinx>=9.1.0,<10",
+  "pydata-sphinx-theme>=0.16,<1",
+  "sphinxcontrib-bibtex>=2.6,<3",
 ]
 
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.26,<2"]
 build-backend = "hatchling.build"
 
 [tool.tox]
@@ -84,7 +84,12 @@ deps = [
 
 [tool.tox.env.sphinx]
 description = "Generate rst and html files using sphinx"
-deps = [".[sphinx-tools]"]
+deps = [
+  ".[dev]",
+  ".[dev-cpu]",
+  ".[sphinx-tools]",
+  "git+https://github.com/microsoft/python-type-stubs.git@main",
+]
 commands = [
   ["sphinx-apidoc", "-o", "docs/source/api", "decent_bench", "--separate", "--no-toc", "--templatedir=docs/source/_templates"],
   ["sphinx-build", "-W", "-E", "-b", "html", "docs/source", "docs/build/html"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,12 +84,7 @@ deps = [
 
 [tool.tox.env.sphinx]
 description = "Generate rst and html files using sphinx"
-deps = [
-  ".[dev]",
-  ".[dev-cpu]",
-  ".[sphinx-tools]",
-  "git+https://github.com/microsoft/python-type-stubs.git@main",
-]
+deps = [".[sphinx-tools]"]
 commands = [
   ["sphinx-apidoc", "-o", "docs/source/api", "decent_bench", "--separate", "--no-toc", "--templatedir=docs/source/_templates"],
   ["sphinx-build", "-W", "-E", "-b", "html", "docs/source", "docs/build/html"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ Issues = "https://github.com/team-decent/decent-bench/issues"
 [project.optional-dependencies]
 dev = [
   "hatch>=1.14,<2",
-  "mypy>=1.11,<2",
-  "pytest>=8,<9",
-  "ruff>=0.7,<1",
+  "mypy==2.1.0",
+  "pytest>=9,<10",
+  "ruff==0.15.20",
   "scipy-stubs>=1.18,<2",
   "types-networkx>=3.4,<4",
   "torch>=2.5,<3",
@@ -50,7 +50,7 @@ dev-gpu = [
   "jax[cuda12]>=0.4,<1",
 ]
 sphinx-tools = [
-  "sphinx>=9.1.0,<10",
+  "sphinx==9.1.0",
   "pydata-sphinx-theme>=0.16,<1",
   "sphinxcontrib-bibtex>=2.6,<3",
 ]


### PR DESCRIPTION
this PR adds version ranges to all dependencies. this required some small changes around the use of pandas functions and DataFrame typing stubs that were raising some warnings.

the PR also adds the configuration for dependabot, which will take care of updating dependencies ranges with automated PRs

closes #227 